### PR TITLE
Improve support for old mods

### DIFF
--- a/inc/common/files.h
+++ b/inc/common/files.h
@@ -87,6 +87,8 @@ typedef struct file_info_s {
 #define FS_Mallocz(size)        Z_TagMallocz(size, TAG_FILESYSTEM)
 #define FS_CopyString(string)   Z_TagCopyString(string, TAG_FILESYSTEM)
 #define FS_LoadFile(path, buf)  FS_LoadFileEx(path, buf, 0, TAG_FILESYSTEM)
+#define FS_LoadFileFlags(path, buf, flags)  \
+                                FS_LoadFileEx(path, buf, (flags), TAG_FILESYSTEM)
 #define FS_FreeFile(buf)        Z_Free(buf)
 
 // just regular malloc for now

--- a/inc/refresh/refresh.h
+++ b/inc/refresh/refresh.h
@@ -202,7 +202,12 @@ typedef enum {
     IF_REPEAT       = (1 << 6),
     IF_NEAREST      = (1 << 7),
     IF_OPAQUE       = (1 << 8),
-	IF_SRGB         = (1 << 9)
+    IF_SRGB         = (1 << 9),
+
+    // Image source indicator/requirement flags
+    IF_SRC_BASE     = (0x1 << 16),
+    IF_SRC_GAME     = (0x2 << 16),
+    IF_SRC_MASK     = (0x3 << 16),
 } imageflags_t;
 
 typedef enum {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -497,7 +497,7 @@ endif()
 
 SET_TARGET_PROPERTIES(client
     PROPERTIES
-    OUTPUT_NAME "q2rtx"
+    OUTPUT_NAME "q2rtx${BINARY_POSTFIX}"
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}"
     RUNTIME_OUTPUT_DIRECTORY_DEBUG "${CMAKE_SOURCE_DIR}"
     RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_SOURCE_DIR}"
@@ -508,7 +508,7 @@ SET_TARGET_PROPERTIES(client
 
 SET_TARGET_PROPERTIES(server
     PROPERTIES
-    OUTPUT_NAME "q2rtxded"
+    OUTPUT_NAME "q2rtxded${BINARY_POSTFIX}"
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}"
     RUNTIME_OUTPUT_DIRECTORY_DEBUG "${CMAKE_SOURCE_DIR}"
     RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_SOURCE_DIR}"
@@ -542,6 +542,32 @@ IF(IS_64_BIT)
 		RUNTIME_OUTPUT_NAME "gamex86_64"
 	)
 ENDIF()
