### PR TITLE
HDR support

### DIFF
--- a/baseq2/q2rtx.menu
+++ b/baseq2/q2rtx.menu
@@ -96,6 +96,7 @@ begin hdr
     blank
     range -f "%.0f nits" "peak brightness" tm_hdr_peak_nits 100 2000 10
     range -f "%.0f nits" "UI brightness" ui_hdr_nits 100 2000 10
+    range -f "%.0f%%" "Saturation adjustment" tm_hdr_saturation_scale 0 200 5
 end
 
 begin photomode

--- a/baseq2/q2rtx.menu
+++ b/baseq2/q2rtx.menu
@@ -88,6 +88,16 @@ begin resolution
     range -f "%.0f%%" "fixed resolution scale" viewsize 25 200 5
 end
 
+begin hdr
+    background #212F3CD0
+    style --compact
+    title "HDR Settings"
+    toggle "Enable HDR" vid_hdr
+    blank
+    range -f "%.0f nits" "peak brightness" tm_hdr_peak_nits 100 2000 10
+    range -f "%.0f nits" "UI brightness" ui_hdr_nits 100 2000 10
+end
+
 begin photomode
     background #212F3CD0
     style --compact
@@ -120,6 +130,7 @@ begin video
 
     ifeq vid_rtx 1
         action "resolution scaling options..." pushmenu resolution
+        action "HDR options..." pushmenu hdr
         blank
         range -f "%+.1f EV" "exposure bias (brightness)" tm_exposure_bias -5 0 0.1
         range -p -f "%.0f%%" "contrast" tm_reinhard 0 1 0.1

