### PR TITLE
Make 'fake emissive' material properties editable

### DIFF
--- a/inc/refresh/refresh.h
+++ b/inc/refresh/refresh.h
@@ -212,6 +212,9 @@ typedef enum {
     IF_SRC_MASK     = (0x3 << 16),
 } imageflags_t;
 
+// Shift amount for storing fake emissive synthesis threshold
+#define IF_FAKE_EMISSIVE_THRESH_SHIFT  20
+
 typedef enum {
     IT_PIC,
     IT_FONT,

--- a/readme.md
+++ b/readme.md
@@ -199,10 +199,13 @@ First, it will look in the `overrides/` directory, then in the original texture 
 suffix, and emissive maps are searched with the `_light` suffix. If no replacement files are found, just the original base
 texture will be used.
 
-Undefined materials can also use the automatic emissive texture generation feature. When the `pt_enable_surface_lights` console
-variable is nonzero, wall surfaces with the `SURF_LIGHT` flag (but not `SURF_SKY` or `SURF_NODRAW`) will generate an emissive
-texture from the base texture and a threshold value, if no emissive texture is found, and marked with the `is_light` material flag.
+Materials can also use the automatic emissive texture generation feature. This is the case for undefined materials when the
+`pt_enable_surface_lights` console variable is nonzero: wall surfaces with the `SURF_LIGHT` flag (but not `SURF_SKY` or
+`SURF_NODRAW`) will generate an emissive texture from the base texture and a threshold value, if no emissive texture is found,
+and marked with the `is_light` material flag.
 The threshold value is set using the `pt_surface_lights_threshold` variable.
+For defined materials you can the `synth_emissive` and `emissive_threshold` material properties to explicitly enable
+emissive texture generation.
 
 Materials can be examined and modified at run time, using the `mat` command. For example, `mat print` will print the properties
 of the currently targeted material to the console. To get more usage information, use `mat help`.

--- a/src/refresh/vkpt/bsp_mesh.c
+++ b/src/refresh/vkpt/bsp_mesh.c
@@ -30,7 +30,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 extern cvar_t *cvar_pt_enable_nodraw;
 extern cvar_t *cvar_pt_enable_surface_lights;
 extern cvar_t *cvar_pt_enable_surface_lights_warp;
-extern cvar_t *cvar_pt_surface_lights_fake_emissive_algo;
 extern cvar_t *cvar_pt_bsp_radiance_scale;
 
 static void
@@ -1847,19 +1846,6 @@ bsp_mesh_destroy(bsp_mesh_t *wm)
 	memset(wm, 0, sizeof(*wm));
 }
 
-static image_t* get_fake_emissive_image(image_t* diffuse)
-{
-	switch(cvar_pt_surface_lights_fake_emissive_algo->integer)
-	{
-	case 0:
-		return diffuse;
-	case 1:
-		return vkpt_fake_emissive_texture(diffuse);
-	default:
-		return NULL;
-	}
-}
-
 void
 bsp_mesh_register_textures(bsp_t *bsp)
 {
@@ -1899,17 +1885,7 @@ bsp_mesh_register_textures(bsp_t *bsp)
 				synth_surface_material &= !is_warp_surface;
 			
 			if (synth_surface_material)
-			{
-				mat->flags |= MATERIAL_FLAG_LIGHT;
-
-				if (!mat->image_emissive) {
-					mat->image_emissive = get_fake_emissive_image(mat->image_base);
-				
-					if (mat->image_emissive) {
-						vkpt_extract_emissive_texture_info(mat->image_emissive);
-					}
-				}
-			}
+				MAT_SynthesizeEmissive(mat);
 		}
 		
 		info->material = mat;

