### PR TITLE
Make initialization failures fatal

### DIFF
--- a/src/refresh/vkpt/main.c
+++ b/src/refresh/vkpt/main.c
@@ -243,6 +243,9 @@ vkpt_initialize_all(VkptInitFlags_t init_flags)
 			? (init->initialize() == VK_SUCCESS)
 			: 1;
 		assert(init->is_initialized);
+
+		if (!init->is_initialized)
+		  Com_Error(ERR_FATAL, "Couldn't initialize %s.\n", init->name);
 	}
 
 	if ((VKPT_INIT_DEFAULT & init_flags) == init_flags)


### PR DESCRIPTION
This prevents the user launching the game without the prerequisite assets [ie. bluenoise, etc].

This bit me so I figured I'd make this more verbose and explicit.

Supercedes https://github.com/NVIDIA/Q2RTX/pull/69