### PR TITLE
Add an 'rtx' variant of basedir 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ save
 */docs
 baseq2/**/*.txt
 !baseq2/*.txt
+filesystem.cfg

--- a/filesystem.cfg.example
+++ b/filesystem.cfg.example
@@ -1,0 +1,4 @@
+// Grab game data from GOG install
+set basedir "C:\Program Files (x86)\GOG Galaxy\Games\Quake II"
+// Look for RTX media next to executable
+set basedir_rtx "."

--- a/inc/shared/platform.h
+++ b/inc/shared/platform.h
@@ -68,6 +68,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define os_fstat(f, s)      _fstat(f, s)
 #define os_fileno(f)        _fileno(f)
 #define os_access(p, m)     _access(p, m)
+#define os_chdir(p)         _chdir(p)
 #define Q_ISREG(m)          (((m) & _S_IFMT) == _S_IFREG)
 #define Q_ISDIR(m)          (((m) & _S_IFMT) == _S_IFDIR)
 #define Q_STATBUF           struct _stat
@@ -78,6 +79,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define os_fstat(f, s)      fstat(f, s)
 #define os_fileno(f)        fileno(f)
 #define os_access(p, m)     access(p, m)
+#define os_chdir(p)         chdir(p)
 #define Q_ISREG(m)          S_ISREG(m)
 #define Q_ISDIR(m)          S_ISDIR(m)
 #define Q_STATBUF           struct stat

--- a/inc/system/system.h
+++ b/inc/system/system.h
@@ -31,6 +31,7 @@ void    Sys_Sleep(int msec);
 qboolean Sys_IsDir(const char *path);
 qboolean Sys_IsFile(const char *path);
 
+void    Sys_GetDefaultBaseDir(char *path, size_t path_size);
 void    Sys_Init(void);
 void    Sys_AddDefaultConfig(void);
 

--- a/inc/system/system.h
+++ b/inc/system/system.h
@@ -62,6 +62,7 @@ qboolean Sys_GetAntiCheatAPI(void);
 #endif
 
 extern cvar_t   *sys_basedir;
+extern cvar_t   *sys_basedir_rtx;
 extern cvar_t   *sys_libdir;
 extern cvar_t   *sys_homedir;
 extern cvar_t   *sys_forcegamelib;

--- a/src/client/sound/ogg.c
+++ b/src/client/sound/ogg.c
@@ -131,6 +131,8 @@ OGG_InitTrackList(void)
 
 	ogg_maxfileindex = 0;
 
+	const char *potMusicRoots[] = {fs_gamedir, sys_basedir->string};
+
 	const char* potMusicDirs[3] = {0};
 	char gameMusicDir[MAX_QPATH] = {0}; // e.g. "xatrix/music"
 	cvar_t* gameCvar = Cvar_Get("game", "", CVAR_LATCH | CVAR_SERVERINFO);
@@ -160,12 +162,17 @@ OGG_InitTrackList(void)
 		}
 
 		char fullMusicPath[MAX_OSPATH] = {0};
-		Q_snprintf(fullMusicPath, MAX_OSPATH, "%s/%s", fs_gamedir, musicDir);
+		qboolean found_music = qfalse;
 
-		if(!Sys_IsDir(fullMusicPath))
+		for (int potMusicRootIdx = 0; potMusicRootIdx < q_countof(potMusicRoots); ++potMusicRootIdx)
 		{
-			continue;
+			Q_snprintf(fullMusicPath, MAX_OSPATH, "%s/%s", potMusicRoots[potMusicRootIdx], musicDir);
+			found_music = Sys_IsDir(fullMusicPath);
+			if(found_music)
+				break;
 		}
+		if(!found_music)
+			continue;
 
 		char testFileName[MAX_OSPATH];
 		char testFileName2[MAX_OSPATH];

--- a/src/unix/system.c
+++ b/src/unix/system.c
@@ -204,6 +204,22 @@ Sys_IsFile(const char *path)
 	return qfalse;
 }
 
+void Sys_GetDefaultBaseDir(char *path, size_t path_size)
+{
+    // Check for a full-install before searching local dirs
+    Q_snprintf(path, path_size, "%s", "/usr/share/quake2rtx");
+    dir_hnd = opendir(path);
+    if (dir_hnd) {
+        closedir(dir_hnd);
+    } else {
+        getcwd(path, path_size);
+    }
+
+    if (!*path) {
+        Sys_Error("Game basedir not found!\n");
+    }
+}
+
 /*
 =================
 Sys_Init
@@ -222,18 +238,8 @@ void Sys_Init(void)
     signal(SIGTTOU, SIG_IGN);
     signal(SIGUSR1, hup_handler);
 
-    // Check for a full-install before searching local dirs
-    sprintf(baseDirectory, "%s", "/usr/share/quake2rtx");
-    dir_hnd = opendir(baseDirectory);
-    if (dir_hnd) {
-        closedir(dir_hnd);
-    } else {
-        getcwd(baseDirectory, PATH_MAX);
-    }
+    Sys_GetDefaultBaseDir(baseDirectory, PATH_MAX);
 
-    if (!baseDirectory[0]) {
-	Sys_Error("Game basedir not found!\n");
-    }
     // basedir <path>
     // allows the game to run from outside the data tree
     sys_basedir = Cvar_Get("basedir", baseDirectory, CVAR_NOSET);

--- a/src/unix/system.c
+++ b/src/unix/system.c
@@ -208,7 +208,7 @@ void Sys_GetDefaultBaseDir(char *path, size_t path_size)
 {
     // Check for a full-install before searching local dirs
     Q_snprintf(path, path_size, "%s", "/usr/share/quake2rtx");
-    dir_hnd = opendir(path);
+    DIR *dir_hnd = opendir(path);
     if (dir_hnd) {
         closedir(dir_hnd);
     } else {
@@ -230,7 +230,6 @@ void Sys_Init(void)
     char    *homedir;
     char     homegamedir[PATH_MAX];
     cvar_t  *sys_parachute;
-    DIR     *dir_hnd;
 
     signal(SIGTERM, term_handler);
     signal(SIGINT, term_handler);

--- a/src/windows/system.c
+++ b/src/windows/system.c
@@ -687,6 +687,11 @@ Sys_IsFile(const char *path)
 	return (fileAttributes & (FILE_ATTRIBUTE_DIRECTORY | FILE_ATTRIBUTE_DEVICE)) == 0;
 }
 
+void Sys_GetDefaultBaseDir(char *path, size_t path_size)
+{
+    Q_strlcpy(path, currentDirectory, path_size);
+}
+
 /*
 ================
 Sys_Init


### PR DESCRIPTION
In the recent LFS poll, there was mentioning of "Game can be built and ran just by cloning the repo, building it and pointing to the original *.pak files." Incidentally, I had laying something around for the "pointing to *.pak files" part...

Currently, the engine knows a "base directory" (cvar `basedir`), with game directories below, which contain files and the game library. This change would add the notion for a "RTX base dir", which can contain additional game directories, itself with data files and (possibly) game libraries.

From the 6074743 message:

> Game library loading was adjusted to check both libdir
> (by default location of Q2RTX executable) and basedir (possibly
> set by user), in that order.
> 
> If basedir_rtx is not set, everything behaves as before.
> 
> basedir_rtx can be set to the special value ".", which means
> "directory of executable".

You can see how this would be used in practice by in ` filesystem.cfg.example`.