### PR TITLE
Add support for BSP "LIGHT" surfaces

### DIFF
--- a/inc/refresh/images.h
+++ b/inc/refresh/images.h
@@ -107,6 +107,7 @@ extern uint32_t d_8to24table[256];
 // these are implemented in src/refresh/images.c
 void IMG_ReloadAll();
 image_t *IMG_Find(const char *name, imagetype_t type, imageflags_t flags);
+image_t *IMG_Clone(image_t *image);
 void IMG_FreeUnused(void);
 void IMG_FreeAll(void);
 void IMG_Init(void);

--- a/inc/refresh/images.h
+++ b/inc/refresh/images.h
@@ -107,6 +107,7 @@ extern uint32_t d_8to24table[256];
 // these are implemented in src/refresh/images.c
 void IMG_ReloadAll();
 image_t *IMG_Find(const char *name, imagetype_t type, imageflags_t flags);
+image_t *IMG_FindExisting(const char *name, imagetype_t type);
 image_t *IMG_Clone(image_t *image, const char* new_name);
 void IMG_FreeUnused(void);
 void IMG_FreeAll(void);

--- a/inc/refresh/images.h
+++ b/inc/refresh/images.h
@@ -107,7 +107,7 @@ extern uint32_t d_8to24table[256];
 // these are implemented in src/refresh/images.c
 void IMG_ReloadAll();
 image_t *IMG_Find(const char *name, imagetype_t type, imageflags_t flags);
-image_t *IMG_Clone(image_t *image);
+image_t *IMG_Clone(image_t *image, const char* new_name);
 void IMG_FreeUnused(void);
 void IMG_FreeAll(void);
 void IMG_Init(void);

--- a/inc/refresh/refresh.h
+++ b/inc/refresh/refresh.h
@@ -202,6 +202,7 @@ typedef enum {
     IF_NEAREST      = (1 << 7),
     IF_OPAQUE       = (1 << 8),
     IF_SRGB         = (1 << 9),
+    IF_FAKE_EMISSIVE= (1 << 10),
 
     // Image source indicator/requirement flags
     IF_SRC_BASE     = (0x1 << 16),

--- a/inc/shared/shared.h
+++ b/inc/shared/shared.h
@@ -262,6 +262,11 @@ static inline float Q_fabs(float f)
 #define Vector4Clear(a)         ((a)[0]=(a)[1]=(a)[2]=(a)[3]=0)
 #define Vector4Negate(a,b)      ((b)[0]=-(a)[0],(b)[1]=-(a)[1],(b)[2]=-(a)[2],(b)[3]=-(a)[3])
 #define Vector4Set(v, a, b, c, d)   ((v)[0]=(a),(v)[1]=(b),(v)[2]=(c),(v)[3]=(d))
+#define Vector4MA(a,b,c,d) \
+        ((d)[0]=(a)[0]+(b)*(c)[0], \
+         (d)[1]=(a)[1]+(b)*(c)[1], \
+         (d)[2]=(a)[2]+(b)*(c)[2], \
+         (d)[3]=(a)[3]+(b)*(c)[3])
 
 #define QuatCopy(a,b)			((b)[0]=(a)[0],(b)[1]=(a)[1],(b)[2]=(a)[2],(b)[3]=(a)[3])
 

--- a/src/refresh/images.c
+++ b/src/refresh/images.c
@@ -32,6 +32,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "stb_image.h"
 #include "stb_image_write.h"
 
+#include <assert.h>
+
 #define R_COLORMAP_PCX    "pics/colormap.pcx"
 
 #define IMG_LOAD(x) \
@@ -1193,7 +1195,7 @@ image_t *IMG_Find(const char *name, imagetype_t type, imageflags_t flags)
 IMG_Clone
 ===============
 */
-image_t *IMG_Clone(image_t *image)
+image_t *IMG_Clone(image_t *image, const char* new_name)
 {
     if(image == R_NOTEXTURE)
         return image;
@@ -1223,7 +1225,12 @@ image_t *IMG_Clone(image_t *image)
     }
 #endif
 
-
+    if(new_name)
+    {
+        Q_strlcpy(new_image->name, new_name, sizeof(new_image->name));
+        new_image->baselen = strlen(new_image->name) - 4;
+        assert(new_image->name[new_image->baselen] == '.');
+    }
     unsigned hash = FS_HashPathLen(new_image->name, new_image->baselen, RIMAGES_HASH);
     List_Append(&r_imageHash[hash], &new_image->entry);
     return new_image;

--- a/src/refresh/images.c
+++ b/src/refresh/images.c
@@ -1008,12 +1008,6 @@ load_img(const char *name, image_t *image)
         get_image_dimensions(fmt, image);
     }
 
