### PR TITLE
Fix MAT_ResetUnused()

### DIFF
--- a/src/refresh/vkpt/material.c
+++ b/src/refresh/vkpt/material.c
@@ -436,7 +436,7 @@ qerror_t MAT_ResetUnused()
 
 	for (int i = 0; i < table->num_materials + table->num_custom_materials; ++i)
 	{
-		pbr_material_t * mat = table->materials;
+		pbr_material_t * mat = table->materials + i;
 
 		if (mat->registration_sequence == registration_sequence)
 			continue;


### PR DESCRIPTION
The material table entry wasn't indexed, so that function only looked at the first material in the table, all the time.