### PR TITLE
Check for negative cluster number in compute_sky_visibility()

### DIFF
--- a/src/refresh/vkpt/bsp_mesh.c
+++ b/src/refresh/vkpt/bsp_mesh.c
@@ -1598,6 +1598,7 @@ compute_sky_visibility(bsp_mesh_t *wm, bsp_t *bsp)
 		int prim = wm->world_sky_offset / 3 + i;
 
 		int cluster = wm->clusters[prim];
+		if (cluster < 0) continue;
 		if ((cluster >> 3) < VIS_MAX_BYTES)
 			clusters_with_sky[cluster >> 3] |= (1 << (cluster & 7));
 	}


### PR DESCRIPTION
Fixes #163.

`cluster == -1` seems to be a legitimate case as that value is set in `bsp_mesh.c:719`.
I didn't dig deeper into the circumstances under which that happens (though it may be worthwhile, if only for documentation/commenting purposes).
But, as can be seen from the code, that value causes an out-of-bounds array access.

Curiously, this access would happen on Windows as well, not just Linux; I guess it's only manifesting as a crash there due to compiler differences (codegen, or perhaps data alignment/arrangement) or ABI differences.