### PR TITLE
Change 'procedural skipping' flag into compile time constant

### DIFF
--- a/src/refresh/vkpt/shader/direct_lighting.rgen
+++ b/src/refresh/vkpt/shader/direct_lighting.rgen
@@ -29,11 +29,14 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #extension GL_GOOGLE_include_directive    : enable
 #pragma optionNV(unroll all)
 
+#include "path_tracer.h"
+
+layout(constant_id = 0) const uint spec_enable_caustics = 0;
+layout(constant_id = 1) const uint spec_skip_procedural = 0;
+
 #define ENABLE_SHADOW_CAUSTICS
 #include "path_tracer_rgen.h"
 #include "projection.glsl"
-
-layout(constant_id = 0) const uint spec_enable_caustics = 0;
 
 void
 direct_lighting(ivec2 ipos, bool is_odd_checkerboard, out vec3 high_freq, out vec3 o_specular)

--- a/src/refresh/vkpt/shader/indirect_lighting.rgen
+++ b/src/refresh/vkpt/shader/indirect_lighting.rgen
@@ -29,10 +29,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #extension GL_GOOGLE_include_directive    : enable
 #pragma optionNV(unroll all)
 
+layout(constant_id = 0) const uint spec_bounce_index = 0;
+layout(constant_id = 1) const uint spec_skip_procedural = 0;
+
 #include "path_tracer_rgen.h"
 #include "path_tracer_transparency.glsl"
-
-layout(constant_id = 0) const uint spec_bounce_index = 0;
 
 void
 indirect_lighting(
@@ -231,7 +232,7 @@ indirect_lighting(
 		shadow_cull_mask |= AS_FLAG_VIEWER_WEAPON;
 	}
 
-	trace_ray(bounce_ray, true, bounce_cull_mask, true);
+	trace_ray(bounce_ray, true, bounce_cull_mask);
 
 	Triangle triangle;
 

--- a/src/refresh/vkpt/shader/path_tracer_rgen.h
+++ b/src/refresh/vkpt/shader/path_tracer_rgen.h
@@ -255,12 +255,12 @@ correct_emissive(uint material_id, vec3 emissive)
 }
 
 void
-trace_ray(Ray ray, bool cull_back_faces, int instance_mask, bool skip_procedural)
+trace_ray(Ray ray, bool cull_back_faces, int instance_mask)
 {
 	uint rayFlags = 0;
 	if (cull_back_faces)
 		rayFlags |= gl_RayFlagsCullBackFacingTrianglesEXT;
-	if (skip_procedural)
+	if (spec_skip_procedural != 0)
 		rayFlags |= gl_RayFlagsSkipProceduralPrimitives;
 
 	ray_payload_brdf.barycentric = vec2(0);
@@ -290,7 +290,7 @@ trace_ray(Ray ray, bool cull_back_faces, int instance_mask, bool skip_procedural
 
 		if (isProcedural)
 		{
-			if (!skip_procedural) // this should be a compile-time constant
+			if (spec_skip_procedural == 0)
 			{
 				// We only have one type of procedural primitives: beams.
 				

--- a/src/refresh/vkpt/shader/primary_rays.rgen
+++ b/src/refresh/vkpt/shader/primary_rays.rgen
@@ -29,6 +29,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #extension GL_GOOGLE_include_directive    : enable
 #pragma optionNV(unroll all)
 
+const uint spec_skip_procedural = 0;
+
 #include "path_tracer_rgen.h"
 #include "projection.glsl"
 
@@ -155,7 +157,7 @@ main()
 		if(global_ubo.pt_show_sky != 0)
 			cull_mask |= AS_FLAG_CUSTOM_SKY;
 
-		trace_ray(ray, true, cull_mask, false);
+		trace_ray(ray, true, cull_mask);
 	}
 
 	direction = ray.direction;
@@ -474,7 +476,7 @@ main()
 
 	{
 		int cull_mask = AS_FLAG_PARTICLES | AS_FLAG_EXPLOSIONS;
-		trace_ray(ray, true, cull_mask, false);
+		trace_ray(ray, true, cull_mask);
 	}
 
 	vec4 transparent = get_payload_transparency(ray_payload_brdf, hit_distance);

--- a/src/refresh/vkpt/shader/reflect_refract.rgen
+++ b/src/refresh/vkpt/shader/reflect_refract.rgen
@@ -28,13 +28,14 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #extension GL_GOOGLE_include_directive    : enable
 #pragma optionNV(unroll all)
 
+layout(constant_id = 0) const uint spec_bounce_index = 0;
+layout(constant_id = 1) const uint spec_skip_procedural = 0;
+
 #define ENABLE_SHADOW_CAUSTICS
 #define ENABLE_SUN_SHAPE
 #include "path_tracer_rgen.h"
 #include "path_tracer_transparency.glsl"
 #include "projection.glsl"
-
-layout(constant_id = 0) const uint spec_bounce_index = 0;
 
 vec3 reflect_point_vs_plane(vec3 plane_pt, vec3 plane_normal, vec3 point)
 {
@@ -481,7 +482,7 @@ main()
 	else
 		reflection_ray.origin -= normal.xyz * 0.001;
 
-	trace_ray(reflection_ray, backface_culling, reflection_cull_mask, false);
+	trace_ray(reflection_ray, backface_culling, reflection_cull_mask);
 
 	// Add the transparency encountered along the reflection ray
 	vec4 payload_transparency = get_payload_transparency_simple(ray_payload_brdf);


### PR DESCRIPTION
This picks up on a comment in `path_tracer_rgen.h`, where it says `skip_procedural` "should be a compile-time constant".
Now it is.