-    // if we are replacing 8-bit texture with a higher resolution 32-bit
-    // texture, we need to recover original image dimensions
-    if (fmt <= IM_WAL && ret > IM_WAL) {
-        get_image_dimensions(fmt, image);
-    }
-
     if (ret < 0) {
         memset(image, 0, sizeof(*image));
         return ret;

--- a/src/refresh/images.c
+++ b/src/refresh/images.c
@@ -1190,6 +1190,40 @@ image_t *IMG_Find(const char *name, imagetype_t type, imageflags_t flags)
     return R_NOTEXTURE;
 }
 
+image_t *IMG_FindExisting(const char *name, imagetype_t type)
+{
+    image_t *image;
+    size_t len;
+    unsigned hash;
+
+    if (!name) {
+        Com_Error(ERR_FATAL, "%s: NULL", __func__);
+    }
+
+    // this should never happen
+    len = strlen(name);
+    if (len >= MAX_QPATH) {
+        Com_Error(ERR_FATAL, "%s: oversize name", __func__);
+    }
+
+    // must have an extension and at least 1 char of base name
+    if (len <= 4) {
+        return R_NOTEXTURE;
+    }
+    if (name[len - 4] != '.') {
+        return R_NOTEXTURE;
+    }
+
+    hash = FS_HashPathLen(name, len - 4, RIMAGES_HASH);
+
+    // look for it
+    if ((image = lookup_image(name, type, hash, len - 4)) != NULL) {
+        return image;
+    }
+
+    return R_NOTEXTURE;
+}
+
 /*
 ===============
 IMG_Clone

--- a/src/refresh/vkpt/bsp_mesh.c
+++ b/src/refresh/vkpt/bsp_mesh.c
@@ -1843,15 +1843,20 @@ bsp_mesh_register_textures(bsp_t *bsp)
 				synth_surface_material &= !is_warp_surface;
 			if(synth_surface_material && needs_emissive)
 			{
-				images.emissive = get_fake_emissive_image(images.diffuse);
-				if(images.emissive)
+				pbr_material_t *new_mat = MAT_CloneForRadiance(mat, info->radiance);
+				if (warp_surface_hack)
 				{
-					pbr_material_t *new_mat = MAT_CloneForRadiance(mat, info->radiance);
-					if (warp_surface_hack)
-					{
-						new_mat->flags = (new_mat->flags & ~MATERIAL_INDEX_MASK) | (mat->flags & MATERIAL_INDEX_MASK);
-					}
-					mat = new_mat;
+					new_mat->flags = (new_mat->flags & ~MATERIAL_INDEX_MASK) | (mat->flags & MATERIAL_INDEX_MASK);
+				}
+				mat = new_mat;
+				if(mat->image_emissive && (mat->image_emissive != R_NOTEXTURE))
+				{
+					// Use previously created emissive image
+					images.emissive = mat->image_emissive;
+				}
+				else
+				{
+					images.emissive = get_fake_emissive_image(images.diffuse);
 				}
 			}
 			else if(needs_emissive && !material_custom)

--- a/src/refresh/vkpt/bsp_mesh.c
+++ b/src/refresh/vkpt/bsp_mesh.c
@@ -727,7 +727,7 @@ is_light_material(uint32_t material)
 }
 
 static void
-collect_ligth_polys(bsp_mesh_t *wm, bsp_t *bsp, int model_idx, int* num_lights, int* allocated_lights, light_poly_t** lights)
+collect_light_polys(bsp_mesh_t *wm, bsp_t *bsp, int model_idx, int* num_lights, int* allocated_lights, light_poly_t** lights)
 {
 	mface_t *surfaces = model_idx < 0 ? bsp->faces : bsp->models[model_idx].firstface;
 	int num_faces = model_idx < 0 ? bsp->numfaces : bsp->models[model_idx].numfaces;
@@ -986,7 +986,7 @@ collect_ligth_polys(bsp_mesh_t *wm, bsp_t *bsp, int model_idx, int* num_lights, 
 }
 
 static void
-collect_sky_and_lava_ligth_polys(bsp_mesh_t *wm, bsp_t* bsp)
+collect_sky_and_lava_light_polys(bsp_mesh_t *wm, bsp_t* bsp)
 {
 	for (int i = 0; i < bsp->numfaces; i++)
 	{
@@ -1651,7 +1651,7 @@ bsp_mesh_create_from_bsp(bsp_mesh_t *wm, bsp_t *bsp, const char* map_name)
     wm->materials = Z_Malloc(MAX_VERT_BSP / 3 * sizeof(*wm->materials));
     wm->clusters = Z_Malloc(MAX_VERT_BSP / 3 * sizeof(*wm->clusters));
 
-	// clear these here because `bsp_mesh_load_custom_sky` creates lights before `collect_ligth_polys`
+	// clear these here because `bsp_mesh_load_custom_sky` creates lights before `collect_light_polys`
 	wm->num_light_polys = 0;
 	wm->allocated_light_polys = 0;
 	wm->light_polys = NULL;
@@ -1735,8 +1735,8 @@ bsp_mesh_create_from_bsp(bsp_mesh_t *wm, bsp_t *bsp, const char* map_name)
 
 	compute_cluster_aabbs(wm);
 
-	collect_ligth_polys(wm, bsp, -1, &wm->num_light_polys, &wm->allocated_light_polys, &wm->light_polys);
-	collect_sky_and_lava_ligth_polys(wm, bsp);
+	collect_light_polys(wm, bsp, -1, &wm->num_light_polys, &wm->allocated_light_polys, &wm->light_polys);
+	collect_sky_and_lava_light_polys(wm, bsp);
 
 	for (int k = 0; k < bsp->nummodels; k++)
 	{
@@ -1746,7 +1746,7 @@ bsp_mesh_create_from_bsp(bsp_mesh_t *wm, bsp_t *bsp, const char* map_name)
 		model->allocated_light_polys = 0;
 		model->light_polys = NULL;
 		
-		collect_ligth_polys(wm, bsp, k, &model->num_light_polys, &model->allocated_light_polys, &model->light_polys);
+		collect_light_polys(wm, bsp, k, &model->num_light_polys, &model->allocated_light_polys, &model->light_polys);
 
 		model->transparent = is_model_transparent(wm, model);
 	}

--- a/src/refresh/vkpt/main.c
+++ b/src/refresh/vkpt/main.c
@@ -53,6 +53,7 @@ cvar_t *cvar_pt_caustics = NULL;
 cvar_t *cvar_pt_enable_nodraw = NULL;
 cvar_t *cvar_pt_enable_surface_lights = NULL;
 cvar_t *cvar_pt_enable_surface_lights_warp = NULL;
+cvar_t *cvar_pt_surface_lights_fake_emissive_algo = NULL;
 cvar_t *cvar_pt_accumulation_rendering = NULL;
 cvar_t *cvar_pt_accumulation_rendering_framenum = NULL;
 cvar_t *cvar_pt_projection = NULL;
@@ -3417,6 +3418,10 @@ R_Init_RTX(qboolean total)
 	 * 1: hack up a material that emits light but doesn't render with an emissive texture
 	 * 2: "full" synthesis (incl emissive texture) */
 	cvar_pt_enable_surface_lights_warp = Cvar_Get("pt_enable_surface_lights_warp", "0", CVAR_FILES);
