### PR TITLE
Create buf_accel_scratch with VK_BUFFER_USAGE_STORAGE_BUFFER_BIT

### DIFF
--- a/src/refresh/vkpt/path_tracer.c
+++ b/src/refresh/vkpt/path_tracer.c
@@ -170,7 +170,7 @@ vkpt_pt_init()
 	minAccelerationStructureScratchOffsetAlignment = accel_struct_properties.minAccelerationStructureScratchOffsetAlignment;
 
 	buffer_create(&buf_accel_scratch, SIZE_SCRATCH_BUFFER, 
-		VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT,
+		VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
 		VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
 	for(int i = 0; i < MAX_FRAMES_IN_FLIGHT; i++) {


### PR DESCRIPTION
Silences the following validation errors that appeared with the latest Vulkan SDK:

validation layer 2 4096: Validation Error: [ VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03674 ] Object 0: handle = 0x27ecae4f478, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0xea5edaf3 | vkBuildAccelerationStructuresKHR(): The buffer associated with pInfos[0].scratchData.deviceAddress was not created with VK_BUFFER_USAGE_STORAGE_BUFFER_BIT bit. The Vulkan spec states: The buffer from which the buffer device address pInfos[i].scratchData.deviceAddress is queried must have been created with VK_BUFFER_USAGE_STORAGE_BUFFER_BIT usage flag (https://vulkan.lunarg.com/doc/view/1.2.189.0/windows/1.2-extensions/vkspec.html#VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03674)

