### PR TITLE
Tweak particles to have more nuanced colors

### DIFF
--- a/src/refresh/vkpt/color.h
+++ b/src/refresh/vkpt/color.h
@@ -1,0 +1,44 @@
+/*
+Copyright (C) 2019, NVIDIA CORPORATION. All rights reserved.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#ifndef COLOR_H_
+#define COLOR_H_
+
+static inline float decode_srgb(byte pix)
+{
+	float x = (float)pix / 255.f;
+	
+	if (x < 0.04045f)
+		return x / 12.92f;
+
+	return powf((x + 0.055f) / 1.055f, 2.4f);
+}
+
+static inline byte encode_srgb(float x)
+{
+    if (x <= 0.0031308f)
+        x *= 12.92f;
+    else
+        x = 1.055f * powf(x, 1.f / 2.4f) - 0.055f;
+     
+    x = max(0.f, min(1.f, x));
+
+    return (byte)roundf(x * 255.f);
+}
+
+#endif // COLOR_H_

--- a/src/refresh/vkpt/shader/global_ubo.h
+++ b/src/refresh/vkpt/shader/global_ubo.h
@@ -90,6 +90,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	UBO_CVAR_DO(pt_ndf_trim, 0.9) /* trim factor for GGX NDF sampling (0..1] */ \
 	UBO_CVAR_DO(pt_num_bounce_rays, 1) /* number of bounce rays, valid values are 0 (disabled), 0.5 (half-res diffuse), 1 (full-res diffuse + specular), 2 (two bounces) */ \
 	UBO_CVAR_DO(pt_particle_softness, 1.0) /* particle softness */ \
+	UBO_CVAR_DO(pt_particle_brightness, 500) /* particle brightness */ \
 	UBO_CVAR_DO(pt_reflect_refract, 2) /* number of reflection or refraction bounces: 0, 1 or 2 */ \
 	UBO_CVAR_DO(pt_roughness_override, -1) /* overrides roughness of all materials if non-negative, [0..1] */ \
 	UBO_CVAR_DO(pt_specular_anti_flicker, 2) /* fade factor for rough reflections of surfaces far away, [0..inf) */ \

--- a/src/refresh/vkpt/shader/global_ubo.h
+++ b/src/refresh/vkpt/shader/global_ubo.h
@@ -89,8 +89,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	UBO_CVAR_DO(pt_metallic_override, -1) /* overrides metallic parameter of all materials if non-negative, [0..1] */ \
 	UBO_CVAR_DO(pt_ndf_trim, 0.9) /* trim factor for GGX NDF sampling (0..1] */ \
 	UBO_CVAR_DO(pt_num_bounce_rays, 1) /* number of bounce rays, valid values are 0 (disabled), 0.5 (half-res diffuse), 1 (full-res diffuse + specular), 2 (two bounces) */ \
-	UBO_CVAR_DO(pt_particle_softness, 1.0) /* particle softness */ \
-	UBO_CVAR_DO(pt_particle_brightness, 500) /* particle brightness */ \
+	UBO_CVAR_DO(pt_particle_softness, 0.7) /* particle softness */ \
+	UBO_CVAR_DO(pt_particle_brightness, 100) /* particle brightness */ \
 	UBO_CVAR_DO(pt_reflect_refract, 2) /* number of reflection or refraction bounces: 0, 1 or 2 */ \
 	UBO_CVAR_DO(pt_roughness_override, -1) /* overrides roughness of all materials if non-negative, [0..1] */ \
 	UBO_CVAR_DO(pt_specular_anti_flicker, 2) /* fade factor for rough reflections of surfaces far away, [0..inf) */ \

--- a/src/refresh/vkpt/shader/path_tracer_hit_shaders.h
+++ b/src/refresh/vkpt/shader/path_tracer_hit_shaders.h
@@ -95,7 +95,7 @@ vec4 pt_logic_particle(int primitiveID, vec2 bary)
 		color.a *= factor;
 		color.rgb *= color.a;
 
-		color.rgb *= global_ubo.prev_adapted_luminance * 500;
+		color.rgb *= global_ubo.prev_adapted_luminance * global_ubo.pt_particle_brightness;
 
 		return color;
 	}

--- a/src/refresh/vkpt/textures.c
+++ b/src/refresh/vkpt/textures.c
@@ -24,6 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include <assert.h>
 
+#include "color.h"
 #include "material.h"
 #include "../stb/stb_image.h"
 #include "../stb/stb_image_resize.h"
@@ -517,28 +518,6 @@ get_num_miplevels(int w, int h)
 IMG_Load
 ================
 */
-
-static inline float decode_srgb(byte pix)
-{
-	float x = (float)pix / 255.f;
-	
-	if (x < 0.04045f)
-		return x / 12.92f;
-
-	return powf((x + 0.055f) / 1.055f, 2.4f);
-}
-
-static inline byte encode_srgb(float x)
-{
-    if (x <= 0.0031308f)
-        x *= 12.92f;
-    else
-        x = 1.055f * powf(x, 1.f / 2.4f) - 0.055f;
-     
-    x = max(0.f, min(1.f, x));
-
-    return (byte)roundf(x * 255.f);
-}
 
 struct filterscratch_s
 {

--- a/src/refresh/vkpt/transparency.c
+++ b/src/refresh/vkpt/transparency.c
@@ -20,6 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "shared/shared.h"
 #include "vkpt.h"
 #include "vk_util.h"
+#include "color.h"
 #include "conversion.h"
 
 #define TR_PARTICLE_MAX_NUM    MAX_PARTICLES
@@ -99,7 +100,7 @@ void cast_u32_to_f32_color(int color_index, const color_t* pcolor, float* color_
 		color.u32 = d_8to24table[color_index & 0xff];
 
 	for (int i = 0; i < 3; i++)
-		color_f32[i] = hdr_factor * ((float)color.u8[i] / 255.0);
+		color_f32[i] = hdr_factor * decode_srgb(color.u8[i]);
 }
 
 bool initialize_transparency()

--- a/src/refresh/vkpt/transparency.c
+++ b/src/refresh/vkpt/transparency.c
@@ -105,7 +105,7 @@ void cast_u32_to_f32_color(int color_index, const color_t* pcolor, float* color_
 
 bool initialize_transparency()
 {
-	cvar_pt_particle_size = Cvar_Get("pt_particle_size", "0.35", 0);
+	cvar_pt_particle_size = Cvar_Get("pt_particle_size", "0.5", 0);
 	cvar_pt_beam_width = Cvar_Get("pt_beam_width", "1.0", 0);
 	cvar_pt_beam_lights = Cvar_Get("pt_beam_lights", "1.0", 0);
 


### PR DESCRIPTION
This is probably a bit subjective...

Particle colors have a bit of nuance to them They typically vary by a few palette indices,
but with a large particle 'brightness' they tend towards looking saturated, appearing to consist of almost almost only primary colors.
(E.g. sparks are basically yellow when original Q2 also had some orange in there.)
So to address this the brightness was toned down to reduce the saturation, with the other particle
settings tweaked so they still have some visual pop.
Converting their colors from sRGB also helps to add visible distinctions between particle colors after scaling.