--- a/src/refresh/vkpt/material.c
+++ b/src/refresh/vkpt/material.c
@@ -715,7 +715,7 @@ void MAT_ChangeMap(const char* map_name)
 
 static void load_material_image(image_t** image, const char* filename, pbr_material_t* mat, imagetype_t type, imageflags_t flags)
 {
-	*image = IMG_Find(filename, type, flags | IF_SRGB | IF_EXACT | (mat->image_flags & IF_SRC_MASK));
+	*image = IMG_Find(filename, type, flags | IF_EXACT | (mat->image_flags & IF_SRC_MASK));
 	if (*image == R_NOTEXTURE) {
 		/* Also try inexact loading in case of an override texture.
 		 * Useful for games that ship a texture in a different directory
@@ -723,7 +723,7 @@ static void load_material_image(image_t** image, const char* filename, pbr_mater
 		 * up, but if the same path is written to a materials file, a
 		 * warning is emitted, since overrides are in generally in baseq2. */
 		if(strncmp(filename, "overrides/", 10) == 0)
-			*image = IMG_Find(filename, type, flags | IF_SRGB | IF_EXACT);
+			*image = IMG_Find(filename, type, flags | IF_EXACT);
 	}
 }
 
@@ -764,7 +764,7 @@ pbr_material_t* MAT_Find(const char* name, imagetype_t type, imageflags_t flags)
 		
 		
 		if (mat->filename_base[0]) {
-			load_material_image(&mat->image_base, mat->filename_base, mat, type, flags);
+			load_material_image(&mat->image_base, mat->filename_base, mat, type, flags | IF_SRGB);
 			if (mat->image_base == R_NOTEXTURE) {
 				Com_WPrintf("Texture '%s' specified in material '%s' could not be found. Using the low-res texture.\n", mat->filename_base, mat_name_no_ext);
 				
@@ -788,7 +788,7 @@ pbr_material_t* MAT_Find(const char* name, imagetype_t type, imageflags_t flags)
 		}
 		
 		if (mat->filename_emissive[0]) {
-			load_material_image(&mat->image_emissive, mat->filename_emissive, mat, type, flags);
+			load_material_image(&mat->image_emissive, mat->filename_emissive, mat, type, flags | IF_SRGB);
 			if (mat->image_emissive == R_NOTEXTURE) {
 				Com_WPrintf("Texture '%s' specified in material '%s' could not be found.\n", mat->filename_emissive, mat_name_no_ext);
 				mat->image_emissive = NULL;

--- a/src/refresh/vkpt/material.c
+++ b/src/refresh/vkpt/material.c
@@ -696,6 +696,20 @@ void MAT_ChangeMap(const char* map_name)
 	}
 }
 
+static void load_material_image(image_t** image, const char* filename, pbr_material_t* mat, imagetype_t type, imageflags_t flags)
+{
+	*image = IMG_Find(filename, type, flags | IF_SRGB | IF_EXACT | (mat->image_flags & IF_SRC_MASK));
+	if (*image == R_NOTEXTURE) {
+		/* Also try inexact loading in case of an override texture.
+		 * Useful for games that ship a texture in a different directory
+		 * (compared to the baseq2 location): the override is still picked
+		 * up, but if the same path is written to a materials file, a
+		 * warning is emitted, since overrides are in generally in baseq2. */
+		if(strncmp(filename, "overrides/", 10) == 0)
+			*image = IMG_Find(filename, type, flags | IF_SRGB | IF_EXACT);
+	}
+}
+
 pbr_material_t* MAT_Find(const char* name, imagetype_t type, imageflags_t flags)
 {
 	char mat_name_no_ext[MAX_QPATH];
@@ -733,7 +747,7 @@ pbr_material_t* MAT_Find(const char* name, imagetype_t type, imageflags_t flags)
 		
 		
 		if (mat->filename_base[0]) {
-			mat->image_base = IMG_Find(mat->filename_base, type, flags | IF_SRGB | IF_EXACT | (mat->image_flags & IF_SRC_MASK));
+			load_material_image(&mat->image_base, mat->filename_base, mat, type, flags);
 			if (mat->image_base == R_NOTEXTURE) {
 				Com_WPrintf("Texture '%s' specified in material '%s' could not be found. Using the low-res texture.\n", mat->filename_base, mat_name_no_ext);
 				
@@ -749,7 +763,7 @@ pbr_material_t* MAT_Find(const char* name, imagetype_t type, imageflags_t flags)
 		}
 
 		if (mat->filename_normals[0]) {
-			mat->image_normals = IMG_Find(mat->filename_normals, type, flags | IF_EXACT | (mat->image_flags & IF_SRC_MASK));
+			load_material_image(&mat->image_normals, mat->filename_normals, mat, type, flags);
 			if (mat->image_normals == R_NOTEXTURE) {
 				Com_WPrintf("Texture '%s' specified in material '%s' could not be found.\n", mat->filename_normals, mat_name_no_ext);
 				mat->image_normals = NULL;
@@ -757,7 +771,7 @@ pbr_material_t* MAT_Find(const char* name, imagetype_t type, imageflags_t flags)
 		}
 		
 		if (mat->filename_emissive[0]) {
-			mat->image_emissive = IMG_Find(mat->filename_emissive, type, flags | IF_SRGB | IF_EXACT | (mat->image_flags & IF_SRC_MASK));
+			load_material_image(&mat->image_emissive, mat->filename_emissive, mat, type, flags);
 			if (mat->image_emissive == R_NOTEXTURE) {
 				Com_WPrintf("Texture '%s' specified in material '%s' could not be found.\n", mat->filename_emissive, mat_name_no_ext);
 				mat->image_emissive = NULL;

--- a/src/refresh/vkpt/material.h
+++ b/src/refresh/vkpt/material.h
@@ -92,4 +92,7 @@ uint32_t MAT_SetKind(uint32_t material, uint32_t kind);
 // tests if the material is of a given kind
 qboolean MAT_IsKind(uint32_t material, uint32_t kind);
 
+// synthesize 'emissive' image for a material, if necessary
+void MAT_SynthesizeEmissive(pbr_material_t * mat);
+
 #endif // __MATERIAL_H_

--- a/src/refresh/vkpt/material.h
+++ b/src/refresh/vkpt/material.h
@@ -57,6 +57,7 @@ typedef struct pbr_material_s {
 	qboolean bsp_radiance;
 	imageflags_t image_flags;
 	imagetype_t image_type;
+	qboolean synth_emissive;
 } pbr_material_t;
 
 extern pbr_material_t r_materials[MAX_PBR_MATERIALS];

--- a/src/refresh/vkpt/material.h
+++ b/src/refresh/vkpt/material.h
@@ -58,6 +58,7 @@ typedef struct pbr_material_s {
 	imageflags_t image_flags;
 	imagetype_t image_type;
 	qboolean synth_emissive;
+	int emissive_threshold;
 } pbr_material_t;
 
 extern pbr_material_t r_materials[MAX_PBR_MATERIALS];

--- a/src/refresh/vkpt/vkpt.h
+++ b/src/refresh/vkpt/vkpt.h
@@ -520,7 +520,7 @@ VkResult vkpt_textures_upload_envmap(int w, int h, byte *data);
 void vkpt_textures_destroy_unused();
 void vkpt_textures_update_descriptor_set();
 void vkpt_normalize_normal_map(image_t *image);
-image_t *vkpt_fake_emissive_texture(image_t *image);
+image_t *vkpt_fake_emissive_texture(image_t *image, int bright_threshold_int);
 void vkpt_extract_emissive_texture_info(image_t *image);
 void vkpt_textures_prefetch();
 void vkpt_invalidate_texture_descriptors();


### PR DESCRIPTION
This allows use of the new material system/editor to toggle "fake emissive" image generation and to change the brightness threshold used by that.

For an example, start rmine1 with these materials:
```
textures/r_mine/walmine01:
	texture_base textures/r_mine/walmine01.wal
	is_light 1
	synth_emissive 1
	emissive_threshold 150

textures/e2u1/ceil1_26:
	texture_base textures/e2u1/ceil1_26.wal
	is_light 1
	synth_emissive 1
	emissive_threshold 200
```
* This makes the "red ore" glow, similar to the blue ore
* Fixes a light texture to actually emit light (visible eg below the computer in that control room)

In general, wrt your changes to the material system: cool stuff :)