--- a/cmake/compileShaders.cmake
+++ b/cmake/compileShaders.cmake
@@ -2,6 +2,8 @@ set(SHADER_SOURCE_DEPENDENCIES
     ${CMAKE_SOURCE_DIR}/src/refresh/vkpt/shader/asvgf.glsl
     ${CMAKE_SOURCE_DIR}/src/refresh/vkpt/shader/brdf.glsl
     ${CMAKE_SOURCE_DIR}/src/refresh/vkpt/shader/constants.h
+    ${CMAKE_SOURCE_DIR}/src/refresh/vkpt/shader/fsr_easu.glsl
+    ${CMAKE_SOURCE_DIR}/src/refresh/vkpt/shader/fsr_rcas.glsl
     ${CMAKE_SOURCE_DIR}/src/refresh/vkpt/shader/global_textures.h
     ${CMAKE_SOURCE_DIR}/src/refresh/vkpt/shader/global_ubo.h
     ${CMAKE_SOURCE_DIR}/src/refresh/vkpt/shader/god_rays_shared.h

--- a/cmake/compileShaders.cmake
+++ b/cmake/compileShaders.cmake
@@ -4,6 +4,7 @@ set(SHADER_SOURCE_DEPENDENCIES
     ${CMAKE_SOURCE_DIR}/src/refresh/vkpt/shader/constants.h
     ${CMAKE_SOURCE_DIR}/src/refresh/vkpt/shader/fsr_easu.glsl
     ${CMAKE_SOURCE_DIR}/src/refresh/vkpt/shader/fsr_rcas.glsl
+    ${CMAKE_SOURCE_DIR}/src/refresh/vkpt/shader/fsr_utils.glsl
     ${CMAKE_SOURCE_DIR}/src/refresh/vkpt/shader/global_textures.h
     ${CMAKE_SOURCE_DIR}/src/refresh/vkpt/shader/global_ubo.h
     ${CMAKE_SOURCE_DIR}/src/refresh/vkpt/shader/god_rays_shared.h

--- a/inc/refresh/images.h
+++ b/inc/refresh/images.h
@@ -127,6 +127,7 @@ void IMG_MipMap(byte *out, byte *in, int width, int height);
 extern void (*IMG_Unload)(image_t *image);
 extern void (*IMG_Load)(image_t *image, byte *pic);
 extern byte* (*IMG_ReadPixels)(int *width, int *height, int *rowbytes);
+extern float* (*IMG_ReadPixelsHDR)(int *width, int *height);
 
 #endif // IMAGES_H
 

--- a/inc/refresh/refresh.h
+++ b/inc/refresh/refresh.h
@@ -291,6 +291,7 @@ extern void    (*R_ModeChanged)(int width, int height, int flags, int rowbytes, 
 extern void    (*R_AddDecal)(decal_t *d);
 
 extern qboolean (*R_InterceptKey)(unsigned key, qboolean down);
+extern qboolean (*R_IsHDR)();
 
 #if REF_GL
 void R_RegisterFunctionsGL();

--- a/src/client/refresh.c
+++ b/src/client/refresh.c
@@ -429,10 +429,12 @@ void(*R_EndFrame)(void) = NULL;
 void(*R_ModeChanged)(int width, int height, int flags, int rowbytes, void *pixels) = NULL;
 void(*R_AddDecal)(decal_t *d) = NULL;
 qboolean(*R_InterceptKey)(unsigned key, qboolean down) = NULL;
+qboolean(*R_IsHDR)() = NULL;
 
 void(*IMG_Unload)(image_t *image) = NULL;
 void(*IMG_Load)(image_t *image, byte *pic) = NULL;
 byte* (*IMG_ReadPixels)(int *width, int *height, int *rowbytes) = NULL;
+float* (*IMG_ReadPixelsHDR)(int *width, int *height) = NULL;
 
 qerror_t(*MOD_LoadMD2)(model_t *model, const void *rawdata, size_t length, const char* mod_name) = NULL;
 #if USE_MD3

--- a/src/refresh/gl/main.c
+++ b/src/refresh/gl/main.c
@@ -1171,9 +1171,11 @@ void R_RegisterFunctionsGL()
 	R_ModeChanged = R_ModeChanged_GL;
 	R_AddDecal = R_AddDecal_GL;
 	R_InterceptKey = R_InterceptKey_GL;
+	R_IsHDR = NULL;
 	IMG_Load = IMG_Load_GL;
 	IMG_Unload = IMG_Unload_GL;
 	IMG_ReadPixels = IMG_ReadPixels_GL;
+	IMG_ReadPixelsHDR = NULL;
 	MOD_LoadMD2 = MOD_LoadMD2_GL;
 	MOD_LoadMD3 = MOD_LoadMD3_GL;
     MOD_LoadIQM = NULL;

--- a/src/refresh/images.c
+++ b/src/refresh/images.c
@@ -447,6 +447,11 @@ static qhandle_t create_screenshot(char *buffer, size_t size,
     return 0;
 }
 
+static qboolean is_render_hdr()
+{
+    return R_IsHDR && R_IsHDR();
+}
+
 static void make_screenshot(const char *name, const char *ext,
                             qerror_t (*save)(qhandle_t, const char *, byte *, int, int, int, int),
                             int param)
@@ -457,13 +462,49 @@ static void make_screenshot(const char *name, const char *ext,
     qhandle_t   f;
     int         w, h, rowbytes;
 
+    if(is_render_hdr()) {
+        Com_WPrintf("Screenshot format not supported in HDR mode");
+        return;
+    }
+
     f = create_screenshot(buffer, sizeof(buffer), name, ext);
     if (!f) {
         return;
     }
 
     pixels = IMG_ReadPixels(&w, &h, &rowbytes);
-    ret = save(f, buffer, pixels, w, h, rowbytes, param);
+    ret = save(f, buffer, pixels, w, h, rowbytes, param) ? Q_ERR_SUCCESS : Q_ERR_LIBRARY_ERROR;
+    FS_FreeTempMem(pixels);
+
+    FS_FCloseFile(f);
+
+    if (ret < 0) {
+        Com_EPrintf("Couldn't write %s: %s\n", buffer, Q_ErrorString(ret));
+    } else if(r_screenshot_message->integer) {
+        Com_Printf("Wrote %s\n", buffer);
+    }
+}
+
+static void make_screenshot_hdr(const char *name)
+{
+    char        buffer[MAX_OSPATH];
+    float       *pixels;
+    qerror_t    ret;
+    qhandle_t   f;
+    int         w, h;
+
+    if(!is_render_hdr()) {
+        Com_WPrintf("Screenshot format supported in HDR mode only");
+    }
+
+    f = create_screenshot(buffer, sizeof(buffer), name, ".hdr");
+    if (!f) {
+        return;
+    }
+
+    pixels = IMG_ReadPixelsHDR(&w, &h);
+    stbi_flip_vertically_on_write(1);
+    ret = stbi_write_hdr_to_func(stbi_write, (void*)(size_t)f, w, h, 3, pixels);
     FS_FreeTempMem(pixels);
 
     FS_FCloseFile(f);
@@ -497,7 +538,15 @@ static void IMG_ScreenShot_f(void)
     if (Cmd_Argc() > 1) {
         s = Cmd_Argv(1);
     } else {
-        s = r_screenshot_format->string;
+        if(is_render_hdr())
+            s = "hdr";
+        else
+            s = r_screenshot_format->string;
+    }
+
+    if (*s == 'h') {
+        make_screenshot_hdr(NULL);
+        return;
     }
 
     if (*s == 'j') {
@@ -568,6 +617,16 @@ static void IMG_ScreenShotPNG_f(void)
     }
 
     make_screenshot(Cmd_Argv(1), ".png", IMG_SavePNG, compression);
+}
+
+static void IMG_ScreenShotHDR_f(void)
+{
+    if (Cmd_Argc() > 2) {
+        Com_Printf("Usage: %s [name]\n", Cmd_Argv(0));
+        return;
+    }
+
+    make_screenshot_hdr(Cmd_Argv(1));
 }
 
 /*

--- a/src/refresh/vkpt/bloom.c
+++ b/src/refresh/vkpt/bloom.c
@@ -110,6 +110,7 @@ void vkpt_bloom_update(QVKUniformBuffer_t * ubo, float frame_time, qboolean unde
 		uint32_t current_ms = Sys_Milliseconds();
 
 		float phase = max(0.f, min(1.f, (float)(current_ms - menu_start_ms) / 150.f));
+		ubo->tonemap_hdr_clamp_strength = phase; // Clamp color in HDR mode, to ensure menu is legible
 		phase = powf(phase, 0.25f);
 
 		bloom_sigma = phase * 0.03f;
@@ -121,6 +122,7 @@ void vkpt_bloom_update(QVKUniformBuffer_t * ubo, float frame_time, qboolean unde
 		menu_start_ms = 0;
 
 		ubo->bloom_intensity = bloom_intensity;
+		ubo->tonemap_hdr_clamp_strength = 0.f;
 	}
 }
 

--- a/src/refresh/vkpt/conversion.h
+++ b/src/refresh/vkpt/conversion.h
@@ -16,8 +16,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef MATERIAL_H_
-#define MATERIAL_H_
+#ifndef CONVERSION_H_
+#define CONVERSION_H_
 
 #include <stdint.h>
 
@@ -76,4 +76,4 @@ static inline uint16_t floatToHalf(float value)
 
 void packHalf4x16(uint32_t* half, float* vec4);
 
-#endif // MATERIAL_H_
+#endif // CONVERSION_H_

--- a/src/refresh/vkpt/draw.c
+++ b/src/refresh/vkpt/draw.c
@@ -45,6 +45,7 @@ typedef struct {
 // Not using global UBO b/c it's only filled when a world is drawn, but here we need it all the time
 typedef struct {
 	float ui_hdr_nits;
+	float tm_hdr_saturation_scale;
 } StretchPic_UBO_t;
 
 static clipRect_t clip_rect;
@@ -68,6 +69,7 @@ static VkDescriptorSet         desc_set_sbo[MAX_FRAMES_IN_FLIGHT];
 static VkDescriptorSet         desc_set_ubo[MAX_FRAMES_IN_FLIGHT];
 
 extern cvar_t* cvar_ui_hdr_nits;
+extern cvar_t* cvar_tm_hdr_saturation_scale;
 
 VkExtent2D
 vkpt_draw_get_extent()
@@ -605,6 +607,7 @@ vkpt_draw_submit_stretch_pics(VkCommandBuffer cmd_buf)
 	BufferResource_t *ubo_res = buf_ubo + qvk.current_frame_index;
 	StretchPic_UBO_t *ubo = (StretchPic_UBO_t *) buffer_map(ubo_res);
 	ubo->ui_hdr_nits = cvar_ui_hdr_nits->value;
+	ubo->tm_hdr_saturation_scale = cvar_tm_hdr_saturation_scale->value;
 	buffer_unmap(ubo_res);
 	ubo = NULL;
 

--- a/src/refresh/vkpt/draw.c
+++ b/src/refresh/vkpt/draw.c
@@ -42,6 +42,11 @@ typedef struct {
 	uint32_t color, tex_handle;
 } StretchPic_t;
 
+// Not using global UBO b/c it's only filled when a world is drawn, but here we need it all the time
+typedef struct {
+	float ui_hdr_nits;
+} StretchPic_UBO_t;
+
 static clipRect_t clip_rect;
 static qboolean clip_enable = qfalse;
 
@@ -54,9 +59,15 @@ static VkPipeline              pipeline_stretch_pic;
 static VkPipeline              pipeline_final_blit;
 static VkFramebuffer*          framebuffer_stretch_pic = NULL;
 static BufferResource_t        buf_stretch_pic_queue[MAX_FRAMES_IN_FLIGHT];
+static BufferResource_t        buf_ubo[MAX_FRAMES_IN_FLIGHT];
 static VkDescriptorSetLayout   desc_set_layout_sbo;
+static VkDescriptorSetLayout   desc_set_layout_ubo;
 static VkDescriptorPool        desc_pool_sbo;
+static VkDescriptorPool        desc_pool_ubo;
 static VkDescriptorSet         desc_set_sbo[MAX_FRAMES_IN_FLIGHT];
+static VkDescriptorSet         desc_set_ubo[MAX_FRAMES_IN_FLIGHT];
+
+extern cvar_t* cvar_ui_hdr_nits;
 
 VkExtent2D
 vkpt_draw_get_extent()
@@ -223,6 +234,10 @@ vkpt_draw_initialize()
 		_VK(buffer_create(buf_stretch_pic_queue + i, sizeof(StretchPic_t) * MAX_STRETCH_PICS, 
 			VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
 			VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT));
+
+		_VK(buffer_create(buf_ubo + i, sizeof(StretchPic_UBO_t),
+			VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
+			VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT));
 	}
 
 	VkDescriptorSetLayoutBinding layout_bindings[] = {
@@ -258,12 +273,52 @@ vkpt_draw_initialize()
 	_VK(vkCreateDescriptorPool(qvk.device, &pool_info, NULL, &desc_pool_sbo));
 	ATTACH_LABEL_VARIABLE(desc_pool_sbo, DESCRIPTOR_POOL);
 
+	VkDescriptorSetLayoutBinding layout_bindings_ubo[] = {
+		{
+			.descriptorType  = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+			.descriptorCount = 1,
+			.binding         = 2,
+			.stageFlags      = VK_SHADER_STAGE_FRAGMENT_BIT,
+		},
+	};
+
+	VkDescriptorSetLayoutCreateInfo layout_info_ubo = {
+		.sType        = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO,
+		.bindingCount = LENGTH(layout_bindings_ubo),
+		.pBindings    = layout_bindings_ubo,
+	};
+
+	_VK(vkCreateDescriptorSetLayout(qvk.device, &layout_info_ubo, NULL, &desc_set_layout_ubo));
+	ATTACH_LABEL_VARIABLE(desc_set_layout_ubo, DESCRIPTOR_SET_LAYOUT);
+
+	VkDescriptorPoolSize pool_size_ubo = {
+		.type            = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+		.descriptorCount = MAX_FRAMES_IN_FLIGHT,
+	};
+
+	VkDescriptorPoolCreateInfo pool_info_ubo = {
+		.sType         = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
+		.poolSizeCount = 1,
+		.pPoolSizes    = &pool_size_ubo,
+		.maxSets       = MAX_FRAMES_IN_FLIGHT,
+	};
+
+	_VK(vkCreateDescriptorPool(qvk.device, &pool_info_ubo, NULL, &desc_pool_ubo));
+	ATTACH_LABEL_VARIABLE(desc_pool_ubo, DESCRIPTOR_POOL);
+
 
 	VkDescriptorSetAllocateInfo descriptor_set_alloc_info = {
 		.sType              = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO,
 		.descriptorPool     = desc_pool_sbo,
 		.descriptorSetCount = 1,
 		.pSetLayouts        = &desc_set_layout_sbo,
+	};
+
+	VkDescriptorSetAllocateInfo descriptor_set_alloc_info_ubo = {
+		.sType              = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO,
+		.descriptorPool     = desc_pool_ubo,
+		.descriptorSetCount = 1,
+		.pSetLayouts        = &desc_set_layout_ubo,
 	};
 
 	for(int i = 0; i < MAX_FRAMES_IN_FLIGHT; i++) {
@@ -287,6 +342,27 @@ vkpt_draw_initialize()
 		};
 
 		vkUpdateDescriptorSets(qvk.device, 1, &output_buf_write, 0, NULL);
+
+		_VK(vkAllocateDescriptorSets(qvk.device, &descriptor_set_alloc_info_ubo, desc_set_ubo + i));
+		BufferResource_t *ubo = buf_ubo + i;
+
+		VkDescriptorBufferInfo buf_info_ubo = {
+			.buffer = ubo->buffer,
+			.offset = 0,
+			.range  = sizeof(StretchPic_UBO_t),
+		};
+
+		VkWriteDescriptorSet output_buf_write_ubo = {
+			.sType           = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
+			.dstSet          = desc_set_ubo[i],
+			.dstBinding      = 2,
+			.dstArrayElement = 0,
+			.descriptorType  = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+			.descriptorCount = 1,
+			.pBufferInfo     = &buf_info_ubo,
+		};
+
+		vkUpdateDescriptorSets(qvk.device, 1, &output_buf_write_ubo, 0, NULL);
 	}
 	return VK_SUCCESS;
 }
@@ -297,10 +373,13 @@ vkpt_draw_destroy()
 	LOG_FUNC();
 	for(int i = 0; i < MAX_FRAMES_IN_FLIGHT; i++) {
 		buffer_destroy(buf_stretch_pic_queue + i);
+		buffer_destroy(buf_ubo + i);
 	}
 	vkDestroyRenderPass(qvk.device, render_pass_stretch_pic, NULL);
 	vkDestroyDescriptorPool(qvk.device, desc_pool_sbo, NULL);
 	vkDestroyDescriptorSetLayout(qvk.device, desc_set_layout_sbo, NULL);
+	vkDestroyDescriptorPool(qvk.device, desc_pool_ubo, NULL);
+	vkDestroyDescriptorSetLayout(qvk.device, desc_set_layout_ubo, NULL);
 
 	return VK_SUCCESS;
 }
@@ -329,7 +408,7 @@ vkpt_draw_create_pipelines()
 
 	assert(desc_set_layout_sbo);
 	VkDescriptorSetLayout desc_set_layouts[] = {
-		desc_set_layout_sbo, qvk.desc_set_layout_textures
+		desc_set_layout_sbo, qvk.desc_set_layout_textures, desc_set_layout_ubo
 	};
 	CREATE_PIPELINE_LAYOUT(qvk.device, &pipeline_layout_stretch_pic, 
 		.setLayoutCount = LENGTH(desc_set_layouts),
@@ -343,9 +422,22 @@ vkpt_draw_create_pipelines()
 		.pSetLayouts = desc_set_layouts
 	);
 
+	VkSpecializationMapEntry specEntries[] = {
+		{ .constantID = 0, .offset = 0, .size = sizeof(uint32_t) }
+	};
+
+	// "HDR display" flag
+	uint32_t spec_data[] = {
+		0,
+		1,
+	};
+
+	VkSpecializationInfo specInfo_SDR = {.mapEntryCount = 1, .pMapEntries = specEntries, .dataSize = sizeof(uint32_t), .pData = &spec_data[0]};
+	VkSpecializationInfo specInfo_HDR = {.mapEntryCount = 1, .pMapEntries = specEntries, .dataSize = sizeof(uint32_t), .pData = &spec_data[1]};
+
 	VkPipelineShaderStageCreateInfo shader_info[] = {
 		SHADER_STAGE(QVK_MOD_STRETCH_PIC_VERT, VK_SHADER_STAGE_VERTEX_BIT),
-		SHADER_STAGE(QVK_MOD_STRETCH_PIC_FRAG, VK_SHADER_STAGE_FRAGMENT_BIT)
+		SHADER_STAGE_SPEC(QVK_MOD_STRETCH_PIC_FRAG, VK_SHADER_STAGE_FRAGMENT_BIT, qvk.surf_is_hdr ? &specInfo_HDR : &specInfo_SDR)
 	};
 
 	VkPipelineVertexInputStateCreateInfo vertex_input_info = {
@@ -510,6 +602,12 @@ vkpt_draw_submit_stretch_pics(VkCommandBuffer cmd_buf)
 	buffer_unmap(buf_spq);
 	spq_dev = NULL;
 
+	BufferResource_t *ubo_res = buf_ubo + qvk.current_frame_index;
+	StretchPic_UBO_t *ubo = (StretchPic_UBO_t *) buffer_map(ubo_res);
+	ubo->ui_hdr_nits = cvar_ui_hdr_nits->value;
+	buffer_unmap(ubo_res);
+	ubo = NULL;
+
 	VkRenderPassBeginInfo render_pass_info = {
 		.sType             = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO,
 		.renderPass        = render_pass_stretch_pic,
@@ -520,7 +618,8 @@ vkpt_draw_submit_stretch_pics(VkCommandBuffer cmd_buf)
 
 	VkDescriptorSet desc_sets[] = {
 		desc_set_sbo[qvk.current_frame_index],
-		qvk_get_current_desc_set_textures()
+		qvk_get_current_desc_set_textures(),
+		desc_set_ubo[qvk.current_frame_index],
 	};
 
 	vkCmdBeginRenderPass(cmd_buf, &render_pass_info, VK_SUBPASS_CONTENTS_INLINE);

--- a/src/refresh/vkpt/main.c
+++ b/src/refresh/vkpt/main.c
@@ -582,7 +582,7 @@ create_swapchain()
 		surface_format_found = pick_surface_format_hdr(&qvk.surf_format, avail_surface_formats, num_formats);
 		qvk.surf_is_hdr = surface_format_found;
 		if(!surface_format_found)
-			Com_WPrintf("HDR was requested but no supported surface format was found.");
+			Com_WPrintf("HDR was requested but no supported surface format was found.\n");
 	}
 	if(!surface_format_found) {
 		// HDR disabled, or fallback to SDR

--- a/src/refresh/vkpt/main.c
+++ b/src/refresh/vkpt/main.c
@@ -3225,7 +3225,7 @@ R_BeginFrame_RTX(void)
 	
 	VkExtent2D extent_screen_images = get_screen_image_extent();
 
-	if(!extents_equal(extent_screen_images, qvk.extent_screen_images))
+	if(!extents_equal(extent_screen_images, qvk.extent_screen_images) || (!!cvar_hdr->value != qvk.surf_is_hdr))
 	{
 		qvk.extent_screen_images = extent_screen_images;
 		recreate_swapchain();
@@ -3477,7 +3477,7 @@ R_Init_RTX(qboolean total)
 	cvar_profiler_scale = Cvar_Get("profiler_scale", "1", CVAR_ARCHIVE);
 	cvar_vsync = Cvar_Get("vid_vsync", "0", CVAR_REFRESH | CVAR_ARCHIVE);
 	cvar_vsync->changed = NULL; // in case the GL renderer has set it
-	cvar_hdr = Cvar_Get("vid_hdr", "0", CVAR_REFRESH | CVAR_ARCHIVE);
+	cvar_hdr = Cvar_Get("vid_hdr", "0", CVAR_ARCHIVE);
 	cvar_pt_caustics = Cvar_Get("pt_caustics", "1", CVAR_ARCHIVE);
 	cvar_pt_enable_nodraw = Cvar_Get("pt_enable_nodraw", "0", 0);
 	/* Synthesize materials for surfaces with LIGHT flag.

--- a/src/refresh/vkpt/main.c
+++ b/src/refresh/vkpt/main.c
@@ -581,8 +581,10 @@ create_swapchain()
 	if(cvar_hdr->integer != 0) {
 		surface_format_found = pick_surface_format_hdr(&qvk.surf_format, avail_surface_formats, num_formats);
 		qvk.surf_is_hdr = surface_format_found;
-		if(!surface_format_found)
+		if(!surface_format_found) {
 			Com_WPrintf("HDR was requested but no supported surface format was found.\n");
+			Cvar_SetByVar(cvar_hdr, "0", FROM_CODE);
+		}
 	}
 	if(!surface_format_found) {
 		// HDR disabled, or fallback to SDR

--- a/src/refresh/vkpt/main.c
+++ b/src/refresh/vkpt/main.c
@@ -517,6 +517,21 @@ qvkDestroyDebugUtilsMessengerEXT(
 	return VK_ERROR_EXTENSION_NOT_PRESENT;
 }
 
+static qboolean pick_surface_format(VkSurfaceFormatKHR* format,
+									const VkFormat acceptable_formats[], size_t num_acceptable_formats,
+									const VkSurfaceFormatKHR avail_surface_formats[], size_t num_avail_surface_formats)
+{
+	for(int i = 0; i < num_acceptable_formats; i++) {
+		for(int j = 0; j < num_avail_surface_formats; j++) {
+			if(acceptable_formats[i] == avail_surface_formats[j].format) {
+				*format = avail_surface_formats[j];
+				return qtrue;
+			}
+		}
+	}
+	return qfalse;
+}
+
 VkResult
 create_swapchain()
 {
@@ -546,14 +561,10 @@ create_swapchain()
 
 	//qvk.surf_format.format     = VK_FORMAT_R8G8B8A8_SRGB;
 	//qvk.surf_format.format     = VK_FORMAT_B8G8R8A8_SRGB;
-	for(int i = 0; i < LENGTH(acceptable_formats); i++) {
-		for(int j = 0; j < num_formats; j++)
-			if(acceptable_formats[i] == avail_surface_formats[j].format) {
-				qvk.surf_format = avail_surface_formats[j];
-				goto out;
-			}
+	if(!pick_surface_format(&qvk.surf_format, acceptable_formats, LENGTH(acceptable_formats), avail_surface_formats, num_formats)) {
+		Com_EPrintf("no acceptable surface format available!\n");
+		return 1;
 	}
-out:;
 
 	uint32_t num_present_modes = 0;
 	vkGetPhysicalDeviceSurfacePresentModesKHR(qvk.physical_device, qvk.surface, &num_present_modes, NULL);

--- a/src/refresh/vkpt/main.c
+++ b/src/refresh/vkpt/main.c
@@ -585,6 +585,8 @@ create_swapchain()
 			Com_WPrintf("HDR was requested but no supported surface format was found.\n");
 			Cvar_SetByVar(cvar_hdr, "0", FROM_CODE);
 		}
+	} else {
+		qvk.surf_is_hdr = qfalse;
 	}
 	if(!surface_format_found) {
 		// HDR disabled, or fallback to SDR

--- a/src/refresh/vkpt/shader/fsr_easu_fp16.comp
+++ b/src/refresh/vkpt/shader/fsr_easu_fp16.comp
@@ -32,6 +32,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define FsrEasuR    FsrEasuRH
 #define FsrEasuG    FsrEasuGH
 #define FsrEasuB    FsrEasuBH
+#define FsrSrtm     FsrSrtmH
+#define FsrSrtmInv  FsrSrtmInvH
 
 // Actual implementation
 #include "fsr_easu.glsl"

--- a/src/refresh/vkpt/shader/fsr_easu_fp32.comp
+++ b/src/refresh/vkpt/shader/fsr_easu_fp32.comp
@@ -31,6 +31,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define FsrEasuR    FsrEasuRF
 #define FsrEasuG    FsrEasuGF
 #define FsrEasuB    FsrEasuBF
+#define FsrSrtm     FsrSrtmF
+#define FsrSrtmInv  FsrSrtmInvF
 
 // Actual implementation
 #include "fsr_easu.glsl"

--- a/src/refresh/vkpt/shader/fsr_rcas_fp16.comp
+++ b/src/refresh/vkpt/shader/fsr_rcas_fp16.comp
@@ -33,6 +33,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define FsrRcasLoad     FsrRcasLoadH
 #define load_coord      ASW2
 #define FsrRcasInput    FsrRcasInputH
+#define FsrSrtm         FsrSrtmH
+#define FsrSrtmInv      FsrSrtmInvH
 
 // Actual implementation
 #include "fsr_rcas.glsl"

--- a/src/refresh/vkpt/shader/fsr_utils.glsl
+++ b/src/refresh/vkpt/shader/fsr_utils.glsl
@@ -17,23 +17,20 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#version 450
-#extension GL_GOOGLE_include_directive    : enable
-#extension GL_ARB_separate_shader_objects : enable
-#extension GL_EXT_nonuniform_qualifier    : enable
+// Assumes spec_hdr constant is defined and that we're included after ffx_fsr1.h
 
-#define FSR_RCAS_F 1
+// Transform (potentially) HDR input for FSR
+fsr_vec3 hdr_input(fsr_vec3 color)
+{
+    if (spec_hdr != 0)
+        FsrSrtm(color);
+    return color;
+}
 
-// Macros for FP16/FP32 abstraction
-#define fsr_val         AF1
-#define fsr_vec3        AF3
-#define fsr_vec4        AF4
-#define FsrRcas         FsrRcasF
-#define FsrRcasLoad     FsrRcasLoadF
-#define load_coord      ASU2
-#define FsrRcasInput    FsrRcasInputF
-#define FsrSrtm         FsrSrtmF
-#define FsrSrtmInv      FsrSrtmInvF
-
-// Actual implementation
-#include "fsr_rcas.glsl"
+// Transform FSR output to (potentially) HDR
+fsr_vec3 hdr_output(fsr_vec3 color)
+{
+    if (spec_hdr != 0)
+        FsrSrtmInv(color);
+    return color;
+}

--- a/src/refresh/vkpt/shader/global_ubo.h
+++ b/src/refresh/vkpt/shader/global_ubo.h
@@ -119,6 +119,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	UBO_CVAR_DO(tm_reinhard, 0.5) /* blend factor between adaptive curve tonemapper (0) and Reinhard curve (1) */ \
 	UBO_CVAR_DO(tm_slope_blur_sigma, 12.0) /* sigma for Gaussian blur of tone curve slopes, (0..inf) */ \
 	UBO_CVAR_DO(tm_white_point, 10.0) /* how bright colors can be before they become white, (0..inf) */ \
+	UBO_CVAR_DO(tm_hdr_peak_nits, 800.0) /* Exposure value 0 is mapped to this display brightness (post tonemapping) */ \
 
     
 #define GLOBAL_UBO_VAR_LIST \

--- a/src/refresh/vkpt/shader/global_ubo.h
+++ b/src/refresh/vkpt/shader/global_ubo.h
@@ -120,6 +120,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	UBO_CVAR_DO(tm_slope_blur_sigma, 12.0) /* sigma for Gaussian blur of tone curve slopes, (0..inf) */ \
 	UBO_CVAR_DO(tm_white_point, 10.0) /* how bright colors can be before they become white, (0..inf) */ \
 	UBO_CVAR_DO(tm_hdr_peak_nits, 800.0) /* Exposure value 0 is mapped to this display brightness (post tonemapping) */ \
+	UBO_CVAR_DO(tm_hdr_saturation_scale, 100) /* HDR mode saturation adjustment, percentage [0..200], with 0% -> desaturated, 100% -> normal, 200% -> oversaturated */ \
 	UBO_CVAR_DO(ui_hdr_nits, 300) /* HDR mode UI (stretch pic) brightness in nits */ \
 
     

--- a/src/refresh/vkpt/shader/global_ubo.h
+++ b/src/refresh/vkpt/shader/global_ubo.h
@@ -201,7 +201,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	\
 	GLOBAL_UBO_VAR_LIST_DO(vec2,            sub_pixel_jitter) \
 	GLOBAL_UBO_VAR_LIST_DO(float,           prev_adapted_luminance) \
-	GLOBAL_UBO_VAR_LIST_DO(float,           padding1) \
+	GLOBAL_UBO_VAR_LIST_DO(float,           tonemap_hdr_clamp_strength) \
 	GLOBAL_UBO_VAR_LIST_DO(vec4,            fs_blend_color) \
 	\
 	GLOBAL_UBO_VAR_LIST_DO(vec4,            world_center) \

--- a/src/refresh/vkpt/shader/global_ubo.h
+++ b/src/refresh/vkpt/shader/global_ubo.h
@@ -120,6 +120,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	UBO_CVAR_DO(tm_slope_blur_sigma, 12.0) /* sigma for Gaussian blur of tone curve slopes, (0..inf) */ \
 	UBO_CVAR_DO(tm_white_point, 10.0) /* how bright colors can be before they become white, (0..inf) */ \
 	UBO_CVAR_DO(tm_hdr_peak_nits, 800.0) /* Exposure value 0 is mapped to this display brightness (post tonemapping) */ \
+	UBO_CVAR_DO(ui_hdr_nits, 300) /* HDR mode UI (stretch pic) brightness in nits */ \
 
     
 #define GLOBAL_UBO_VAR_LIST \

--- a/src/refresh/vkpt/shader/stretch_pic.frag
+++ b/src/refresh/vkpt/shader/stretch_pic.frag
@@ -30,8 +30,11 @@ layout(constant_id = 0) const uint spec_tone_mapping_hdr = 0;
 #define GLOBAL_TEXTURES_DESC_SET_IDX 1
 #include "global_textures.h"
 
+#include "utils.glsl"
+
 layout(set = 2, binding = 2, std140) uniform UBO {
 	float ui_hdr_nits;
+	float tm_hdr_saturation_scale;
 };
 
 layout(location = 0) in vec4 color;
@@ -50,6 +53,7 @@ main()
 	}
 	if(spec_tone_mapping_hdr != 0) {
 		c.rgb *= ui_hdr_nits / 80;
+		c.rgb = apply_saturation_scale(c.rgb, tm_hdr_saturation_scale * 0.01);
 	}
 	outColor = c;
 }

--- a/src/refresh/vkpt/shader/stretch_pic.frag
+++ b/src/refresh/vkpt/shader/stretch_pic.frag
@@ -25,8 +25,14 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #extension GL_ARB_separate_shader_objects : enable
 #extension GL_EXT_nonuniform_qualifier    : enable
 
+layout(constant_id = 0) const uint spec_tone_mapping_hdr = 0;
+
 #define GLOBAL_TEXTURES_DESC_SET_IDX 1
 #include "global_textures.h"
+
+layout(set = 2, binding = 2, std140) uniform UBO {
+	float ui_hdr_nits;
+};
 
 layout(location = 0) in vec4 color;
 layout(location = 1) in flat uint tex_id;
@@ -41,6 +47,9 @@ main()
 	if(tex_id != ~0u) {
 		vec2 tc = tex_coord;
 		c *= global_textureLod(tex_id, tc, 0);
+	}
+	if(spec_tone_mapping_hdr != 0) {
+		c.rgb *= ui_hdr_nits / 80;
 	}
 	outColor = c;
 }

