### PR TITLE
Print a warning if screen-space image memory usage is very high

### DIFF
--- a/src/refresh/vkpt/textures.c
+++ b/src/refresh/vkpt/textures.c
@@ -2152,13 +2152,13 @@ LIST_IMAGES_A_B
 #endif
 	}
 
-	Com_DPrintf("Screen-space image memory: %.2f MB\n", (float)total_size / megabyte);
+	Com_Printf("Screen-space image memory: %.2f MB\n", (float)total_size / megabyte);
 	VkDeviceSize video_mem_total = available_video_memory();
 	if(total_size > video_mem_total / 2)
 	{
-		Com_WPrintf("Screen-space image memory size (%.2f MB) is larger than half of available video memory (%.2f MB)\n"
+		Com_WPrintf("Screen-space image memory size is larger than half of available video memory (%.2f MB)\n"
 					"Consider limiting the DRS max resolution, using a fixed resolution scale, or lowering your output resolution.\n",
-					(float)total_size / megabyte, (float)video_mem_total / megabyte);
+					(float)video_mem_total / megabyte);
 	}
 
 	/* attach labels to images */

--- a/src/refresh/vkpt/textures.c
+++ b/src/refresh/vkpt/textures.c
@@ -2157,7 +2157,8 @@ LIST_IMAGES_A_B
 	if(total_size > video_mem_total / 2)
 	{
 		Com_WPrintf("Screen-space image memory size is larger than half of available video memory (%.2f MB)\n"
-					"Consider limiting the DRS max resolution, using a fixed resolution scale, or lowering your output resolution.\n",
+					"The increased VRAM pressure may cause performance drops. To counter this,\n"
+					"consider limiting the DRS max resolution, using a fixed resolution scale, or lowering your output resolution.\n",
 					(float)video_mem_total / megabyte);
 	}
 


### PR DESCRIPTION
Certain combinations of settings make Q2RTX eat video memory like popcorn, and more than's healthy at that, possibly causing performance issues. Try to detect when that happens and print a warning (together with some advice).

This happened to me after changing to 4K output resolution... my DRS max scale was still set to 150%, causing my poor og 3080 with it's 10GB of vram to choke noticeably. 

While I want to point out this would not have happened with default settings, I figure this may happen to other people as well - so print a warning if a suspiciously large amount of memory is used for screen-space memory. (Though I wonder if it makes sense to have it more prominent - e.g. displaying it in the menu.)

However, what I'm not sure about is how well this works when using multiple GPUs...
