### PR TITLE
Fix custom install to work

### DIFF
--- a/setup/find-retail-paks.sh
+++ b/setup/find-retail-paks.sh
@@ -60,7 +60,7 @@ if [[ "0" -eq ${NO_COPY_RETAIL} ]]; then
 	# Prompt user for custom existing-install location
 	if [[ ! -z ${ZEN} ]]; then
 		${ZEN_INFO} "Please select your existing Quake 2 Retail Installation Directory."
-		copy_retail_files $(${ZEN_DIR_SELECT})
+		copy_retail_files "$(${ZEN_DIR_SELECT})"
 		exit 0;
 	fi
 fi


### PR DESCRIPTION
Custom install location breaks for all default Steam installs as the space in the directory 'Quake 2' causes only the first part of the path to be passed. Fixes error: ```./find-retail-paks.sh: line 14: pushd: /mnt/steam/steamapps/common/Quake: No such file or directory```