+
+include(ProcessorCount)
+
+if(WIN32 AND IS_64_BIT)
+    set(X86_BUILD_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/build_x86")
+    file(MAKE_DIRECTORY "${X86_BUILD_DIRECTORY}")
+    set(OUTPUT_FILE_NAME "${CMAKE_CURRENT_BINARY_DIR}/config_x86_out.txt")
+    set(ERROR_FILE_NAME "${CMAKE_CURRENT_BINARY_DIR}/config_x86_err.txt")
+    execute_process(COMMAND "${CMAKE_COMMAND}" "${CMAKE_SOURCE_DIR}" "-G" "${CMAKE_GENERATOR}" "-A" "Win32" "-DBINARY_POSTFIX=_x86"
+                    WORKING_DIRECTORY "${X86_BUILD_DIRECTORY}"
+                    OUTPUT_FILE "${OUTPUT_FILE_NAME}"
+                    ERROR_FILE "${ERROR_FILE_NAME}"
+                    RESULT_VARIABLE CONFIG_RESULT)
+    if(NOT CONFIG_RESULT EQUAL 0)
+        message(WARNING "Configuring X86 dedicated server failed with exit code ${CONFIG_RESULT}")
+        message(STATUS " Please see ${OUTPUT_FILE_NAME} and ${ERROR_FILE_NAME} for output")
+    else()
+        ProcessorCount(N)
+        if(N GREATER 0)
+            set(PARALLEL_ARGS "-j" "${N}")
+        endif()
+        add_custom_target(server_x86 ALL
+                          COMMAND "${CMAKE_COMMAND}" "--build" "${X86_BUILD_DIRECTORY}" "--target" "server" "--config" "$<CONFIG>" ${PARALLEL_ARGS}
+                          COMMENT "Build X86 dedicated server")
+    endif()
+endif()
 
 IF(CONFIG_LINUX_PACKAGING_SUPPORT)
     # Put the real game binary in /usr/share so we can have a wrapper in /usr/bin

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -489,10 +489,10 @@ TARGET_INCLUDE_DIRECTORIES(server PRIVATE "${ZLIB_INCLUDE_DIRS}")
 # Use dynamic zlib for steam runtime
 if (CONFIG_LINUX_STEAM_RUNTIME_SUPPORT)
     TARGET_LINK_LIBRARIES(client SDL2main SDL2-static z)
-    TARGET_LINK_LIBRARIES(server SDL2main SDL2-static z)
+    TARGET_LINK_LIBRARIES(server z)
 else()
     TARGET_LINK_LIBRARIES(client SDL2main SDL2-static zlibstatic)
-    TARGET_LINK_LIBRARIES(server SDL2main SDL2-static zlibstatic)
+    TARGET_LINK_LIBRARIES(server zlibstatic)
 endif()
 
 SET_TARGET_PROPERTIES(client

--- a/src/client/ui/playermodels.c
+++ b/src/client/ui/playermodels.c
@@ -36,7 +36,7 @@ static qboolean IconOfSkinExists(char *skin, char **pcxfiles, int npcxfiles)
     Q_strlcat(scratch, "_i.pcx", sizeof(scratch));
 
     for (i = 0; i < npcxfiles; i++) {
-        if (strcmp(pcxfiles[i], scratch) == 0)
+        if (stricmp(pcxfiles[i], scratch) == 0)
             return qtrue;
     }
 

--- a/src/common/bsp.c
+++ b/src/common/bsp.c
@@ -1188,11 +1188,7 @@ qerror_t BSP_Load(const char *name, bsp_t **bsp_p)
 
 	if (!BSP_LoadPatchedPVS(bsp))
 	{
-		if (dedicated->integer)
-			Com_WPrintf("WARNING: Pathced PVS file for %s unavailable. Some entities may disappear.\n"
-				"Load the map with the RTX renderer once to generate the patched PVS file.\n", bsp->name);
-		else
-			BSP_BuildPvsMatrix(bsp);
+		BSP_BuildPvsMatrix(bsp);
 	}
 	else
 	{

--- a/src/common/files.c
+++ b/src/common/files.c
@@ -3690,13 +3690,15 @@ static void fs_game_changed(cvar_t *self)
     // otherwise, restart the filesystem
     CL_RestartFilesystem(qfalse);
 
-    // FIXME: if baseq2/autoexec.cfg exists DO NOT exec default.cfg and config.cfg.
-    // this assumes user prefers to do configuration via autoexec.cfg and doesn't
-    // want settings and binds messed up whenever gamedir changes after startup.
-    if (!FS_FileExistsEx(COM_AUTOEXEC_CFG, FS_TYPE_REAL | FS_PATH_BASE)) {
-        Com_AddConfigFile(COM_DEFAULT_CFG, FS_PATH_GAME);
-		Com_AddConfigFile(COM_Q2RTX_CFG, 0);
-		Com_AddConfigFile(COM_CONFIG_CFG, FS_TYPE_REAL | FS_PATH_GAME);
+    Com_AddConfigFile(COM_DEFAULT_CFG, FS_PATH_GAME);
+    Com_AddConfigFile(COM_Q2RTX_CFG, 0);
+    Com_AddConfigFile(COM_CONFIG_CFG, FS_TYPE_REAL | FS_PATH_GAME);
+
+    // If baseq2/autoexec.cfg exists exec it again after default.cfg and config.cfg.
+    // Assumes user prefers to do configuration via autoexec.cfg and hopefully
+    // settings and binds will be restored to their preference whenever gamedir changes after startup.
+    if(Q_stricmp(s, BASEGAME) && FS_FileExistsEx(COM_AUTOEXEC_CFG, FS_TYPE_REAL | FS_PATH_BASE)) {
+        Com_AddConfigFile(COM_AUTOEXEC_CFG, FS_TYPE_REAL | FS_PATH_BASE);
     }
 
     // exec autoexec.cfg (must be a real file within the game directory)

--- a/src/refresh/images.c
+++ b/src/refresh/images.c
@@ -968,6 +968,10 @@ load_img(const char *name, image_t *image)
          try_location >= TRY_IMAGE_SRC_BASE;
          try_location--)
     {
+        int location_flag = try_location == TRY_IMAGE_SRC_GAME ? IF_SRC_GAME : IF_SRC_MASK;
+        if(((image->flags & IF_SRC_MASK) != 0) && ((image->flags & IF_SRC_MASK) != location_flag))
+            continue;
+
         // first try with original extension
         ret = _try_image_format(fmt, image, try_location, &pic);
         if (ret == Q_ERR_NOENT) {
@@ -1048,6 +1052,10 @@ static qerror_t find_or_load_image(const char *name, size_t len,
          try_location >= TRY_IMAGE_SRC_BASE;
          try_location--)
     {
+        int location_flag = try_location == TRY_IMAGE_SRC_GAME ? IF_SRC_GAME : IF_SRC_MASK;
+        if(((flags & IF_SRC_MASK) != 0) && ((flags & IF_SRC_MASK) != location_flag))
+            continue;
+
         for (int use_override = override_textures; use_override >= 0; use_override--)
         {
             // fill in some basic info
@@ -1069,7 +1077,7 @@ static qerror_t find_or_load_image(const char *name, size_t len,
                 image->baselen = len - 4;
             }
             image->type = type;
-            image->flags = flags;
+            image->flags = flags | location_flag;
             image->registration_sequence = registration_sequence;
 
             // find out original extension

--- a/src/refresh/models.c
+++ b/src/refresh/models.c
@@ -302,6 +302,9 @@ static qerror_t MOD_LoadSP2(model_t *model, const void *rawdata, size_t length)
     return Q_ERR_SUCCESS;
 }
 
+#define TRY_MODEL_SRC_GAME      1
+#define TRY_MODEL_SRC_BASE      0
+
 qhandle_t R_RegisterModel(const char *name)
 {
     char normalized[MAX_QPATH];
@@ -344,15 +347,31 @@ qhandle_t R_RegisterModel(const char *name)
         goto done;
     }
 
-	char* extension = normalized + namelen - 4;
-	if (namelen > 4 && (strcmp(extension, ".md2") == 0) && vid_rtx->integer)
-	{
-		memcpy(extension, ".md3", 4);
+    // Always prefer models from the game dir, even if format might be 'inferior'
+    for (int try_location = Q_stricmp(fs_game->string, BASEGAME) ? TRY_MODEL_SRC_GAME : TRY_MODEL_SRC_BASE;
+         try_location >= TRY_MODEL_SRC_BASE;
+         try_location--)
+    {
+        int fs_flags = 0;
+        if (try_location > 0)
+            fs_flags = try_location == TRY_MODEL_SRC_GAME ? FS_PATH_GAME : FS_PATH_BASE;
 
-		filelen = FS_LoadFile(normalized, (void **)&rawdata);
+        char* extension = normalized + namelen - 4;
+        if (namelen > 4 && (strcmp(extension, ".md2") == 0) && vid_rtx->integer)
+        {
+            memcpy(extension, ".md3", 4);
 
-		memcpy(extension, ".md2", 4);
-	}
+            filelen = FS_LoadFileFlags(normalized, (void **)&rawdata, fs_flags);
+
+            memcpy(extension, ".md2", 4);
+        }
+        if (!rawdata)
+        {
+            filelen = FS_LoadFileFlags(normalized, (void **)&rawdata, fs_flags);
+        }
+        if (rawdata)
+            break;
+    }
 
 	if (!rawdata)
 	{

--- a/src/refresh/vkpt/bsp_mesh.c
+++ b/src/refresh/vkpt/bsp_mesh.c
@@ -300,9 +300,10 @@ get_triangle_off_center(const float* positions, float* center, float* anti_cente
 	CrossProduct(e1, e2, normal);
 	float length = VectorNormalize(normal);
 
-	// Offset the center by one normal to make sure that the point is
+	// Offset the center by a fraction of the normal to make sure that the point is
 	// inside a BSP leaf and not on a boundary plane.
 
+	VectorScale(normal, 0.0001, normal);
 	VectorAdd(center, normal, center);
 
 	if (anti_center)

--- a/src/refresh/vkpt/models.c
+++ b/src/refresh/vkpt/models.c
@@ -258,32 +258,10 @@ qerror_t MOD_LoadMD2_RTX(model_t *model, const void *rawdata, size_t length)
 		if (!mat)
 			Com_EPrintf("error finding material '%s'\n", skinname);
 
-		image_t* image_diffuse = IMG_Find(skinname, IT_SKIN, IF_SRGB);
-		image_t* image_normals = NULL;
-		image_t* image_emissive = NULL;
+		vkpt_material_images_t images;
+		vkpt_load_material_images(&images, skinname, IT_SKIN, IF_NONE);
 
-		if (image_diffuse != R_NOTEXTURE)
-		{
-			// attempt loading the normals texture
-			if (!Q_strlcpy(skinname, src_skin, strlen(src_skin) - 3))
-				return Q_ERR_STRING_TRUNCATED;
-
-			Q_concat(skinname, sizeof(skinname), skinname, "_n.tga", NULL);
-			FS_NormalizePath(skinname, skinname);
-			image_normals = IMG_Find(skinname, IT_SKIN, IF_NONE);
-			if (image_normals == R_NOTEXTURE) image_normals = NULL;
-
-			// attempt loading the emissive texture
-			if (!Q_strlcpy(skinname, src_skin, strlen(src_skin) - 3))
-				return Q_ERR_STRING_TRUNCATED;
-
-			Q_concat(skinname, sizeof(skinname), skinname, "_light.tga", NULL);
-			FS_NormalizePath(skinname, skinname);
-			image_emissive = IMG_Find(skinname, IT_SKIN, IF_SRGB);
-			if (image_emissive == R_NOTEXTURE) image_emissive = NULL;
-		}
-
-		MAT_RegisterPBRMaterial(mat, image_diffuse, image_normals, image_emissive);
+		MAT_RegisterPBRMaterial(mat, images.diffuse, images.normals, images.emissive);
 
 		dst_mesh->materials[i] = mat;
 
@@ -468,32 +446,10 @@ static qerror_t MOD_LoadMD3Mesh(model_t *model, maliasmesh_t *mesh,
 		if (!mat)
 			Com_EPrintf("error finding material '%s'\n", skinname);
 
-		image_t* image_diffuse = IMG_Find(skinname, IT_SKIN, IF_SRGB);
-		image_t* image_normals = NULL;
-		image_t* image_emissive = NULL;
+		vkpt_material_images_t images;
+		vkpt_load_material_images(&images, skinname, IT_SKIN, IF_NONE);
 
-		if (image_diffuse != R_NOTEXTURE)
-		{
-			// attempt loading the normals texture
-			if (!Q_strlcpy(skinname, src_skin->name, strlen(src_skin->name) - 3))
-				return Q_ERR_STRING_TRUNCATED;
-
-			Q_concat(skinname, sizeof(skinname), skinname, "_n.tga", NULL);
-			FS_NormalizePath(skinname, skinname);
-			image_normals = IMG_Find(skinname, IT_SKIN, IF_NONE);
-			if (image_normals == R_NOTEXTURE) image_normals = NULL;
-
-			// attempt loading the emissive texture
-			if (!Q_strlcpy(skinname, src_skin->name, strlen(src_skin->name) - 3))
-				return Q_ERR_STRING_TRUNCATED;
-
-			Q_concat(skinname, sizeof(skinname), skinname, "_light.tga", NULL);
-			FS_NormalizePath(skinname, skinname);
-			image_emissive = IMG_Find(skinname, IT_SKIN, IF_SRGB);
-			if (image_emissive == R_NOTEXTURE) image_emissive = NULL;
-		}
-
-		MAT_RegisterPBRMaterial(mat, image_diffuse, image_normals, image_emissive);
+		MAT_RegisterPBRMaterial(mat, images.diffuse, images.normals, images.emissive);
 
 		mesh->materials[i] = mat;
     }

--- a/src/refresh/vkpt/textures.c
+++ b/src/refresh/vkpt/textures.c
@@ -622,6 +622,7 @@ void vkpt_load_material_images(vkpt_material_images_t* images, const char *diffu
 
 	if (images->diffuse != R_NOTEXTURE)
 	{
+		int src_flag = images->diffuse->flags & IF_SRC_MASK;
 		char other_name[MAX_QPATH];
 
 		// attempt loading a matching normal map
@@ -629,14 +630,14 @@ void vkpt_load_material_images(vkpt_material_images_t* images, const char *diffu
 		other_name[diffuse_name_len - 4] = 0;
 		Q_strlcat(other_name, "_n.tga", q_countof(other_name));
 		FS_NormalizePath(other_name, other_name);
-		images->normals = IMG_Find(other_name, type, flags);
+		images->normals = IMG_Find(other_name, type, flags | src_flag);
 		if (images->normals == R_NOTEXTURE) images->normals = NULL;
 
 		// attempt loading the emissive texture
 		other_name[diffuse_name_len - 4] = 0;
 		Q_strlcat(other_name, "_light.tga", q_countof(other_name));
 		FS_NormalizePath(other_name, other_name);
-		images->emissive = IMG_Find(other_name, type, flags | IF_SRGB);
+		images->emissive = IMG_Find(other_name, type, flags | src_flag | IF_SRGB);
 		if (images->emissive == R_NOTEXTURE) images->emissive = NULL;
 	}
 }

--- a/src/refresh/vkpt/vkpt.h
+++ b/src/refresh/vkpt/vkpt.h
@@ -528,6 +528,13 @@ void vkpt_extract_emissive_texture_info(image_t *image);
 void vkpt_textures_prefetch();
 void vkpt_init_light_textures();
 
+typedef struct vkpt_material_images_s {
+    image_t *diffuse;
+    image_t *normals;
+    image_t *emissive;
+} vkpt_material_images_t;
+void vkpt_load_material_images(vkpt_material_images_t* images, const char *diffuse_path, imagetype_t type, imageflags_t flags);
+
 VkCommandBuffer vkpt_begin_command_buffer(cmd_buf_group_t* group);
 void vkpt_free_command_buffers(cmd_buf_group_t* group);
 void vkpt_reset_command_buffers(cmd_buf_group_t* group);


### PR DESCRIPTION
...such as those you'd find in the GOG version of Quake II.

* A 32-bit dedicated server build is provided, so old `gamex86.dll` game libraries can be used.
* Inhibition of other config files when `autoexec.cfg` is present was removed. That behavior broke mods that rely on `default.cfg` being executed.
* Texture and model asset loading was adjusted so a baseq2 "better quality" asset doesn't automatically override assets from the game. This is allows mods to actually replace models, textures and images.

Limitations:
* Since it's a dedicated server, only multiplayer games work.
* No Linux support. It should probably work, but I don't really have any i386 mods to test with.

But hey, it's enough to play against some bots -
start a server with `q2rtxded_x86.exe +set game eraser`, set `bot_num` to some value in the terminal, and connect with `q2rtx.exe +connect localhost`.