### PR TITLE
Animate poly lights

### DIFF
--- a/src/refresh/vkpt/vkpt.h
+++ b/src/refresh/vkpt/vkpt.h
@@ -328,6 +328,7 @@ typedef struct light_poly_s {
 	struct pbr_material_s* material;
 	int cluster;
 	int style;
+	float emissive_factor;
 } light_poly_t;
 
 typedef struct bsp_model_s {
@@ -404,6 +405,7 @@ typedef struct bsp_mesh_s {
 void bsp_mesh_create_from_bsp(bsp_mesh_t *wm, bsp_t *bsp, const char* map_name);
 void bsp_mesh_destroy(bsp_mesh_t *wm);
 void bsp_mesh_register_textures(bsp_t *bsp);
+void bsp_mesh_animate_light_polys(bsp_mesh_t *wm);
 
 typedef struct vkpt_refdef_s {
 	QVKUniformBuffer_t uniform_buffer;


### PR DESCRIPTION
Change the color of poly lights with multiple frames. For #134

Previously, for materials consisting of multiple frames, only the emissive data from the first frame would be used to set up the poly light. (The mitigation was to not create poly lights from animated materials.)
Now, poly light colors are updated as well when the "world" is animated.

Some properties are different from frame to frame but can't change dynamically; they're dealt with as such:
* `is_light` property: As soon as a single frame has this property a poly light is created.
* emissive area: This is the bounding area of all emissive areas of the frames.

Other properties (e.g. `emissive_factor`) still apply per frame.