### PR TITLE
Reintroduce 'full screen blend'

### DIFF
--- a/src/refresh/vkpt/main.c
+++ b/src/refresh/vkpt/main.c
@@ -2683,6 +2683,8 @@ R_RenderFrame_RTX(refdef_t *fd)
 	prepare_ubo(fd, viewleaf, &ref_mode, sky_matrix, render_world);
 	ubo->prev_adapted_luminance = prev_adapted_luminance;
 
+	Vector4Copy(fd->blend, ubo->fs_blend_color);
+
 	vkpt_physical_sky_update_ubo(ubo, &sun_light, render_world);
 	vkpt_bloom_update(ubo, frame_time, ubo->medium != MEDIUM_NONE, menu_mode);
 

--- a/src/refresh/vkpt/shader/global_ubo.h
+++ b/src/refresh/vkpt/shader/global_ubo.h
@@ -105,7 +105,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	UBO_CVAR_DO(tm_exposure_speed_down, 1) /* speed of exponential eye adaptation when scene gets darker, 0 means instant */ \
 	UBO_CVAR_DO(tm_exposure_speed_up, 2) /* speed of exponential eye adaptation when scene gets brighter, 0 means instant */ \
 	UBO_CVAR_DO(tm_blend_scale_border, 1) /* scale factor for full screen blend intensity, at screen border */ \
-	UBO_CVAR_DO(tm_blend_scale_center, 0.3) /* scale factor for full screen blend intensity, at screen center */ \
+	UBO_CVAR_DO(tm_blend_scale_center, 0.6) /* scale factor for full screen blend intensity, at screen center */ \
 	UBO_CVAR_DO(tm_blend_scale_fade_exp, 4) /* exponent used to interpolate between "border" and "center" factors */ \
 	UBO_CVAR_DO(tm_high_percentile, 90) /* high percentile for computing histogram average, (0..100] */ \
 	UBO_CVAR_DO(tm_knee_start, 0.6) /* where to switch from a linear to a rational function ramp in the post-tonemapping process, (0..1)  */ \

--- a/src/refresh/vkpt/shader/global_ubo.h
+++ b/src/refresh/vkpt/shader/global_ubo.h
@@ -104,6 +104,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	UBO_CVAR_DO(tm_exposure_bias, -1.0) /* exposure bias, log-2 scale */ \
 	UBO_CVAR_DO(tm_exposure_speed_down, 1) /* speed of exponential eye adaptation when scene gets darker, 0 means instant */ \
 	UBO_CVAR_DO(tm_exposure_speed_up, 2) /* speed of exponential eye adaptation when scene gets brighter, 0 means instant */ \
+	UBO_CVAR_DO(tm_blend_scale, 1) /* scale factor for full screen blend intensity [0..1] */ \
 	UBO_CVAR_DO(tm_high_percentile, 90) /* high percentile for computing histogram average, (0..100] */ \
 	UBO_CVAR_DO(tm_knee_start, 0.6) /* where to switch from a linear to a rational function ramp in the post-tonemapping process, (0..1)  */ \
 	UBO_CVAR_DO(tm_low_percentile, 70) /* low percentile for computing histogram average, [0..100) */ \
@@ -189,6 +190,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	GLOBAL_UBO_VAR_LIST_DO(vec2,            sub_pixel_jitter) \
 	GLOBAL_UBO_VAR_LIST_DO(float,           prev_adapted_luminance) \
 	GLOBAL_UBO_VAR_LIST_DO(float,           padding1) \
+	GLOBAL_UBO_VAR_LIST_DO(vec4,            fs_blend_color) \
 	\
 	GLOBAL_UBO_VAR_LIST_DO(vec4,            world_center) \
 	GLOBAL_UBO_VAR_LIST_DO(vec4,            world_size) \

--- a/src/refresh/vkpt/shader/global_ubo.h
+++ b/src/refresh/vkpt/shader/global_ubo.h
@@ -104,7 +104,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	UBO_CVAR_DO(tm_exposure_bias, -1.0) /* exposure bias, log-2 scale */ \
 	UBO_CVAR_DO(tm_exposure_speed_down, 1) /* speed of exponential eye adaptation when scene gets darker, 0 means instant */ \
 	UBO_CVAR_DO(tm_exposure_speed_up, 2) /* speed of exponential eye adaptation when scene gets brighter, 0 means instant */ \