--- a/src/refresh/vkpt/shader/tone_mapping_apply.comp
+++ b/src/refresh/vkpt/shader/tone_mapping_apply.comp
@@ -200,8 +200,10 @@ void main()
     else
     {
         // HDR: map colors such that values at EV 0 map to a display brightness of 'tm_hdr_peak_nits'
-        const float nits_factor = (global_ubo.tm_hdr_peak_nits / 80); // an scRGB luminance of 1.0 is defined as 80 nits
-        mapped_color *= nits_factor;
+        const float nits_factor = global_ubo.tm_hdr_peak_nits / 80; // an scRGB luminance of 1.0 is defined as 80 nits
+        const float nits_factor_ui = global_ubo.ui_hdr_nits / 80;
+        float color_scale = mix(nits_factor, min(nits_factor, nits_factor_ui), global_ubo.tonemap_hdr_clamp_strength); // clamps color in menu mode, ensures it's legible
+        mapped_color *= color_scale;
     }
 
     // Show tonemapping curve if enabled:

--- a/src/refresh/vkpt/shader/tone_mapping_apply.comp
+++ b/src/refresh/vkpt/shader/tone_mapping_apply.comp
@@ -35,6 +35,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #extension GL_GOOGLE_include_directive    : enable
 #extension GL_EXT_nonuniform_qualifier    : enable
 