+	/* How to choose emissive texture for LIGHT flag synthesis:
+	 * 0: Just use diffuse texture
+	 * 1: Use (diffuse) pixels above a certain relative brightness for emissive texture */
+	cvar_pt_surface_lights_fake_emissive_algo = Cvar_Get("pt_surface_lights_fake_emissive_algo", "1", CVAR_FILES);
 
 	// 0 -> disabled, regular pause; 1 -> enabled; 2 -> enabled, hide GUI
 	cvar_pt_accumulation_rendering = Cvar_Get("pt_accumulation_rendering", "1", CVAR_ARCHIVE);

--- a/src/refresh/vkpt/main.c
+++ b/src/refresh/vkpt/main.c
@@ -51,6 +51,8 @@ cvar_t *cvar_profiler = NULL;
 cvar_t *cvar_vsync = NULL;
 cvar_t *cvar_pt_caustics = NULL;
 cvar_t *cvar_pt_enable_nodraw = NULL;
+cvar_t *cvar_pt_enable_surface_lights = NULL;
+cvar_t *cvar_pt_enable_surface_lights_warp = NULL;
 cvar_t *cvar_pt_accumulation_rendering = NULL;
 cvar_t *cvar_pt_accumulation_rendering_framenum = NULL;
 cvar_t *cvar_pt_projection = NULL;
