### PR TITLE
Fixes for lighting in custom maps

### DIFF
--- a/src/refresh/vkpt/bsp_mesh.c
+++ b/src/refresh/vkpt/bsp_mesh.c
@@ -126,6 +126,22 @@ encode_normal(const vec3_t normal)
 	return ux | (uy << 16);
 }
 
+// Compute emissive factor for a surface
+static float
+compute_emissive(mtexinfo_t *texinfo)
+{
+	if(!texinfo->material)
+		return 1.f;
+
+	const float bsp_emissive = (float)texinfo->radiance * cvar_pt_bsp_radiance_scale->value;
+
+	const qboolean is_emissive_fake = texinfo->material->image_emissive && ((texinfo->material->image_emissive->flags & IF_FAKE_EMISSIVE) != 0);
+	// If emissive is not "fake" (ie explicit image), treat absence of SURF_LIGHT flag as "fully emissive"
+	// If emissive is "fake", treat absence of SURF_LIGHT flag as "not emissive"
+	const float fallback_emissive = !is_emissive_fake ? 1.f : 0.f;
+	return ((texinfo->c.flags & SURF_LIGHT) && texinfo->material->bsp_radiance) ? bsp_emissive : fallback_emissive;
+}
+
 #define DUMP_WORLD_MESH_TO_OBJ 0
 #if DUMP_WORLD_MESH_TO_OBJ
 static FILE* obj_dump_file = NULL;
@@ -232,9 +248,7 @@ create_poly(
 	if (!primitives_out)
 		return num_triangles;
 
-	const float emissive_factor = (texinfo->c.flags & SURF_LIGHT) && texinfo->material && texinfo->material->bsp_radiance
-		? (float)texinfo->radiance * cvar_pt_bsp_radiance_scale->value
-		: 1.f;
+	const float emissive_factor = compute_emissive(texinfo);
 
 	float alpha = 1.f;
 	if (MAT_IsKind(material_id, MATERIAL_KIND_TRANSPARENT))
@@ -1180,9 +1194,9 @@ collect_light_polys(bsp_mesh_t *wm, bsp_t *bsp, int model_idx, int* num_lights, 
 			continue;
 		}
 
-		float emissive_factor = (texinfo->c.flags & SURF_LIGHT) && texinfo->material->bsp_radiance
-			? (float)texinfo->radiance * cvar_pt_bsp_radiance_scale->value
-			: 1.f;
+		float emissive_factor = compute_emissive(texinfo);
+		if(emissive_factor == 0)
+			continue;
 
 		int light_style = (texinfo->material->light_styles) ? get_surf_light_style(surf) : 0;
 

--- a/src/refresh/vkpt/bsp_mesh.c
+++ b/src/refresh/vkpt/bsp_mesh.c
@@ -1166,8 +1166,6 @@ collect_light_polys(bsp_mesh_t *wm, bsp_t *bsp, int model_idx, int* num_lights, 
 		if(!any_light_frame)
 			continue;
 
-		uint32_t material_id = texinfo->material->flags;
-
 		// Collect emissive texture info from across frames
 		bool entire_texture_emissive;
 		vec2_t min_light_texcoord;

--- a/src/refresh/vkpt/shader/indirect_lighting.rgen
+++ b/src/refresh/vkpt/shader/indirect_lighting.rgen
@@ -348,6 +348,7 @@ indirect_lighting(
 
 
 		vec3 emissive = sample_emissive_texture(triangle.material_id, bounce_minfo, tex_coord, vec2(0), vec2(0), is_specular_ray ? 2 : 3);
+		emissive *= triangle.emissive_factor;
 
     	emissive += get_emissive_shell(triangle.material_id) * bounce_base_color;
 


### PR DESCRIPTION
Background:
After a bit of a while I looked at some custom maps again, specifically some which use very few "baseq2" textures and rely on `SURF_LIGHT` faces for lighting quite a bit.

The issue:
Suddenly all the walls very way too bright...

Turns out the map author used textures, including the wall textures, _mostly_ for "normal" surfaces, but _sometimes_ for emissive surfaces!
However, the code currently handling light surfaces with materials not specified in the material system sets `MATERIAL_FLAG_LIGHT` if a material is encountered on an emissive surface (`SURF_LIGHT`) - so one occurrence of that and suddenly all uses emit light!

Attempt 1:
My first thought was to treat surfaces lacking the `SURF_LIGHT` as always non-emissive.
However, this breaks quite a few updated materials that add emissive layers on textures that where not used for light emission in the original game.

Attempt 2 (this PR):
This only considers the presence of `SURF_LIGHT` if the emissive texture was not explicitly given (ie synthesized emissive texture): no `SURF_LIGHT` → no emission.
Otherwise, no `SURF_LIGHT` means "fully emissive" (previous behavior).