+layout(constant_id = 0) const uint spec_tone_mapping_hdr = 0;
+
 #include "utils.glsl"
 
 #define GLOBAL_UBO_DESC_SET_IDX 0
@@ -164,29 +166,43 @@ void main()
 
     vec3 mapped_color = input_color * out_luminance / lum;
 
-    // Finally, since our mapped color has luminance in [0,1], but could have
-    // components greater than 1, we apply a customizable knee to bring all values
-    // fully into range.
-    const vec3 step_value = step(global_ubo.tm_knee_start, mapped_color);
-    mapped_color = mix(mapped_color, (push.knee_w*mapped_color + push.knee_a)/max(vec3(1e-6), mapped_color + push.knee_b), step_value);
+    if(spec_tone_mapping_hdr == 0)
+    {
+        // Finally, since our mapped color has luminance in [0,1], but could have
+        // components greater than 1, we apply a customizable knee to bring all values
+        // fully into range.
+        const vec3 step_value = step(global_ubo.tm_knee_start, mapped_color);
+        mapped_color = mix(mapped_color, (push.knee_w*mapped_color + push.knee_a)/max(vec3(1e-6), mapped_color + push.knee_b), step_value);
+    }
 
     // Original autoexposure tonemapping application code
     // Exposure adjustment followed by Reinhard tonemapper
     const float adapted_luminance = tonemap_buffer.adapted_luminance;
     const float scaled_luminance = exp2(global_ubo.tm_exposure_bias - 2) * lum / adapted_luminance;
