### PR TITLE
Explicitly track active renderer instead of relying on vid_rtx.

### DIFF
--- a/inc/refresh/refresh.h
+++ b/inc/refresh/refresh.h
@@ -228,8 +228,15 @@ typedef enum {
     IT_MAX
 } imagetype_t;
 
+typedef enum ref_type_e
+{
+    REF_TYPE_NONE = 0,
+    REF_TYPE_GL,
+    REF_TYPE_VKPT
+} ref_type_t;
+
 // called when the library is loaded
-extern bool        (*R_Init)(bool total);
+extern ref_type_t  (*R_Init)(bool total);
 
 // called before the library is unloaded
 extern void        (*R_Shutdown)(bool total);

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -378,6 +378,7 @@ typedef struct client_static_s {
     active_t    active;
 
     bool        ref_initialized;
+    ref_type_t  ref_type;
     unsigned    disable_screen;
 
     int         userinfo_modified;

--- a/src/client/effects.c
+++ b/src/client/effects.c
@@ -448,7 +448,7 @@ void CL_MuzzleFlash(void)
 	// Q2RTX
     }
 
-	if (vid_rtx->integer)
+	if (cls.ref_type == REF_TYPE_VKPT)
 	{
 		// don't add muzzle flashes in RTX mode
 		DL_RADIUS(0.f);

--- a/src/client/entities.c
+++ b/src/client/entities.c
@@ -725,7 +725,7 @@ static void CL_AddPacketEntities(void)
 
 			if (!cl.thirdPersonView)
 			{
-				if(vid_rtx->integer)
+				if(cls.ref_type == REF_TYPE_VKPT)
 					base_entity_flags |= RF_VIEWERMODEL;    // only draw from mirrors
 				else
                 goto skip;
@@ -770,7 +770,7 @@ static void CL_AddPacketEntities(void)
         ent.flags |= base_entity_flags;
 
 		// in rtx mode, the base entity has the renderfx for shells
-		if ((effects & EF_COLOR_SHELL) && vid_rtx->integer) {
+		if ((effects & EF_COLOR_SHELL) && cls.ref_type == REF_TYPE_VKPT) {
 			renderfx = adjust_shell_fx(renderfx);
 			ent.flags |= renderfx;
 		}
@@ -800,7 +800,7 @@ static void CL_AddPacketEntities(void)
                 }
 
         // color shells generate a separate entity for the main model
-        if ((effects & EF_COLOR_SHELL) && !vid_rtx->integer) {
+        if ((effects & EF_COLOR_SHELL) && cls.ref_type != REF_TYPE_VKPT) {
 			renderfx = adjust_shell_fx(renderfx);
             ent.flags = renderfx | RF_TRANSLUCENT | base_entity_flags;
             ent.alpha = 0.30f;
@@ -836,7 +836,7 @@ static void CL_AddPacketEntities(void)
                 ent.flags = RF_TRANSLUCENT;
             }
 
-			if ((effects & EF_COLOR_SHELL) && vid_rtx->integer) {
+			if ((effects & EF_COLOR_SHELL) && cls.ref_type == REF_TYPE_VKPT) {
 				ent.flags |= renderfx;
 			}
 
@@ -1091,7 +1091,7 @@ static void CL_AddViewWeapon(void)
 	shell_flags = shell_effect_hack();
 
 	// same entity in rtx mode
-	if (vid_rtx->integer) {
+	if (cls.ref_type == REF_TYPE_VKPT) {
 		gun.flags |= shell_flags;
 	}
 
@@ -1102,7 +1102,7 @@ static void CL_AddViewWeapon(void)
     V_AddEntity(&gun);
 
 	// separate entity in non-rtx mode
-    if (shell_flags && !vid_rtx->integer) {
+    if (shell_flags && cls.ref_type != REF_TYPE_VKPT) {
         gun.alpha = 0.30f * cl_gunalpha->value;
         gun.flags |= shell_flags | RF_TRANSLUCENT;
         V_AddEntity(&gun);

--- a/src/client/refresh.c
+++ b/src/client/refresh.c
@@ -345,7 +345,8 @@ void CL_InitRefresh(void)
 #error "REF_GL and REF_VKPT are both disabled, at least one has to be enableds"
 #endif
 
-    if (!R_Init(true)) {
+    cls.ref_type = R_Init(true);
+    if (cls.ref_type == REF_TYPE_NONE) {
         Com_Error(ERR_FATAL, "Couldn't initialize refresh: %s", Com_GetLastError());
     }
 
@@ -393,6 +394,7 @@ void CL_ShutdownRefresh(void)
     R_Shutdown(true);
 
     cls.ref_initialized = false;
+    cls.ref_type = REF_TYPE_NONE;
 
     // no longer active
     cls.active = ACT_MINIMIZED;
@@ -403,7 +405,7 @@ void CL_ShutdownRefresh(void)
 
 refcfg_t r_config;
 
-bool(*R_Init)(bool total) = NULL;
+ref_type_t(*R_Init)(bool total) = NULL;
 void(*R_Shutdown)(bool total) = NULL;
 void(*R_BeginRegistration)(const char *map) = NULL;
 void(*R_SetSky)(const char *name, float rotate, vec3_t axis) = NULL;

--- a/src/client/screen.c
+++ b/src/client/screen.c
@@ -753,7 +753,7 @@ static void SCR_DrawFPS(void)
 	int scale = CL_GetResolutionScale();
 
 	char buffer[MAX_QPATH];
-	if (scr_fps->integer == 2 && vid_rtx->integer)
+	if (scr_fps->integer == 2 && cls.ref_type == REF_TYPE_VKPT)
 		Q_snprintf(buffer, MAX_QPATH, "%d FPS at %3d%%", fps, scale);
 	else
 		Q_snprintf(buffer, MAX_QPATH, "%d FPS", fps);

--- a/src/client/tent.c
+++ b/src/client/tent.c
@@ -383,7 +383,7 @@ static void CL_AddExplosions(void)
         if (ex->type == ex_free)
             continue;
 
-		if (vid_rtx->integer)
+		if (cls.ref_type == REF_TYPE_VKPT)
 			CL_AddExplosionLight(ex, frac / (ex->frames - 1));
 		else
 		{

--- a/src/client/ui/playerconfig.c
+++ b/src/client/ui/playerconfig.c
@@ -17,6 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #include "ui.h"
+#include "../client.h"
 
 
 /*
@@ -333,7 +334,7 @@ void M_Menu_PlayerConfig(void)
     m_player.menu.free = Free;
 	m_player.menu.image = uis.backgroundHandle;
 
-	if (vid_rtx->integer)
+	if (cls.ref_type == REF_TYPE_VKPT)
 	{
 		// Q2RTX: make the player menu transparent so that we can see 
 		// the model below: all 2D stuff is rendered after 3D, in stretch_pics.
@@ -362,7 +363,7 @@ void M_Menu_PlayerConfig(void)
     m_player.refdef.entities = m_player.entities;
     m_player.refdef.rdflags = RDF_NOWORLDMODEL;
 
-	if (vid_rtx->integer)
+	if (cls.ref_type == REF_TYPE_VKPT)
 	{
 		m_player.refdef.num_dlights = sizeof(dlights) / sizeof(*dlights);
 		m_player.refdef.dlights = dlights;

--- a/src/refresh/gl/main.c
+++ b/src/refresh/gl/main.c
@@ -828,13 +828,13 @@ static void GL_PostInit(void)
 R_Init
 ===============
 */
-bool R_Init_GL(bool total)
+ref_type_t R_Init_GL(bool total)
 {
     Com_DPrintf("GL_Init( %i )\n", total);
 
     if (!total) {
         GL_PostInit();
-        return true;
+        return REF_TYPE_GL;
     }
 
     Com_Printf("------- R_Init -------\n");
@@ -843,7 +843,7 @@ bool R_Init_GL(bool total)
     // initialize OS-specific parts of OpenGL
     // create the window and set up the context
     if (!VID_Init(GAPI_OPENGL)) {
-        return false;
+        return REF_TYPE_NONE;
     }
 
     // initialize our QGL dynamic bindings
@@ -865,14 +865,14 @@ bool R_Init_GL(bool total)
 
     Com_Printf("----------------------\n");
 
-    return true;
+    return REF_TYPE_GL;
 
 fail:
     memset(&gl_static, 0, sizeof(gl_static));
     memset(&gl_config, 0, sizeof(gl_config));
     QGL_Shutdown();
     VID_Shutdown();
-    return false;
+    return REF_TYPE_NONE;
 }
 
 /*

--- a/src/refresh/images.c
+++ b/src/refresh/images.c
@@ -26,6 +26,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "common/common.h"
 #include "common/cvar.h"
 #include "common/files.h"
+#include "../client/client.h"
 #include "refresh/images.h"
 #include "system/system.h"
 #include "format/pcx.h"
@@ -1283,7 +1284,7 @@ static int find_or_load_image(const char *name, size_t len,
     }
 
 	int override_textures = !!r_override_textures->integer;
-	if (!vid_rtx->integer && (type != IT_PIC) && !gl_use_hd_assets->integer)
+	if (cls.ref_type == REF_TYPE_GL && (type != IT_PIC) && !gl_use_hd_assets->integer)
 		override_textures = 0;
     if (flags & IF_EXACT)
         override_textures = 0;

--- a/src/refresh/models.c
+++ b/src/refresh/models.c
@@ -349,7 +349,8 @@ qhandle_t R_RegisterModel(const char *name)
             fs_flags = try_location == TRY_MODEL_SRC_GAME ? FS_PATH_GAME : FS_PATH_BASE;
 
         char* extension = normalized + namelen - 4;
-        if (namelen > 4 && (strcmp(extension, ".md2") == 0) && (vid_rtx->integer || gl_use_hd_assets->integer))
+        bool try_md3 = cls.ref_type == REF_TYPE_VKPT || (cls.ref_type == REF_TYPE_GL && gl_use_hd_assets->integer);
+        if (namelen > 4 && (strcmp(extension, ".md2") == 0) && try_md3)
         {
             memcpy(extension, ".md3", 4);
 

--- a/src/refresh/vkpt/main.c
+++ b/src/refresh/vkpt/main.c
@@ -3502,14 +3502,14 @@ static void ray_tracing_api_g(genctx_t *ctx)
 }
 
 /* called when the library is loaded */
-bool
+ref_type_t
 R_Init_RTX(bool total)
 {
 	registration_sequence = 1;
 
 	if (!VID_Init(GAPI_VULKAN)) {
 		Com_Error(ERR_FATAL, "VID_Init failed\n");
-		return false;
+		return REF_TYPE_NONE;
 	}
 
 	extern SDL_Window *sdl_window;
@@ -3650,7 +3650,7 @@ R_Init_RTX(bool total)
 	
 	if(!init_vulkan()) {
 		Com_Error(ERR_FATAL, "Couldn't initialize Vulkan.\n");
-		return false;
+		return REF_TYPE_NONE;
 	}
 
 	_VK(create_command_pool_and_fences());
@@ -3680,7 +3680,7 @@ R_Init_RTX(bool total)
 		taa_samples[i][1] = halton(3, i + 1) - 0.5f;
 	}
 
-	return true;
+	return REF_TYPE_VKPT;
 }
 
 /* called before the library is unloaded */


### PR DESCRIPTION
A lot of code assumes the value of vid_rtx also reflects the current renderer.
However, it can happen that this is not the case, causing code to rely on this
assumption to break (see #198).

Address by explicitly storing the currently active renderer and updating that
field on renderer initialization/shutdown. Also change any code that used vid_rtx
to check the renderer to use that new value.