### PR TITLE
Remove insane and dead soldiers with nomonsters 1

### DIFF
--- a/src/baseq2/g_spawn.c
+++ b/src/baseq2/g_spawn.c
@@ -619,7 +619,7 @@ void SpawnEntities(const char *mapname, const char *entities, const char *spawnp
 
         // remove things (except the world) from different skill levels or deathmatch
         if (ent != g_edicts) {
-			if (nomonsters->value && strstr(ent->classname, "monster")) {
+			if (nomonsters->value && (strstr(ent->classname, "monster") || strstr(ent->classname, "misc_deadsoldier") || strstr(ent->classname, "misc_insane"))) {
 				G_FreeEdict(ent);
 				inhibit++;
 				continue;


### PR DESCRIPTION
This change makes the nomonsters 1 console option, which inhibits members of the "monster" class from being spawned on level load, also apply to the members of the "misc_deadsoldier" and "misc_insane" classes. If you're turning off the enemies for sightseeing, there's no need for those classes either.