+    // HDR: Adjust white point upward for large brightness
+    const float white_point = (spec_tone_mapping_hdr != 0) ? max(global_ubo.tm_white_point, global_ubo.tm_hdr_peak_nits / 80) : global_ubo.tm_white_point;
     // The autoexposure tonemap has its own Reinhard tonemapper that gets applied to luminance only:
-    const float white_point_squared = global_ubo.tm_white_point * global_ubo.tm_white_point;
+    const float white_point_squared = white_point * white_point;
     const float mapped_luminance = (scaled_luminance * (1 + scaled_luminance / white_point_squared)) / (1 + scaled_luminance);
     const vec3 ae_mapped_color = input_color * mapped_luminance / lum;
 
     // Finally, allow for some amount of blending with the original frame:
     mapped_color = mix(mapped_color, ae_mapped_color, global_ubo.tm_reinhard);
 
-    // Clip to [0,1]:
-    mapped_color = clamp(mapped_color, vec3(0), vec3(1));
+    if(spec_tone_mapping_hdr == 0)
+    {
+        // Clip to [0,1]:
+        mapped_color = clamp(mapped_color, vec3(0), vec3(1));
 
-    // Apply dither:
-    mapped_color = srgb_dither(mapped_color, ipos);
+        // Apply dither:
+        mapped_color = srgb_dither(mapped_color, ipos);
+    }
+    else
+    {
+        // HDR: map colors such that values at EV 0 map to a display brightness of 'tm_hdr_peak_nits'
+        const float nits_factor = (global_ubo.tm_hdr_peak_nits / 80); // an scRGB luminance of 1.0 is defined as 80 nits
+        mapped_color *= nits_factor;
+    }
 
     // Show tonemapping curve if enabled:
     if(global_ubo.tm_debug != 0)

