### PR TITLE
Fix some Vulkan validation errors

### DIFF
--- a/src/refresh/vkpt/path_tracer.c
+++ b/src/refresh/vkpt/path_tracer.c
@@ -333,7 +333,7 @@ get_geometry(VkBuffer buffer, size_t offset, uint32_t num_vertices)
 				.vertexStride = size_per_vertex,
 				.vertexFormat = VK_FORMAT_R32G32B32_SFLOAT,
 				.indexType    = VK_INDEX_TYPE_NONE_NV,
-				.indexCount   = num_vertices, /* idiotic, doesn't work without */
+				.indexCount   = 0,
 			},
 			.aabbs = { .sType = VK_STRUCTURE_TYPE_GEOMETRY_AABB_NV }
 		}
@@ -450,10 +450,12 @@ vkpt_pt_destroy_explosions(int idx)
 }
 
 static int accel_matches(accel_bottom_match_info_t *match,
-						 VkGeometryNV *geometry) {
-	return match->flags == geometry->flags &&
-		match->vertexCount >= geometry->geometry.triangles.vertexCount &&
-		match->indexCount >= geometry->geometry.triangles.indexCount;
+						 VkGeometryFlagsNV flags,
+						 uint32_t vertex_count,
+						 uint32_t index_count) {
+	return match->flags == flags &&
+		match->vertexCount >= vertex_count &&
+		match->indexCount >= index_count;
 }
 
 // How much to bloat the dynamic geometry allocations
@@ -480,7 +482,7 @@ vkpt_pt_create_accel_bottom(
 	int doFree = 0;
 	int doAlloc = 0;
 
-	if (!match || !accel_matches(match, &geometry) || *accel == VK_NULL_HANDLE) {
+	if (!match || !accel_matches(match, geometry.flags, num_vertices, num_vertices) || *accel == VK_NULL_HANDLE) {
 		doAlloc = 1;
 		doFree = (*accel != VK_NULL_HANDLE);
 	}
@@ -541,7 +543,7 @@ vkpt_pt_create_accel_bottom(
 		if (match) {
 			match->flags = allocGeometry.flags;
 			match->vertexCount = allocGeometry.geometry.triangles.vertexCount;
-			match->indexCount = allocGeometry.geometry.triangles.indexCount;
+			match->indexCount = num_vertices;
 		}
 	}
 

--- a/src/refresh/vkpt/transparency.c
+++ b/src/refresh/vkpt/transparency.c
@@ -703,8 +703,19 @@ static void update_particle_blas(VkCommandBuffer command_buffer)
 	if (transparency.particle_num == 0 && transparency.blas_particle_num == 0)
 		return;
 
+	uint32_t barrier_count = 0;
+	VkBufferMemoryBarrier barriers[4];
+
+	for (uint32_t i = 0; i < LENGTH(transparency.transfer_barriers); i++) {
+		if (!transparency.transfer_barriers[i].size)
+			continue;
+
+		barriers[barrier_count] = transparency.transfer_barriers[i];
+		barrier_count++;
+	}
+
 	vkCmdPipelineBarrier(command_buffer, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT,
-		0, 0, NULL, LENGTH(transparency.transfer_barriers), transparency.transfer_barriers, 0, NULL);
+		0, 0, NULL, barrier_count, barriers, 0, NULL);
 
 	const VkGeometryTrianglesNV triangles = {
 		.sType = VK_STRUCTURE_TYPE_GEOMETRY_TRIANGLES_NV,

--- a/src/refresh/vkpt/transparency.c
+++ b/src/refresh/vkpt/transparency.c
@@ -645,7 +645,7 @@ static void upload_geometry(VkCommandBuffer command_buffer)
 		.size = (transparency.particle_num + transparency.beam_num + transparency.sprite_num) * 4 * TR_POSITION_SIZE
 	};
 
-	const VkBufferCopy paritcle_colors = {
+	const VkBufferCopy particle_colors = {
 		.srcOffset = transparency.particle_color_host_offset,
 		.dstOffset = 0,
 		.size = transparency.particle_num * TR_COLOR_SIZE
@@ -667,9 +667,9 @@ static void upload_geometry(VkCommandBuffer command_buffer)
 		vkCmdCopyBuffer(command_buffer, transparency.host_buffer, transparency.vertex_buffer,
 			1, &vertices);
 	
-	if (paritcle_colors.size)
+	if (particle_colors.size)
 		vkCmdCopyBuffer(command_buffer, transparency.host_buffer, transparency.particle_color_buffer,
-			1, &paritcle_colors);
+			1, &particle_colors);
 
 	if (beam_colors.size)
 		vkCmdCopyBuffer(command_buffer, transparency.host_buffer, transparency.beam_color_buffer,
@@ -691,7 +691,7 @@ static void upload_geometry(VkCommandBuffer command_buffer)
 	transparency.transfer_barriers[0].buffer = transparency.vertex_buffer;
 	transparency.transfer_barriers[0].size = vertices.size;
 	transparency.transfer_barriers[1].buffer = transparency.particle_color_buffer;
-	transparency.transfer_barriers[1].size = paritcle_colors.size;
+	transparency.transfer_barriers[1].size = particle_colors.size;
 	transparency.transfer_barriers[2].buffer = transparency.beam_color_buffer;
 	transparency.transfer_barriers[2].size = beam_colors.size;
 	transparency.transfer_barriers[3].buffer = transparency.sprite_info_buffer;

--- a/src/refresh/vkpt/transparency.c
+++ b/src/refresh/vkpt/transparency.c
@@ -663,17 +663,21 @@ static void upload_geometry(VkCommandBuffer command_buffer)
 		.size = transparency.sprite_num * TR_SPRITE_INFO_SIZE
 	};
 
-	vkCmdCopyBuffer(command_buffer, transparency.host_buffer, transparency.vertex_buffer,
-		1, &vertices);
+	if (vertices.size)
+		vkCmdCopyBuffer(command_buffer, transparency.host_buffer, transparency.vertex_buffer,
+			1, &vertices);
+	
+	if (paritcle_colors.size)
+		vkCmdCopyBuffer(command_buffer, transparency.host_buffer, transparency.particle_color_buffer,
+			1, &paritcle_colors);
 
-	vkCmdCopyBuffer(command_buffer, transparency.host_buffer, transparency.particle_color_buffer,
-		1, &paritcle_colors);
+	if (beam_colors.size)
+		vkCmdCopyBuffer(command_buffer, transparency.host_buffer, transparency.beam_color_buffer,
+			1, &beam_colors);
 
-	vkCmdCopyBuffer(command_buffer, transparency.host_buffer, transparency.beam_color_buffer,
-		1, &beam_colors);
-
-	vkCmdCopyBuffer(command_buffer, transparency.host_buffer, transparency.sprite_info_buffer,
-		1, &sprite_infos);
+	if (sprite_infos.size)
+		vkCmdCopyBuffer(command_buffer, transparency.host_buffer, transparency.sprite_info_buffer,
+			1, &sprite_infos);
 
 	for (size_t i = 0; i < LENGTH(transparency.transfer_barriers); i++)
 	{


### PR DESCRIPTION
Sometimes we have no particles so we shouldn't perform a degenerate (size = 0) copy as this is forbidden by the spec.