### PR TITLE
vkpt: fix type definition from auto(which is storage specifier in C) to corresponding types

### DIFF
--- a/src/refresh/vkpt/device_memory_allocator.c
+++ b/src/refresh/vkpt/device_memory_allocator.c
@@ -144,7 +144,7 @@ int create_sub_allocator(DeviceMemoryAllocator* allocator, uint32_t memory_type)
 	}
 #endif
 
-	const auto result = vkAllocateMemory(allocator->device, &memory_allocate_info, NULL, &sub_allocator->memory);
+	const VkResult result = vkAllocateMemory(allocator->device, &memory_allocate_info, NULL, &sub_allocator->memory);
 	if (result != VK_SUCCESS)
 		return 0;
 

--- a/src/refresh/vkpt/god_rays.c
+++ b/src/refresh/vkpt/god_rays.c
@@ -365,10 +365,10 @@ static void create_uniform_buffer()
 	vkGetBufferMemoryRequirements(qvk.device, god_rays.host_buffer, &host_buffer_requirements);
 	vkGetBufferMemoryRequirements(qvk.device, god_rays.device_buffer, &device_buffer_requirements);
 
-	const uint32_t host_flags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT |
+	const VkMemoryPropertyFlags host_flags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT |
 		VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
 
-	const uint32_t device_flags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+	const VkMemoryPropertyFlags device_flags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
 
 	const uint32_t host_memory_type = get_memory_type(host_buffer_requirements.memoryTypeBits, host_flags);
 	const uint32_t device_memory_type = get_memory_type(device_buffer_requirements.memoryTypeBits, device_flags);

--- a/src/refresh/vkpt/god_rays.c
+++ b/src/refresh/vkpt/god_rays.c
@@ -365,10 +365,10 @@ static void create_uniform_buffer()
 	vkGetBufferMemoryRequirements(qvk.device, god_rays.host_buffer, &host_buffer_requirements);
 	vkGetBufferMemoryRequirements(qvk.device, god_rays.device_buffer, &device_buffer_requirements);
 
-	const auto host_flags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT |
+	const uint32_t host_flags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT |
 		VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
 
-	const auto device_flags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+	const uint32_t device_flags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
 
 	const uint32_t host_memory_type = get_memory_type(host_buffer_requirements.memoryTypeBits, host_flags);
 	const uint32_t device_memory_type = get_memory_type(device_buffer_requirements.memoryTypeBits, device_flags);

--- a/src/refresh/vkpt/transparency.c
+++ b/src/refresh/vkpt/transparency.c
@@ -774,7 +774,7 @@ static qboolean allocate_and_bind_memory_to_buffers()
 	VkMemoryRequirements host_buffer_requirements;
 	vkGetBufferMemoryRequirements(qvk.device, transparency.host_buffer, &host_buffer_requirements);
 
-	const auto host_flags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT |
+	const uint32_t host_flags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT |
 		VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
 
 	const uint32_t host_memory_type = get_memory_type(host_buffer_requirements.memoryTypeBits, host_flags);
@@ -798,7 +798,7 @@ static qboolean allocate_and_bind_memory_to_buffers()
 		transparency.sprite_info_buffer
 	};
 
-	const auto device_flags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+	const uint32_t device_flags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
 	uint32_t memory_types[LENGTH(device_buffers)];
 	VkMemoryRequirements requirements[LENGTH(device_buffers)];
 

--- a/src/refresh/vkpt/transparency.c
+++ b/src/refresh/vkpt/transparency.c
@@ -774,7 +774,7 @@ static qboolean allocate_and_bind_memory_to_buffers()
 	VkMemoryRequirements host_buffer_requirements;
 	vkGetBufferMemoryRequirements(qvk.device, transparency.host_buffer, &host_buffer_requirements);
 
-	const uint32_t host_flags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT |
+	const VkMemoryPropertyFlags host_flags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT |
 		VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
 
 	const uint32_t host_memory_type = get_memory_type(host_buffer_requirements.memoryTypeBits, host_flags);
@@ -798,7 +798,7 @@ static qboolean allocate_and_bind_memory_to_buffers()
 		transparency.sprite_info_buffer
 	};
 
-	const uint32_t device_flags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+	const VkMemoryPropertyFlags device_flags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
 	uint32_t memory_types[LENGTH(device_buffers)];
 	VkMemoryRequirements requirements[LENGTH(device_buffers)];
 

--- a/src/refresh/vkpt/uniform_buffer.c
+++ b/src/refresh/vkpt/uniform_buffer.c
@@ -49,10 +49,10 @@ vkpt_uniform_buffer_create()
 
 	_VK(vkCreateDescriptorSetLayout(qvk.device, &layout_info, NULL, &qvk.desc_set_layout_ubo));
 
-	const uint32_t host_memory_flags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT |
+	const VkMemoryPropertyFlags host_memory_flags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT |
 		VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
 
-	const uint32_t device_memory_flags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+	const VkMemoryPropertyFlags device_memory_flags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
 
 	VkPhysicalDeviceProperties properties;
 	vkGetPhysicalDeviceProperties(qvk.physical_device, &properties);

--- a/src/refresh/vkpt/uniform_buffer.c
+++ b/src/refresh/vkpt/uniform_buffer.c
@@ -49,10 +49,10 @@ vkpt_uniform_buffer_create()
 
 	_VK(vkCreateDescriptorSetLayout(qvk.device, &layout_info, NULL, &qvk.desc_set_layout_ubo));
 
-	const auto host_memory_flags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT |
+	const uint32_t host_memory_flags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT |
 		VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
 
-	const auto device_memory_flags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+	const uint32_t device_memory_flags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
 
 	VkPhysicalDeviceProperties properties;
 	vkGetPhysicalDeviceProperties(qvk.physical_device, &properties);


### PR DESCRIPTION
Looks like this code was copy-pasted from C++11 code. Luckily, C99 allows to not specify the type but it would default to `int`.