### PR TITLE
Fixes for FPS display, for #117

### DIFF
--- a/inc/client/video.h
+++ b/inc/client/video.h
@@ -44,9 +44,6 @@ void    VID_UpdateGamma(const byte *table);
 void    *VID_GetCoreAddr(const char *sym);
 void    *VID_GetProcAddr(const char *sym);
 
-qboolean VID_VideoSync(void);
-void    VID_VideoWait(void);
-
 void    VID_BeginFrame(void);
 void    VID_EndFrame(void);
 

--- a/inc/refresh/refresh.h
+++ b/inc/refresh/refresh.h
@@ -175,8 +175,7 @@ typedef struct refdef_s {
 typedef enum {
     QVF_ACCELERATED     = (1 << 0),
     QVF_GAMMARAMP       = (1 << 1),
-    QVF_FULLSCREEN      = (1 << 2),
-    QVF_VIDEOSYNC       = (1 << 3)
+    QVF_FULLSCREEN      = (1 << 2)
 } vidFlags_t;
 
 typedef struct {

--- a/src/client/main.c
+++ b/src/client/main.c
@@ -3189,8 +3189,8 @@ void CL_UpdateFrameTimes(void)
         }
     }
 
-    Com_DDDPrintf("%s: mode=%s main_msec=%d ref_msec=%d, phys_msec=%d\n",
-                  __func__, sync_names[sync_mode], main_msec, ref_msec, phys_msec);
+    Com_DDPrintf("%s: mode=%s main_msec=%d ref_msec=%d, phys_msec=%d\n",
+                 __func__, sync_names[sync_mode], main_msec, ref_msec, phys_msec);
 
     ref_extra = phys_extra = main_extra = 0;
 }

--- a/src/client/main.c
+++ b/src/client/main.c
@@ -3261,6 +3261,10 @@ unsigned CL_Frame(unsigned msec)
         } else if (ref_extra > ref_msec * 4) {
             ref_extra = ref_msec;
         }
+        // Return immediately if neither physics or refresh are scheduled
+        if(!phys_frame && !ref_frame) {
+            return min(phys_msec - phys_extra, ref_msec - ref_extra);
+        }
         break;
     case SYNC_MAXFPS:
         // everything ticks in sync with refresh

--- a/src/client/main.c
+++ b/src/client/main.c
@@ -3247,8 +3247,8 @@ unsigned CL_Frame(unsigned msec)
         break;
     case ASYNC_FULL:
         // run physics and refresh separately
-        phys_extra += main_extra;
-        ref_extra += main_extra;
+        phys_extra += msec;
+        ref_extra += msec;
 
         if (phys_extra < phys_msec) {
             phys_frame = qfalse;

--- a/src/client/screen.c
+++ b/src/client/screen.c
@@ -858,7 +858,7 @@ static void SCR_DrawFPS(void)
 	if (scr_fps->integer == 0)
 		return;
 
-	int fps = CL_GetFps();
+	int fps = R_FPS;
 	int scale = CL_GetResolutionScale();
 
 	char buffer[MAX_QPATH];

--- a/src/unix/sdl2/video.c
+++ b/src/unix/sdl2/video.c
@@ -257,15 +257,6 @@ void VID_SetMode(void)
     VID_SDL_ModeChanged();
 }
 
-void VID_VideoWait(void)
-{
-}
-
-qboolean VID_VideoSync(void)
-{
-    return qtrue;
-}
-
 void VID_BeginFrame(void)
 {
 }

--- a/src/windows/glimp.c
+++ b/src/windows/glimp.c
@@ -493,15 +493,6 @@ qboolean VID_Init(void)
     return qtrue;
 }
 
-void VID_VideoWait(void)
-{
-}
-
-qboolean VID_VideoSync(void)
-{
-    return qtrue;
-}
-
 void VID_BeginFrame(void)
 {
 }


### PR DESCRIPTION
Contains the following changes:
* A fix in CL_Frame() causing from physics & refresh intervals in `SYNC_ASYNC` case
* Display "refresh" FPS on screen instead of "client FPS" (the latter may run faster) - "refresh" FPS is probably what most people expect
* Port a number of `maxfps`-related patches from Q2PRO. Notably, it contains a change to inform the user when the requested `maxfps` value can not be achieved exactly.

All in all, these changes should address the complaints from #117.