### PR TITLE
Remove MAX_SWAPCHAIN_IMAGES limit for XWayland

### DIFF
--- a/src/refresh/vkpt/draw.c
+++ b/src/refresh/vkpt/draw.c
@@ -52,7 +52,7 @@ static VkPipelineLayout        pipeline_layout_final_blit;
 static VkRenderPass            render_pass_stretch_pic;
 static VkPipeline              pipeline_stretch_pic;
 static VkPipeline              pipeline_final_blit;
-static VkFramebuffer           framebuffer_stretch_pic[MAX_SWAPCHAIN_IMAGES];
+static VkFramebuffer*          framebuffer_stretch_pic = NULL;
 static BufferResource_t        buf_stretch_pic_queue[MAX_FRAMES_IN_FLIGHT];
 static VkDescriptorSetLayout   desc_set_layout_sbo;
 static VkDescriptorPool        desc_pool_sbo;
@@ -316,6 +316,9 @@ vkpt_draw_destroy_pipelines()
 	for(int i = 0; i < qvk.num_swap_chain_images; i++) {
 		vkDestroyFramebuffer(qvk.device, framebuffer_stretch_pic[i], NULL);
 	}
+	free(framebuffer_stretch_pic);
+	framebuffer_stretch_pic = NULL;
+	
 	return VK_SUCCESS;
 }
 
@@ -465,7 +468,7 @@ vkpt_draw_create_pipelines()
 	_VK(vkCreateGraphicsPipelines(qvk.device, VK_NULL_HANDLE, 1, &pipeline_info, NULL, &pipeline_final_blit));
 	ATTACH_LABEL_VARIABLE(pipeline_final_blit, PIPELINE);
 
-
+	framebuffer_stretch_pic = malloc(qvk.num_swap_chain_images * sizeof(*framebuffer_stretch_pic));
 	for(int i = 0; i < qvk.num_swap_chain_images; i++) {
 		VkImageView attachments[] = {
 			qvk.swap_chain_image_views[i]

--- a/src/refresh/vkpt/main.c
+++ b/src/refresh/vkpt/main.c
@@ -642,11 +642,11 @@ out:;
 	}
 
 	vkGetSwapchainImagesKHR(qvk.device, qvk.swap_chain, &qvk.num_swap_chain_images, NULL);
-	//qvk.swap_chain_images = malloc(qvk.num_swap_chain_images * sizeof(*qvk.swap_chain_images));
-	assert(qvk.num_swap_chain_images < MAX_SWAPCHAIN_IMAGES);
+	assert(qvk.num_swap_chain_images);
+	qvk.swap_chain_images = malloc(qvk.num_swap_chain_images * sizeof(*qvk.swap_chain_images));
 	vkGetSwapchainImagesKHR(qvk.device, qvk.swap_chain, &qvk.num_swap_chain_images, qvk.swap_chain_images);
 
-	//qvk.swap_chain_image_views = malloc(qvk.num_swap_chain_images * sizeof(*qvk.swap_chain_image_views));
+	qvk.swap_chain_image_views = malloc(qvk.num_swap_chain_images * sizeof(*qvk.swap_chain_image_views));
 	for(int i = 0; i < qvk.num_swap_chain_images; i++) {
 		VkImageViewCreateInfo img_create_info = {
 			.sType      = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
@@ -672,6 +672,14 @@ out:;
 
 		if(vkCreateImageView(qvk.device, &img_create_info, NULL, qvk.swap_chain_image_views + i) != VK_SUCCESS) {
 			Com_EPrintf("error creating image view!");
+
+			free(qvk.swap_chain_image_views);
+			qvk.swap_chain_image_views = NULL;
+
+			free(qvk.swap_chain_images);
+			qvk.swap_chain_images = NULL;
+
+			qvk.num_swap_chain_images = 0;
 			return 1;
 		}
 	}
@@ -1495,6 +1503,12 @@ destroy_swapchain()
 		vkDestroyImageView  (qvk.device, qvk.swap_chain_image_views[i], NULL);
 		qvk.swap_chain_image_views[i] = VK_NULL_HANDLE;
 	}
+	free(qvk.swap_chain_image_views);
+	qvk.swap_chain_image_views = NULL;
+
+	free(qvk.swap_chain_images);
+	qvk.swap_chain_images = NULL;
+
 	qvk.num_swap_chain_images = 0;
 
 	vkDestroySwapchainKHR(qvk.device, qvk.swap_chain, NULL);

--- a/src/refresh/vkpt/vkpt.h
+++ b/src/refresh/vkpt/vkpt.h
@@ -140,7 +140,6 @@ enum QVK_SHADER_MODULES {
 };
 
 #define MAX_FRAMES_IN_FLIGHT 2
-#define MAX_SWAPCHAIN_IMAGES 4
 
 typedef struct cmd_buf_group_s {
 	uint32_t count_per_frame;
@@ -189,8 +188,8 @@ typedef struct QVK_s {
 	uint32_t                    gpu_slice_width;
 	uint32_t                    gpu_slice_width_prev;
 	uint32_t                    num_swap_chain_images;
-	VkImage                     swap_chain_images[MAX_SWAPCHAIN_IMAGES];
-	VkImageView                 swap_chain_image_views[MAX_SWAPCHAIN_IMAGES];
+	VkImage*                    swap_chain_images;
+	VkImageView*                swap_chain_image_views;
 
 	qboolean                    use_khr_ray_tracing;
 	qboolean                    use_ray_query;


### PR DESCRIPTION
A well-behaved Vulkan application should not care about the number of swapchain images exposed by vkGetSwapchainImagesKHR.

In XWayland (right now), there is no IMMEDIATE mode, only MAILBOX, which is exposed as IMMEDIATE.

However, this means that the max number of swapchain images exceeds what would normally be expected for typical IMMEDIATE implementations under X11.

With this change I can run Quake 2 RTX under XWayland on my Radeon VII.
This will also likely be needed by NVIDIA following the release of their 470 driver which enables [X]Wayland support.

Signed-off-by: Joshua Ashton <joshua@froggi.es>