@@ -3404,6 +3406,17 @@ R_Init_RTX(qboolean total)
 	cvar_vsync->changed = NULL; // in case the GL renderer has set it
 	cvar_pt_caustics = Cvar_Get("pt_caustics", "1", CVAR_ARCHIVE);
 	cvar_pt_enable_nodraw = Cvar_Get("pt_enable_nodraw", "0", 0);
+	/* Synthesize materials for surfaces with LIGHT flag.
+	 * 0: disabled
+	 * 1: enabled for "custom" materials (not in materials.csv)
+	 * 2: enabled for all materials w/o an emissive texture */
+	cvar_pt_enable_surface_lights = Cvar_Get("pt_enable_surface_lights", "1", CVAR_FILES);
+	/* LIGHT flag synthesis for "warp" surfaces (water, slime),
+	 * separately controlled for aesthetic reasons
+	 * 0: disabled
+	 * 1: hack up a material that emits light but doesn't render with an emissive texture
+	 * 2: "full" synthesis (incl emissive texture) */
+	cvar_pt_enable_surface_lights_warp = Cvar_Get("pt_enable_surface_lights_warp", "0", CVAR_FILES);
 
 	// 0 -> disabled, regular pause; 1 -> enabled; 2 -> enabled, hide GUI
 	cvar_pt_accumulation_rendering = Cvar_Get("pt_accumulation_rendering", "1", CVAR_ARCHIVE);

--- a/src/refresh/vkpt/material.c
+++ b/src/refresh/vkpt/material.c
@@ -664,3 +664,8 @@ qboolean MAT_IsKind(uint32_t material, uint32_t kind)
 {
 	return (material & MATERIAL_KIND_MASK) == kind;
 }
+
+qboolean MAT_IsCustom(uint32_t material)
+{
+	return (material & MATERIAL_INDEX_MASK) >= pbr_materials_table.num_materials;
+}

--- a/src/refresh/vkpt/material.c
+++ b/src/refresh/vkpt/material.c
@@ -420,6 +420,7 @@ pbr_material_t *MAT_CloneForRadiance(pbr_material_t *src_mat, int radiance)
 	mat->flags &= ~MATERIAL_INDEX_MASK;
 	mat->flags |= index;
 	mat->flags |= MATERIAL_FLAG_LIGHT;
+	mat->registration_sequence = 0;
 	mat->emissive_scale = radiance * 0.001f;
 
 	return mat;

