### PR TITLE
FSR quality presets

### DIFF
--- a/baseq2/q2rtx.menu
+++ b/baseq2/q2rtx.menu
@@ -84,8 +84,9 @@ begin resolution
 	range -f "%.0f FPS" --status "only effective in dynamic mode" "target frames per second" drs_target 30 200 10
 	range -f "%.0f%%" --status "only effective in dynamic mode" "minimum scale" drs_minscale 25 100 5
 	range -f "%.0f%%" --status "only effective in dynamic mode" "maximum scale" drs_maxscale 50 150 5
+
 	blank
-    range -f "%.0f%%" "fixed resolution scale" viewsize 25 200 5
+	range -f "%.0f%%" --status "not effective if AMD FSR is enabled" "fixed resolution scale" viewsize 25 200 5
 end
 
 begin hdr
@@ -137,7 +138,8 @@ begin video
         range -p -f "%.0f%%" "contrast" tm_reinhard 0 1 0.1
 		range "texture LOD bias" pt_texture_lod_bias -2 2 0.5
         pairs "anti-aliasing" flt_taa "none" 0 "temporal AA" 1 "temporal upscaling" 2
-        toggle "AMD FSR 1.0" flt_fsr_enable
+        pairs --status "Note: Dynamic scaling will override quality preset" "AMD FSR 1.0" \
+            flt_fsr_enable "off" 0 "ultra quality" 1 "quality" 2 "balanced" 3 "performance" 4
         range --status "lower is sharper" "AMD FSR 1.0 sharpness" flt_fsr_sharpness 0 2 0.01
         pairs "global illumination" pt_num_bounce_rays low 0.5 medium 1 high 2
         pairs "reflection/refraction depth" pt_reflect_refract off 0 1 1 2 2 4 4 8 8

--- a/doc/client.md
+++ b/doc/client.md
@@ -696,18 +696,19 @@ Enables temporal anti-aliasing and primary ray direction jitter. Default value i
 
 #### `flt_fsr_enable`
 Enables FidelityFX Super Resolution 1.0 ("AMD FSR 1.0") upscaling. Default value is 0.
-If enabled, upscaling is applied when the resolution scale is below 100%, either from
-dynamic resolution scaling or by setting a fixes resolution scale.
 
-There's currently no UI to choose the AMD FSR 1.0 quality mode.
-You can closely approximate that setting by using an appropriate fixed
-resolution scale:
-| AMD FSR 1.0 Quality Mode | Fixed resolution scale |
-| ------------------------ | ---------------------- |
-| Ultra Quality            | 75%                    |
-| Quality                  | 65%                    |
-| Balanced                 | 60%                    |
-| Performance              | 50%                    |
+If non-zero, upscaling is applied when the resolution scale is below 100%.
+If dynamic resolution scaling is disabled the resolution scale is chosen
+depending on the `flt_fsr_enable` value (see table below).
+If dynamic resolution scaling is enabled the dynamic scale is used, and any non-zero
+value for `flt_fsr_enable` will mean "enabled".
+
+| AMD FSR 1.0 Quality Mode | Fixed resolution scale | `flt_fsr_enable` value |
+| ------------------------ | ---------------------- | ---------------------- |
+| Ultra Quality            | 75%                    | 1                      |
+| Quality                  | 65%                    | 2                      |
+| Balanced                 | 60%                    | 3                      |
+| Performance              | 50%                    | 4                      |
 
 #### `flt_fsr_sharpness`
 FidelityFX Super Resolution 1.0 sharpening amount. Default is 0.2.

--- a/src/refresh/vkpt/fsr.c
+++ b/src/refresh/vkpt/fsr.c
@@ -48,7 +48,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 	Q2RTX cvars
 	-----------
-	* flt_fsr_enable - 0 = disable FSR, 1 = enable FSR.
+	* flt_fsr_enable - 0 = disable FSR, 1 = ultra quality, 2 = quality,
+		3 = performance, other nonzero - enable but use `viewsize`
+	  The quality presets affect the resolution scaling.
+	  However, the scale from DRS takes precedence.
 	* flt_fsr_sharpness - float in the range [0,2]
 		Default is 0.2, a recommendation from the docs.
 	* flt_fsr_easu, flt_fsr_rcas - individual toggles for EASU and