-	UBO_CVAR_DO(tm_blend_scale, 1) /* scale factor for full screen blend intensity [0..1] */ \
+	UBO_CVAR_DO(tm_blend_scale_border, 1) /* scale factor for full screen blend intensity, at screen border */ \
+	UBO_CVAR_DO(tm_blend_scale_center, 0.3) /* scale factor for full screen blend intensity, at screen center */ \
+	UBO_CVAR_DO(tm_blend_scale_fade_exp, 4) /* exponent used to interpolate between "border" and "center" factors */ \
 	UBO_CVAR_DO(tm_high_percentile, 90) /* high percentile for computing histogram average, (0..100] */ \
 	UBO_CVAR_DO(tm_knee_start, 0.6) /* where to switch from a linear to a rational function ramp in the post-tonemapping process, (0..1)  */ \
 	UBO_CVAR_DO(tm_low_percentile, 70) /* low percentile for computing histogram average, [0..100) */ \

--- a/src/refresh/vkpt/shader/tone_mapping_apply.comp
+++ b/src/refresh/vkpt/shader/tone_mapping_apply.comp
@@ -130,6 +130,12 @@ void main()
     // Get input color and luminance.
     vec3 input_color = imageLoad(IMG_TAA_OUTPUT, ipos).rgb;
     input_color /= STORAGE_SCALE_HDR;
+
+    // Mix in full screen blend color
+    vec4 blend_color = global_ubo.fs_blend_color;
+    blend_color.rgb *= global_ubo.prev_adapted_luminance;
+    input_color = mix(input_color, blend_color.rgb, blend_color.a * clamp(global_ubo.tm_blend_scale, 0, 1));
+
     const float lum = max(luminance(input_color), exp2(min_log_luminance));
 
     // Apply linear interpolation manually 

--- a/src/refresh/vkpt/shader/tone_mapping_apply.comp
+++ b/src/refresh/vkpt/shader/tone_mapping_apply.comp
@@ -131,9 +131,9 @@ void main()
     vec3 input_color = imageLoad(IMG_TAA_OUTPUT, ipos).rgb;
     input_color /= STORAGE_SCALE_HDR;
 
-    // Mix in full screen blend color
+    // Mix in full screen blend color. Scale it up so it's noticeable against bright pixels as well.
     vec4 blend_color = global_ubo.fs_blend_color;
-    blend_color.rgb *= global_ubo.prev_adapted_luminance;
+    blend_color.rgb *= tonemap_buffer.adapted_luminance / max(luminance(blend_color.rgb), exp2(min_log_luminance));
 
     // Fade strength of blend effect between center and border
     vec2 norm_pos = (vec2(ipos) / vec2(screenSize) - vec2(0.5)) * vec2(2);

--- a/src/refresh/vkpt/shader/tone_mapping_apply.comp
+++ b/src/refresh/vkpt/shader/tone_mapping_apply.comp
@@ -134,7 +134,13 @@ void main()
     // Mix in full screen blend color
     vec4 blend_color = global_ubo.fs_blend_color;
     blend_color.rgb *= global_ubo.prev_adapted_luminance;
-    input_color = mix(input_color, blend_color.rgb, blend_color.a * clamp(global_ubo.tm_blend_scale, 0, 1));
+
+    // Fade strength of blend effect between center and border
+    vec2 norm_pos = (vec2(ipos) / vec2(screenSize) - vec2(0.5)) * vec2(2);
+    float blend_color_scale = mix(global_ubo.tm_blend_scale_center, global_ubo.tm_blend_scale_border,
+                                  pow(min(length(norm_pos), 1), global_ubo.tm_blend_scale_fade_exp));
+
+    input_color = mix(input_color, blend_color.rgb, blend_color.a * clamp(blend_color_scale, 0, 1));
 
     const float lum = max(luminance(input_color), exp2(min_log_luminance));
 


### PR DESCRIPTION
One of the effects that's currently "lost" in RTX mode is the "full screen blend", where a color is mixed into the final image (literally, an alpha blended screen-covering rectangle). It's used for certain in-game events, eg damage received, item pickups, active effects (quad damage) - that has certainly value for the player. It's also used to give everything a murky color when underwater (so, for atmosphere of a sort).

I added the "full-screen blend" into the tone mapping step, after the final image, but before the tonemapping.
The motivation to add it there, and not the "final_blit" shader, was that I guess making it work with colors not mapped to [0,1] would be more useful if proper HDR output is ever added.