--- a/src/refresh/vkpt/material.c
+++ b/src/refresh/vkpt/material.c
@@ -438,11 +438,11 @@ qerror_t MAT_RegisterPBRMaterial(pbr_material_t * mat,  image_t * image_diffuse,
 	if (mat->registration_sequence == registration_sequence)
 		return Q_ERR_SUCCESS;
 
-	mat->registration_sequence = registration_sequence;
-
 	mat->image_diffuse = image_diffuse;
 	mat->image_normals = image_normals;
 	mat->image_emissive = image_emissive;
+
+	MAT_UpdateRegistration(mat);
 
 	//if (mat->image_diffuse == R_NOTEXTURE)
 	//    mat->flags &= ~(MATERIAL_FLAG_VALID);

--- a/src/refresh/vkpt/material.c
+++ b/src/refresh/vkpt/material.c
@@ -268,6 +268,7 @@ static qerror_t parseMaterialsTable(char const * filename, pbr_materials_table_t
 	assert(table);
 
 	table->num_materials = 0;
+	table->num_custom_materials = 0;
 
 	byte * buffer = NULL; ssize_t buffer_size = 0;
 	buffer_size = FS_LoadFile(filename, (void**)&buffer);

--- a/src/refresh/vkpt/material.c
+++ b/src/refresh/vkpt/material.c
@@ -17,6 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #include "material.h"
+#include "common/common.h"
 #include "common/files.h"
 #include "refresh/images.h"
 #include "vk_util.h"
@@ -134,6 +135,8 @@ typedef struct pbr_materials_table_s {
 
 static pbr_materials_table_t pbr_materials_table = { .num_materials = 0, .num_custom_materials = 0, .alpha_sorted = qtrue };
 
+static pbr_material_t *find_existing_pbr_material(char const *name);
+
 pbr_material_t const * MAT_GetPBRMaterialsTable()
 {
 	return &pbr_materials_table.materials[0];
@@ -238,6 +241,10 @@ static qerror_t writeMaterialsTable(char const * filename, pbr_materials_table_t
 	for (int i = 0; i < table->num_materials; ++i)
 	{
 		pbr_material_t const * mat = &table->materials[i];
+
+		// Skip materials generated for LIGHT surfaces
+		if(strchr(mat->name, '*') != NULL)
+			continue;
 
 		FS_FPrintf(f, "%s,",  mat->name);
 
@@ -391,6 +398,31 @@ qerror_t MAT_SavePBRMaterials()
 	return writeMaterialsTable(materials_filename, &pbr_materials_table);
 }
 
+pbr_material_t *MAT_CloneForRadiance(pbr_material_t *src_mat, int radiance)
+{
+	char clone_name[MAX_QPATH];
+	Q_snprintf(clone_name, sizeof(clone_name), "%s*%d", src_mat->name, radiance);
+	pbr_material_t *mat = find_existing_pbr_material(clone_name);
+
+	if(mat)
+		return mat;
+
+	// not found - create a material entry
+	Com_DPrintf("Synthesizing material for 'emissive' surface with '%s' (%d)\n", src_mat->name, radiance);
+	pbr_materials_table_t * table = &pbr_materials_table;
+	int index = table->num_materials + table->num_custom_materials;
+	table->num_custom_materials++;
+	mat = &table->materials[index];
+	memcpy(mat, src_mat, sizeof(pbr_material_t));
+	strcpy(mat->name, clone_name);
+	mat->next_frame = index;
+	mat->flags &= ~MATERIAL_INDEX_MASK;
+	mat->flags |= index;
+	mat->flags |= MATERIAL_FLAG_LIGHT;
+	mat->emissive_scale = radiance * 0.001f;
+
+	return mat;
+}
 
 qerror_t MAT_RegisterPBRMaterial(pbr_material_t * mat,  image_t * image_diffuse, image_t * image_normals, image_t * image_emissive)
 {
@@ -460,12 +492,8 @@ pbr_material_t * MAT_GetPBRMaterial(int index)
 }
 
 
-pbr_material_t * MAT_FindPBRMaterial(char const * name)
+static pbr_material_t * find_existing_pbr_material(char const * name)
 {
-	char name_copy[MAX_QPATH];
-	int len = truncateExtension(name, name_copy);
-	assert(len>0);
-
 	pbr_materials_table_t * table = &pbr_materials_table;
 
 	// note : key comparison must be case insensitive
@@ -481,7 +509,7 @@ pbr_material_t * MAT_FindPBRMaterial(char const * name)
 		{
 			int middle = floor((left + right) / 2);
 			pbr_material_t * mat = &table->materials[middle];
-			int cmp = Q_strcasecmp(name_copy, mat->name);
+			int cmp = Q_strcasecmp(name, mat->name);
 			if (cmp < 0)
 				right = middle - 1;
 			else if (cmp > 0)
@@ -497,11 +525,25 @@ pbr_material_t * MAT_FindPBRMaterial(char const * name)
 	for (int i = search_start; i < table->num_materials + table->num_custom_materials; ++i)
 	{
 		pbr_material_t * mat = &table->materials[i];
-		if (Q_strcasecmp(mat->name, name_copy) == 0)
+		if (Q_strcasecmp(mat->name, name) == 0)
 			return mat;
 	}
 
+	return NULL;
+}
+
+pbr_material_t * MAT_FindPBRMaterial(char const * name)
+{
+	char name_copy[MAX_QPATH];
+	int len = truncateExtension(name, name_copy);
+	assert(len>0);
+
+	pbr_material_t *existing_mat = find_existing_pbr_material(name_copy);
+	if(existing_mat)
+		return existing_mat;
+
 	// not found - create a material entry
+	pbr_materials_table_t * table = &pbr_materials_table;
 	int index = table->num_materials + table->num_custom_materials;
 	table->num_custom_materials++;
 	pbr_material_t * mat = &table->materials[index];

--- a/src/refresh/vkpt/material.h
+++ b/src/refresh/vkpt/material.h
@@ -97,4 +97,7 @@ uint32_t MAT_SetKind(uint32_t material, uint32_t kind);
 // tests if the material is of a given kind
 qboolean MAT_IsKind(uint32_t material, uint32_t kind);
 
+// tests if the material is "custom" (not in materials.csv)
+qboolean MAT_IsCustom(uint32_t material);
+
 #endif // __MATERIAL_H_

--- a/src/refresh/vkpt/material.h
+++ b/src/refresh/vkpt/material.h
@@ -49,6 +49,9 @@ typedef struct pbr_material_s {
 // returns index of given material in table
 int MAT_GetPBRMaterialIndex(pbr_material_t const * mat);
 
+// Clone a material for use on a surface with LIGHT flag
+pbr_material_t *MAT_CloneForRadiance(pbr_material_t *mat, int radiance);
+
 // registration sequence : set material PBR textures
 qerror_t MAT_RegisterPBRMaterial(pbr_material_t * mat, image_t * image_diffuse, image_t * image_normals, image_t * image_emissive);
 

--- a/src/refresh/vkpt/textures.c
+++ b/src/refresh/vkpt/textures.c
@@ -722,7 +722,10 @@ image_t *vkpt_fake_emissive_texture(image_t *image)
 	// See if we previously created a fake emissive texture for the same base texture
 	image_t *prev_image = IMG_FindExisting(emissive_image_name, image->type);
 	if(prev_image != R_NOTEXTURE)
+	{
+		prev_image->registration_sequence = registration_sequence;
 		return prev_image;
+	}
 
 	image_t *new_image = IMG_Clone(image, emissive_image_name);
 	if(new_image == R_NOTEXTURE)

--- a/src/refresh/vkpt/textures.c
+++ b/src/refresh/vkpt/textures.c
@@ -710,7 +710,21 @@ image_t *vkpt_fake_emissive_texture(image_t *image)
 		return image;
 	}
 
-	image_t *new_image = IMG_Clone(image, NULL);
+	// Construct a new name for the fake emissive image
+	const char emissive_image_suffix[] = "*E.wal"; // 'fake' extension needed for image lookup logic
+	char emissive_image_name[MAX_QPATH];
+	Q_strlcpy(emissive_image_name, image->name, sizeof(emissive_image_name));
+	size_t pos = strlen(emissive_image_name) - 4;
+	if (pos + sizeof(emissive_image_suffix) > sizeof(emissive_image_name))
+		pos = sizeof(emissive_image_name) - sizeof(emissive_image_suffix);
+	Q_strlcpy(emissive_image_name + pos, emissive_image_suffix, sizeof(emissive_image_name) - pos);
+
+	// See if we previously created a fake emissive texture for the same base texture
+	image_t *prev_image = IMG_FindExisting(emissive_image_name, image->type);
+	if(prev_image != R_NOTEXTURE)
+		return prev_image;
+
+	image_t *new_image = IMG_Clone(image, emissive_image_name);
 	if(new_image == R_NOTEXTURE)
 		return image;
 

--- a/src/refresh/vkpt/textures.c
+++ b/src/refresh/vkpt/textures.c
@@ -710,7 +710,7 @@ image_t *vkpt_fake_emissive_texture(image_t *image)
 		return image;
 	}
 
-	image_t *new_image = IMG_Clone(image);
+	image_t *new_image = IMG_Clone(image, NULL);
 	if(new_image == R_NOTEXTURE)
 		return image;
 

--- a/src/refresh/vkpt/vkpt.h
+++ b/src/refresh/vkpt/vkpt.h
@@ -527,6 +527,7 @@ VkResult vkpt_textures_upload_envmap(int w, int h, byte *data);
 void vkpt_textures_destroy_unused();
 void vkpt_textures_update_descriptor_set();
 void vkpt_normalize_normal_map(image_t *image);
+image_t *vkpt_fake_emissive_texture(image_t *image);
 void vkpt_extract_emissive_texture_info(image_t *image);
 void vkpt_textures_prefetch();
 void vkpt_invalidate_texture_descriptors();


### PR DESCRIPTION
For lighting, Q2RTX predominantly uses light-emitting surfaces. The amount of light a surface should emit is determined by an entry in the materials list and an "emissive" texture associated with a material. Material definitions and, if appropriate, emissive textures are provided for basically all baseq2 materials.
Unfortunately, if an emissive texture is not present, a surface won't emit light. This is a problem for maps that use materials beyond the baseq2 set - ie from mods or mission packs (see also #77).
Fortunately, the original light information is still present: the `SURF_LIGHT` flag indicates that a surface should emit light.
With this information "old" maps could be lit much more like they were intended to.

This patch adds a check for `LIGHT` surfaces and the ability to synthesize an appropriate light-emitting material.
An emissive texture is guessed from the diffuse texture by taking the "brightest" pixels. This looks okay for textures in the typical Quake 2 "wall light" style. (An earlier approach was to use the diffuse texture only. While useable, it's not the most attractive look.)

Additionally, while trying out the changes, I noticed:
* Quite rarely there's a surface with a `LIGHT` flag, and it's texture has a `materials.csv` entry, but it lacks the emissive texture (happens in eg `base3`). This probably indicates an "artwork problem" - missing emissive texture - that results in surfaces not emitting light, though they were originally intended to.
* Water and slime are supposed to faintly emit light! This makes a visible difference in some cases (eg `base1` cellar). To see the difference set `pt_enable_surface_lights_warp` to 1. I left it off by default since mainly because it's a hack, having water emit light without light textures. That "proper" way is also available (set both `pt_enable_surface_lights` and `pt_enable_surface_lights_warp` to 2), but the result looks quite weird/jarring/unappealing.<br/>FWIW, the faint "water light" might very well be relevant in certain dark areas, so it might be good to find a way to have it back (without hacks).