### PR TITLE
Tonemapping: debug aids, tweaks

### DIFF
--- a/inc/refresh/refresh.h
+++ b/inc/refresh/refresh.h
@@ -142,6 +142,7 @@ typedef struct ref_feedback_s {
     int         view_material_index;
 
 	vec3_t      hdr_color;
+	float       adapted_luminance;
 } ref_feedback_t;
 
 typedef struct refdef_s {

--- a/src/refresh/vkpt/main.c
+++ b/src/refresh/vkpt/main.c
@@ -2253,6 +2253,7 @@ process_render_feedback(ref_feedback_t *feedback, mleaf_t* viewleaf, qboolean* s
 		}
 
 		VectorCopy(readback.hdr_color, feedback->hdr_color);
+		feedback->adapted_luminance = readback.adapted_luminance;
 
 		*sun_visible = readback.sun_luminance > 0.f;
 		*adapted_luminance = readback.adapted_luminance;
@@ -3219,6 +3220,8 @@ R_EndFrame_RTX(void)
 
 	if(cvar_profiler->integer)
 		draw_profiler(cvar_flt_enable->integer != 0);
+	if(cvar_tm_debug->integer)
+		vkpt_tone_mapping_draw_debug();
 
 	VkCommandBuffer cmd_buf = vkpt_begin_command_buffer(&qvk.cmd_buffers_graphics);
 

--- a/src/refresh/vkpt/main.c
+++ b/src/refresh/vkpt/main.c
@@ -49,6 +49,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <assert.h>
 
 cvar_t *cvar_profiler = NULL;
+cvar_t *cvar_profiler_scale = NULL;
 cvar_t *cvar_vsync = NULL;
 cvar_t *cvar_pt_caustics = NULL;
 cvar_t *cvar_pt_enable_nodraw = NULL;
@@ -3389,6 +3390,7 @@ R_Init_RTX(qboolean total)
 	qvk.window = sdl_window;
 
 	cvar_profiler = Cvar_Get("profiler", "0", 0);
+	cvar_profiler_scale = Cvar_Get("profiler_scale", "1", CVAR_ARCHIVE);
 	cvar_vsync = Cvar_Get("vid_vsync", "0", CVAR_REFRESH | CVAR_ARCHIVE);
 	cvar_vsync->changed = NULL; // in case the GL renderer has set it
 	cvar_pt_caustics = Cvar_Get("pt_caustics", "1", CVAR_ARCHIVE);

--- a/src/refresh/vkpt/profiler.c
+++ b/src/refresh/vkpt/profiler.c
@@ -27,6 +27,7 @@ static uint64_t query_pool_results[NUM_PROFILER_QUERIES_PER_FRAME * 2];
 // causing vkGetQueryPoolResults to stop writing the results halfway through 
 // the buffer if it's properly sized.
 
+extern cvar_t *cvar_profiler_scale;
 extern cvar_t *cvar_pt_reflect_refract;
 extern cvar_t *cvar_flt_fsr_enable;
 
@@ -147,13 +148,16 @@ draw_query(int x, int y, qhandle_t font, const char *enum_name, int idx)
 void
 draw_profiler(int enable_asvgf)
 {
-	int x = 500;
-	int y = 100;
+	float profiler_scale = R_ClampScale(cvar_profiler_scale);
+	int x = 500 * profiler_scale;
+	int y = 100 * profiler_scale;
 
 	qhandle_t font;
 	font = R_RegisterFont("conchars");
 	if(!font)
 		return;
+
+	R_SetScale(profiler_scale);
 
 #define PROFILER_DO(name, indent) \
 	draw_query(x, y, font, &#name[9], name); y += 10;
@@ -200,6 +204,8 @@ draw_profiler(int enable_asvgf)
 		PROFILER_DO(PROFILER_FSR_RCAS, 2);
 	}
 #undef PROFILER_DO
+
+	R_SetScale(1.0f);
 }
 
 double vkpt_get_profiler_result(int idx)

--- a/src/refresh/vkpt/shader/tone_mapping_apply.comp
+++ b/src/refresh/vkpt/shader/tone_mapping_apply.comp
@@ -64,12 +64,13 @@ layout(push_constant, std430) uniform PushConstants {
 // computed tone mapping curve.
 vec4 show_bar_chart(ivec2 pos, bool is_curve)
 {
-    const int bin_width = 2;
-    ivec2 size = ivec2(HISTOGRAM_BINS * bin_width, 100);
+    const float scale = float(global_ubo.screen_image_height) / float(global_ubo.unscaled_height);
+    const float bin_width = 2 * scale;
+    ivec2 size = ivec2(HISTOGRAM_BINS * bin_width, 100 * scale);
 
     ivec2 TL, BR;
-    TL.x = 10;
-    BR.y = global_ubo.height - 10;
+    TL.x = int(10 * scale);
+    BR.y = global_ubo.screen_image_height - int(10 * scale);
     TL.y = BR.y - size.y - 1;
     BR.x = TL.x + size.x + 1;
     
@@ -82,7 +83,7 @@ vec4 show_bar_chart(ivec2 pos, bool is_curve)
     if(pos.x < TL.x || pos.y < TL.y || pos.x > BR.x  || pos.y > BR.y)
         return vec4(0);
 
-    int bin = (pos.x - TL.x - 1) / 2;
+    int bin = int((pos.x - TL.x - 1) / bin_width);
     float pix_value = (BR.y - pos.y + 1) / float(size.y);
     float bin_value;
     if(is_curve)

--- a/src/refresh/vkpt/shader/tone_mapping_curve.comp
+++ b/src/refresh/vkpt/shader/tone_mapping_curve.comp
@@ -296,7 +296,11 @@ void main()
     // Since blurring may have made the tone curve value at noise_stop_bin greater than -r,
     // we apply the expected incremental adjustment:
     if(linear_idx < noise_stop_bin){
-        my_tonecurve = mix(bin_log_luminance - log_target_lum,
+        /* log_target_lum has a fugde factor applied to avoid the "somewhat autoexposure" value
+         * to get larger than the actual curve, which would introduce a "bump" followed by a "valley"
+         * to the TM curve. This looks odd. */
+        const float tone_curve_ae = bin_log_luminance - log_target_lum * sqrt(0.5);
+        my_tonecurve = mix(tone_curve_ae,
             my_tonecurve,
             mix(smoothstep(0.5*noise_stop_bin, noise_stop_bin, linear_idx), 1.0, global_ubo.tm_noise_blend));
     }

--- a/src/refresh/vkpt/shader/tone_mapping_curve.comp
+++ b/src/refresh/vkpt/shader/tone_mapping_curve.comp
@@ -296,10 +296,23 @@ void main()
     // Since blurring may have made the tone curve value at noise_stop_bin greater than -r,
     // we apply the expected incremental adjustment:
     if(linear_idx < noise_stop_bin){
-        /* log_target_lum has a fugde factor applied to avoid the "somewhat autoexposure" value
-         * to get larger than the actual curve, which would introduce a "bump" followed by a "valley"
-         * to the TM curve. This looks odd. */
-        const float tone_curve_ae = bin_log_luminance - log_target_lum * sqrt(0.5);
+        /* The "somewhat autoexposure" value (tone_curve_ae) can become larger than the actual curve,
+         * and when mixed into the tone curve, would would introduce a "bump" followed by a "valley"
+         * to the resulting TM curve. This looks odd.
+         * To avoid this valley a "fudge factor" is used to compute tone_curve_ae.
+         * The factor is chosen such that the maximum possible "somewhat autoexposure" value
+         * equals the unchanged tone curve value at tm_noise_stops (ie where mixing in of the
+         * "somewhat autoexposure" value stops). */
+
+        /* Tone curve value before noise_stop_bin. Takes advantage of prior call to computePrefixSum()
+         * (Since that contains a prefix sum it's also the maximum value of the curve to that point.) */
+        const float my_tonecurve_at_ns = s_Shared[int(noise_stop_bin) - 1]*delta - r;
+        // The "somewhat autoexposure" value at tm_noise_stops
+        const float bin_log_luminance_at_ns = (float(noise_stop_bin - 1)/float(HISTOGRAM_BINS)) * (max_log_luminance - min_log_luminance) + min_log_luminance;
+        // Compute "fudge factor" so tone_curve_ae values will not be larger than my_tonecurve_at_ns
+        const float fudge = -(my_tonecurve_at_ns - bin_log_luminance_at_ns) / log_target_lum;
+
+        const float tone_curve_ae = bin_log_luminance - log_target_lum * fudge;
         my_tonecurve = mix(tone_curve_ae,
             my_tonecurve,
             mix(smoothstep(0.5*noise_stop_bin, noise_stop_bin, linear_idx), 1.0, global_ubo.tm_noise_blend));

--- a/src/refresh/vkpt/tone_mapping.c
+++ b/src/refresh/vkpt/tone_mapping.c
@@ -55,6 +55,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "vkpt.h"
 
+extern cvar_t *cvar_profiler_scale;
+
 // Here are each of the pipelines we'll be using, followed by an additional
 // enum value to count the number of tone mapping pipelines.
 enum {
@@ -396,4 +398,28 @@ vkpt_tone_mapping_record_cmd_buffer(VkCommandBuffer cmd_buf, float frame_time)
 	reset_required = 0;
 
 	return VK_SUCCESS;
+}
+
+void
+vkpt_tone_mapping_draw_debug()
+{
+	float profiler_scale = R_ClampScale(cvar_profiler_scale);
+	int x = 10 * profiler_scale;
+	int y = (qvk.extent_unscaled.height - 10) * profiler_scale;
+
+	qhandle_t font;
+	font = R_RegisterFont("conchars");
+	if(!font)
+		return;
+
+	R_SetScale(profiler_scale);
+
+	if(vkpt_refdef.fd)
+	{
+		char buf[256];
+		snprintf(buf, sizeof buf, "Adapted luminance: %8.6f", vkpt_refdef.fd->feedback.adapted_luminance);
+		R_DrawString(x, y, 0, 128, buf, font);
+	}
+
+	R_SetScale(1.0f);
 }

--- a/src/refresh/vkpt/tone_mapping.c
+++ b/src/refresh/vkpt/tone_mapping.c
@@ -417,7 +417,7 @@ vkpt_tone_mapping_draw_debug()
 	if(vkpt_refdef.fd)
 	{
 		char buf[256];
-		snprintf(buf, sizeof buf, "Adapted luminance: %8.6f", vkpt_refdef.fd->feedback.adapted_luminance);
+		snprintf(buf, sizeof buf, "Adapted luminance: %8.6f (ev: %f)", vkpt_refdef.fd->feedback.adapted_luminance, log2f(vkpt_refdef.fd->feedback.adapted_luminance));
 		R_DrawString(x, y, 0, 128, buf, font);
 	}
 

--- a/src/refresh/vkpt/vkpt.h
+++ b/src/refresh/vkpt/vkpt.h
@@ -660,6 +660,7 @@ VkResult vkpt_tone_mapping_reset(VkCommandBuffer cmd_buf);
 VkResult vkpt_tone_mapping_destroy_pipelines();
 VkResult vkpt_tone_mapping_record_cmd_buffer(VkCommandBuffer cmd_buf, float frame_time);
 void vkpt_tone_mapping_request_reset();
+void vkpt_tone_mapping_draw_debug();
 
 VkResult vkpt_shadow_map_initialize();
 VkResult vkpt_shadow_map_destroy();


### PR DESCRIPTION
I'm currently playing around with tonemapping, and here are some related bits and pieces that I have accumulated...

Most significant is probably b4c2b3f: This tries to address an issue where the tonemapping curve has a "valley" in certain dark areas (see below for illustration: both the curve, as well as a location where this happens, here the basement in base1).
![image](https://user-images.githubusercontent.com/4117506/137627588-90e2ddc8-84dc-4306-bb9e-a7c034589082.png)


By default, that "valley" isn't visible (due to the Reinhard mixed in), but for the screenshot I set `tm_reinhard` to 0 so it can be perceived: some areas suddenly have a sort-of "negative" effect, like the walls left and right of the cross hair having a part that's darker than it's neighboring parts.

Since my attempt to address this is basically an empirically determined "fudge factor" I think a second opinion would be good here ;)

Otherwise, small stuff:
* The `tm_debug` overlay was moving around and changing size if for `viewsize`s other than 100, correct for that
* Print the "adapted luminance" when `tm_debug` is enabled
* Allow scaling of the profiler overlay (it can get really hard to read on high DPI displays/resolutions).