--- a/src/refresh/vkpt/shader/tone_mapping_apply.comp
+++ b/src/refresh/vkpt/shader/tone_mapping_apply.comp
@@ -204,6 +204,8 @@ void main()
         const float nits_factor_ui = global_ubo.ui_hdr_nits / 80;
         float color_scale = mix(nits_factor, min(nits_factor, nits_factor_ui), global_ubo.tonemap_hdr_clamp_strength); // clamps color in menu mode, ensures it's legible
         mapped_color *= color_scale;
+
+        mapped_color.rgb = apply_saturation_scale(mapped_color.rgb, global_ubo.tm_hdr_saturation_scale * 0.01);
     }
 
     // Show tonemapping curve if enabled:

--- a/src/refresh/vkpt/shader/tone_mapping_apply.comp
+++ b/src/refresh/vkpt/shader/tone_mapping_apply.comp
@@ -209,7 +209,11 @@ void main()
     // Show tonemapping curve if enabled:
     if(global_ubo.tm_debug != 0)
     {
-        const vec4 bar_chart_overlay = show_bar_chart(ipos, global_ubo.tm_debug == 2);
+        vec4 bar_chart_overlay = show_bar_chart(ipos, global_ubo.tm_debug == 2);
+        if(spec_tone_mapping_hdr != 0)
+        {
+            bar_chart_overlay *= vec4(vec3(global_ubo.ui_hdr_nits / 80), 1);
+        }
         mapped_color = mix(mapped_color.rgb, bar_chart_overlay.rgb, bar_chart_overlay.a);
     }
 