@@ -203,6 +206,30 @@ bool vkpt_fsr_is_enabled()
 
 	// Need one of EASU or RCAS enabled
 	return (cvar_flt_fsr_easu->integer != 0) || (cvar_flt_fsr_rcas->integer != 0);
+}
+
+int vkpt_fsr_get_viewsize()
+{
+	if (cvar_flt_fsr_enable->integer == 0)
+		return 0;
+
+	switch(cvar_flt_fsr_enable->integer)
+	{
+	case 1:
+		// Ultra Quality
+		return 75;
+	case 2:
+		// Quality
+		return 65;
+	case 3:
+		// Balanced
+		return 60;
+	case 4:
+		// Performance
+		return 50;
+	}
+
+	return 0;
 }
 
 bool vkpt_fsr_needs_upscale()

--- a/src/refresh/vkpt/main.c
+++ b/src/refresh/vkpt/main.c
@@ -211,6 +211,16 @@ static inline bool extents_equal(VkExtent2D a, VkExtent2D b)
 	return a.width == b.width && a.height == b.height;
 }
 
+static int get_static_viewsize()
+{
+	// FSR: Return specific viewsize if a quality preset is selected
+	int fsr_viewsize = vkpt_fsr_get_viewsize();
+	if(fsr_viewsize > 0)
+		return fsr_viewsize;
+	// Otherwise: user-configured viewsize
+	return scr_viewsize->integer;
+}
+
 static VkExtent2D get_render_extent()
 {
 	int scale;
@@ -220,7 +230,7 @@ static VkExtent2D get_render_extent()
 	}
 	else
 	{
-		scale = scr_viewsize->integer;
+		scale = get_static_viewsize();
 		if(cvar_drs_enable->integer)
 		{
 			// Ensure render extent stays below get_screen_image_extent() result
@@ -3173,7 +3183,7 @@ static void drs_process()
 	if(!last_scale)
 		last_scale = cvar_drs_last_scale->integer;
 	if(!last_scale)
-		last_scale = scr_viewsize->integer;
+		last_scale = get_static_viewsize();
 
 	if (!drs_last_frame_world)
 	{
@@ -3259,7 +3269,7 @@ R_BeginFrame_RTX(void)
 	drs_process();
 	if (vkpt_refdef.fd)
 	{
-		vkpt_refdef.fd->feedback.resolution_scale = (drs_effective_scale != 0) ? drs_effective_scale : scr_viewsize->integer;
+		vkpt_refdef.fd->feedback.resolution_scale = (drs_effective_scale != 0) ? drs_effective_scale : get_static_viewsize();
 	}
 
 	qvk.extent_render = get_render_extent();

--- a/src/refresh/vkpt/vkpt.h
+++ b/src/refresh/vkpt/vkpt.h
@@ -670,6 +670,7 @@ VkResult vkpt_fsr_destroy();
 VkResult vkpt_fsr_create_pipelines();
 VkResult vkpt_fsr_destroy_pipelines();
 bool vkpt_fsr_is_enabled();
+int vkpt_fsr_get_viewsize();
 bool vkpt_fsr_needs_upscale();
 void vkpt_fsr_update_ubo(QVKUniformBuffer_t *ubo);
 VkResult vkpt_fsr_do(VkCommandBuffer cmd_buf);


### PR DESCRIPTION
The current way the AMD FSR setting interacts with resolution scale (and, hence, whether it actually is effective) is currently somewhat non-obvious. While it's documented in `client.md` not everyone reads this (or knows this document exists).

So tweak the behaviour of `flt_fsr_enable` to allow specification of fixed view sizes, in line with the "official" quality presets.
Try to deal with the interactions between FSR, dynamic scaling, and the "fixed" viewsize by adding notices to the menu entries.