### PR TITLE
Fix bsp model texture animation

### DIFF
--- a/src/refresh/vkpt/shader/instance_geometry.comp
+++ b/src/refresh/vkpt/shader/instance_geometry.comp
@@ -206,21 +206,8 @@ main()
 		if (mi.material != 0)
 			t.material_id = mi.material;
 
-		// Apply frame-based material animation: go through the linked list of materials.
-		int frame = mi.frame;
-		if (frame > 0)
-		{
-			uint material = t.material_id;
-			MaterialInfo minfo = get_material_info(material);
-			frame = frame % int(minfo.num_frames);
-
-			while (frame --> 0) {
-				material = minfo.next_frame;
-				minfo = get_material_info(material);
-			}
-
-			t.material_id = material | (t.material_id & ~MATERIAL_INDEX_MASK); // preserve flags
-		}
+		// Apply frame-based material animation
+		t.material_id = animate_material(t.material_id, mi.frame);
 
 		store_triangle(t, mi.render_buffer_idx, idx + mi.render_prim_offset);
 	}


### PR DESCRIPTION
Fix missing texture animation on bsp models (issue #185) by "animating" the frame in `load_and_transform_triangle()`.

Another approach I considered was to go over each bsp model once per frame and animating the material on each primitive - think similar principle as `instance_geometry`, only for bsp models, and material animation only.

I went for the `load_and_transform_triangle()` approach mainly because it's simpler.
However, it may have a performance disadvantage, as the "animation" would potentially be done quite a number of times, compared for guaranteed once per frame in the approach above.
(Perhaps it would be worthwhile to implement that as well and check if there's a measurable performance difference.)