### PR TITLE
separate out nearest filtering for UI, default it on

### DIFF
--- a/src/refresh/vkpt/main.c
+++ b/src/refresh/vkpt/main.c
@@ -68,7 +68,8 @@ cvar_t *cvar_pt_projection = NULL;
 cvar_t *cvar_pt_dof = NULL;
 cvar_t* cvar_pt_freecam = NULL;
 cvar_t *cvar_pt_nearest = NULL;
-cvar_t *cvar_pt_nearest_2d = NULL;
+cvar_t *cvar_pt_bilerp_chars = NULL;
+cvar_t *cvar_pt_bilerp_pics = NULL;
 cvar_t *cvar_drs_enable = NULL;
 cvar_t *cvar_drs_target = NULL;
 cvar_t *cvar_drs_minscale = NULL;
@@ -3576,11 +3577,12 @@ R_Init_RTX(bool total)
 	cvar_pt_nearest = Cvar_Get("pt_nearest", "0", CVAR_ARCHIVE);
 	cvar_pt_nearest->changed = pt_nearest_changed;
 
-	// texture filtering mode for UI elements:
-	// 0 -> linear magnification
-	// 1 -> nearest magnification
-	cvar_pt_nearest_2d = Cvar_Get("pt_nearest_2d", "1", CVAR_ARCHIVE);
-	cvar_pt_nearest_2d->changed = pt_nearest_changed;
+	// texture filtering mode for UI elements, follows
+	// the gl_bilerp_ cvars, except for `cvar_pt_bilerp_pics` which
+	// is only on/off, since vk has no scrap
+	cvar_pt_bilerp_chars = Cvar_Get("pt_bilerp_chars", "0", CVAR_ARCHIVE);
+	cvar_pt_bilerp_pics = Cvar_Get("pt_bilerp_pics", "0", CVAR_ARCHIVE);
+	cvar_pt_bilerp_chars->changed = cvar_pt_bilerp_pics->changed = pt_nearest_changed;
 
 #ifdef VKPT_DEVICE_GROUPS
 	cvar_sli = Cvar_Get("sli", "1", CVAR_REFRESH | CVAR_ARCHIVE);

--- a/src/refresh/vkpt/main.c
+++ b/src/refresh/vkpt/main.c
@@ -68,6 +68,7 @@ cvar_t *cvar_pt_projection = NULL;
 cvar_t *cvar_pt_dof = NULL;
 cvar_t* cvar_pt_freecam = NULL;
 cvar_t *cvar_pt_nearest = NULL;
+cvar_t *cvar_pt_nearest_2d = NULL;
 cvar_t *cvar_drs_enable = NULL;
 cvar_t *cvar_drs_target = NULL;
 cvar_t *cvar_drs_minscale = NULL;
@@ -3568,12 +3569,18 @@ R_Init_RTX(bool total)
 	// freecam mode toggle
 	cvar_pt_freecam = Cvar_Get("pt_freecam", "1", CVAR_ARCHIVE);
 
-	// texture filtering mode:
+	// texture filtering mode for non-UI elements:
 	// 0 -> linear magnification, anisotropic minification
 	// 1 -> nearest magnification, anisotropic minification
 	// 2 -> nearest magnification and minification, no mipmaps (noisy)
 	cvar_pt_nearest = Cvar_Get("pt_nearest", "0", CVAR_ARCHIVE);
 	cvar_pt_nearest->changed = pt_nearest_changed;
+
+	// texture filtering mode for UI elements:
+	// 0 -> linear magnification
+	// 1 -> nearest magnification
+	cvar_pt_nearest_2d = Cvar_Get("pt_nearest_2d", "1", CVAR_ARCHIVE);
+	cvar_pt_nearest_2d->changed = pt_nearest_changed;
 
 #ifdef VKPT_DEVICE_GROUPS
 	cvar_sli = Cvar_Get("sli", "1", CVAR_REFRESH | CVAR_ARCHIVE);

--- a/src/refresh/vkpt/textures.c
+++ b/src/refresh/vkpt/textures.c
@@ -91,6 +91,7 @@ static uint8_t descriptor_set_dirty_flags[MAX_FRAMES_IN_FLIGHT] = { 0 }; // init
 static const float megabyte = 1048576.0f;
 
 extern cvar_t* cvar_pt_nearest;
+extern cvar_t* cvar_pt_nearest_2d;
 
 void vkpt_textures_prefetch()
 {
@@ -1936,14 +1937,21 @@ void vkpt_textures_update_descriptor_set()
 			image_view = tex_invalid_texture_image_view;
 		
 		VkSampler sampler = qvk.tex_sampler;
-		if (!strcmp(q_img->name, "pics/conchars.pcx") || !strcmp(q_img->name, "pics/ch1.pcx"))
-			sampler = qvk.tex_sampler_nearest;
-		else if (q_img->type == IT_SPRITE)
+		// 2d elements
+		if (q_img->type == IT_PIC || q_img->type == IT_FONT) {
+			if (cvar_pt_nearest_2d->integer || q_img->type == IT_FONT || !strcmp(q_img->name, "pics/ch1.pcx")) {
+				sampler = qvk.tex_sampler_nearest;
+			} else {
+				sampler = qvk.tex_sampler_linear_clamp;
+			}
+		} else if (q_img->type == IT_SPRITE) {
 			sampler = qvk.tex_sampler_linear_clamp;
-		else if (cvar_pt_nearest->integer == 1)
-			sampler = qvk.tex_sampler_nearest_mipmap_aniso;
-		else if (cvar_pt_nearest->integer >= 2)
-			sampler = qvk.tex_sampler_nearest;
+		} else {
+			if (cvar_pt_nearest->integer == 1)
+				sampler = qvk.tex_sampler_nearest_mipmap_aniso;
+			else if (cvar_pt_nearest->integer >= 2)
+				sampler = qvk.tex_sampler_nearest;
+		}
 
 		VkDescriptorImageInfo img_info = {
 			.imageLayout = VK_IMAGE_LAYOUT_GENERAL,


### PR DESCRIPTION
Split pt_nearest into two variables (the second one is named pt_nearest_2d), and default it to on, to match other Q2 engines/not cause blurry low quality UI textures.

Also fixes blurry non-standard fonts, since it was hardcoded to blur only the main font.