### PR TITLE
HDR screenshot crash fix & improvements

### DIFF
--- a/src/refresh/images.c
+++ b/src/refresh/images.c
@@ -570,8 +570,22 @@ static void make_screenshot_hdr(const char *name)
 
     // TODO: async support
     pixels = IMG_ReadPixelsHDR(&w, &h);
+
+    screenshot_t s = {
+        .save_cb = NULL,
+        .pixels = (byte*)pixels,
+        .fp = fp,
+        .filename = buffer,
+        .width = w,
+        .height = h,
+        .row_stride = 0,
+        .status = -1,
+        .param = 0,
+        .async = false,
+    };
+
     stbi_flip_vertically_on_write(1);
-    ret = stbi_write_hdr_to_func(stbi_write, fp, w, h, 3, pixels);
+    ret = stbi_write_hdr_to_func(stbi_write, &s, w, h, 3, pixels);
     FS_FreeTempMem(pixels);
 
     fclose(fp);

--- a/src/refresh/images.c
+++ b/src/refresh/images.c
@@ -510,7 +510,7 @@ static void make_screenshot(const char *name, const char *ext,
     int         w, h, ret, row_stride;
     
     if(is_render_hdr()) {
-        Com_WPrintf("Screenshot format not supported in HDR mode");
+        Com_WPrintf("Screenshot format not supported in HDR mode\n");
         return;
     }
     ret = create_screenshot(buffer, sizeof(buffer), &fp, name, ext);
@@ -559,7 +559,7 @@ static void make_screenshot_hdr(const char *name)
     int         w, h;
 
     if(!is_render_hdr()) {
-        Com_WPrintf("Screenshot format supported in HDR mode only");
+        Com_WPrintf("Screenshot format supported in HDR mode only\n");
         return;
     }
 

--- a/src/refresh/images.c
+++ b/src/refresh/images.c
@@ -560,6 +560,7 @@ static void make_screenshot_hdr(const char *name)
 
     if(!is_render_hdr()) {
         Com_WPrintf("Screenshot format supported in HDR mode only");
+        return;
     }
 
     ret = create_screenshot(buffer, sizeof(buffer), &fp, name, ".hdr");


### PR DESCRIPTION
Most importantly this fixes a crash that currently occurs when making a HDR screenshot.

On top of that some small tweaks and async writing support were added.