--- a/src/refresh/vkpt/shader/utils.glsl
+++ b/src/refresh/vkpt/shader/utils.glsl
@@ -224,6 +224,16 @@ vec4 alpha_blend_premultiplied(vec4 top, vec4 bottom)
     return vec4(top.rgb + bottom.rgb * (1 - top.a), 1 - (1 - top.a) * (1 - bottom.a)); 
 }
 
+/* Adjust saturation by changing amplifying or muting difference to gray value.
+ * Preserves luminance. */
+vec3 apply_saturation_scale(in vec3 color, in float saturation_scale)
+{
+    float lum = luminance(color);
+    vec3 base_gray = vec3(lum);
+    vec3 d = color - base_gray;
+    return max(base_gray + d * saturation_scale, vec3(0));
+}
+
 mat3
 construct_ONB_frisvad(vec3 normal)
 {

--- a/src/refresh/vkpt/tone_mapping.c
+++ b/src/refresh/vkpt/tone_mapping.c
@@ -62,7 +62,8 @@ extern cvar_t *cvar_profiler_scale;
 enum {
 	TONE_MAPPING_HISTOGRAM,
 	TONE_MAPPING_CURVE,
-	TONE_MAPPING_APPLY,
+	TONE_MAPPING_APPLY_SDR,
+	TONE_MAPPING_APPLY_HDR,
 	TM_NUM_PIPELINES
 };
 
@@ -146,6 +147,19 @@ vkpt_tone_mapping_request_reset()
 VkResult
 vkpt_tone_mapping_create_pipelines()
 {
+	VkSpecializationMapEntry specEntries[] = {
+		{ .constantID = 0, .offset = 0, .size = sizeof(uint32_t) }
+	};
+
+	// "HDR tone mapping" flag
+	uint32_t spec_data[] = {
+		0,
+		1,
+	};
+
+	VkSpecializationInfo specInfo_SDR = {.mapEntryCount = 1, .pMapEntries = specEntries, .dataSize = sizeof(uint32_t), .pData = &spec_data[0]};
+	VkSpecializationInfo specInfo_HDR = {.mapEntryCount = 1, .pMapEntries = specEntries, .dataSize = sizeof(uint32_t), .pData = &spec_data[1]};
+
 	VkComputePipelineCreateInfo pipeline_info[TM_NUM_PIPELINES] = {
 		[TONE_MAPPING_HISTOGRAM] = {
 			.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO,
@@ -157,9 +171,14 @@ vkpt_tone_mapping_create_pipelines()
 			.stage = SHADER_STAGE(QVK_MOD_TONE_MAPPING_CURVE_COMP, VK_SHADER_STAGE_COMPUTE_BIT),
 			.layout = pipeline_layout_tone_mapping_curve,
 		},
-		[TONE_MAPPING_APPLY] = {
+		[TONE_MAPPING_APPLY_SDR] = {
 			.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO,
-			.stage = SHADER_STAGE(QVK_MOD_TONE_MAPPING_APPLY_COMP, VK_SHADER_STAGE_COMPUTE_BIT),
+			.stage = SHADER_STAGE_SPEC(QVK_MOD_TONE_MAPPING_APPLY_COMP, VK_SHADER_STAGE_COMPUTE_BIT, &specInfo_SDR),
+			.layout = pipeline_layout_tone_mapping_apply,
+		},
+		[TONE_MAPPING_APPLY_HDR] = {
+			.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO,
+			.stage = SHADER_STAGE_SPEC(QVK_MOD_TONE_MAPPING_APPLY_COMP, VK_SHADER_STAGE_COMPUTE_BIT, &specInfo_HDR),
 			.layout = pipeline_layout_tone_mapping_apply,
 		},
 	};
@@ -336,7 +355,7 @@ vkpt_tone_mapping_record_cmd_buffer(VkCommandBuffer cmd_buf, float frame_time)
 	// Record instructions to apply our tone curve to the final image, apply
 	// the autoexposure tone mapper to the final image, and blend the results
 	// of the two techniques.
-	vkCmdBindPipeline(cmd_buf, VK_PIPELINE_BIND_POINT_COMPUTE, pipelines[TONE_MAPPING_APPLY]);
+	vkCmdBindPipeline(cmd_buf, VK_PIPELINE_BIND_POINT_COMPUTE, pipelines[qvk.surf_is_hdr ? TONE_MAPPING_APPLY_HDR : TONE_MAPPING_APPLY_SDR]);
 	vkCmdBindDescriptorSets(cmd_buf, VK_PIPELINE_BIND_POINT_COMPUTE,
 		pipeline_layout_tone_mapping_apply, 0, LENGTH(desc_sets), desc_sets, 0, 0);
 

--- a/src/refresh/vkpt/vkpt.h
+++ b/src/refresh/vkpt/vkpt.h
@@ -182,6 +182,7 @@ typedef struct QVK_s {
 	VkSurfaceKHR                surface;
 	VkSwapchainKHR              swap_chain;
 	VkSurfaceFormatKHR          surf_format;
+	qboolean                    surf_is_hdr;
 	VkPresentModeKHR            present_mode;
 	VkExtent2D                  extent_screen_images;
 	VkExtent2D                  extent_render;

--- a/src/refresh/vkpt/vkpt.h
+++ b/src/refresh/vkpt/vkpt.h
@@ -231,6 +231,7 @@ typedef struct QVK_s {
 	// when set, we'll do a WFI before acquire for this many frames
 	uint32_t                    wait_for_idle_frames;
 	float                       timestampPeriod;
+	qboolean                    frame_menu_mode;
 
 	VkShaderModule              shader_modules[NUM_QVK_SHADER_MODULES];
 

--- a/src/refresh/vkpt/vkpt.h
+++ b/src/refresh/vkpt/vkpt.h
@@ -810,6 +810,7 @@ qboolean R_InterceptKey_RTX(unsigned key, qboolean down);
 void IMG_Load_RTX(image_t *image, byte *pic);
 void IMG_Unload_RTX(image_t *image);
 byte *IMG_ReadPixels_RTX(int *width, int *height, int *rowbytes);
+float *IMG_ReadPixelsHDR_RTX(int *width, int *height);
 
 qerror_t MOD_LoadMD2_RTX(model_t *model, const void *rawdata, size_t length, const char* mod_name);
 qerror_t MOD_LoadMD3_RTX(model_t* model, const void* rawdata, size_t length, const char* mod_name);


### PR DESCRIPTION
This builds upon the basic approach outlined by #83 ("pick float16 surface format") and updates various systems for HDR.

Tonemapping: This tweaks the current algorithm to disable the "knee" for bringing things into range and clamping/sRGB conversion. Extending the brightness range is done by applying a (user-configurable) scale after tonemapping; seems to work and look well enough.

Screenshots: They can be written in the Radiance `.hdr` format. The main motivation for using this was simplicity: STB comes with an HDR writer. Viewers are available online (eg https://viewer.openhdr.org/) and standalone (eg https://github.com/wkjarosz/hdrview).

Other tweaks include:
* Adjustments to FSR shaders to handle HDR values
* User-configurable UI brightness