### PR TITLE
Ignore a material definition if a game overrides a texture

### DIFF
--- a/src/refresh/images.c
+++ b/src/refresh/images.c
@@ -999,24 +999,6 @@ static int _try_image_format(imageformat_t fmt, image_t *image, int try_src, byt
     if (!data) {
         return len;
     }
-    /* Don't prefer game image if it's identical to the base version
-       Some games (eg rogue) ship image assets that are identical to the
-       baseq2 version.
-       If that is the case, prefer the baseq2 copy - because those may have
-       override image and additional material images!
-     */
-    if (try_src == TRY_IMAGE_SRC_GAME) {
-        byte *data_base;
-        int len_base;
-        len_base = FS_LoadFileFlags(image->name, (void **)&data_base, FS_PATH_BASE);
-        if((len == len_base) && (memcmp(data, data_base, len) == 0)) {
-            // Identical data in game, pretend file doesn't exist
-            FS_FreeFile(data);
-            FS_FreeFile(data_base);
-            return Q_ERR_NOENT;
-        }
-        FS_FreeFile(data_base);
-    }
 
     // decompress the image
     ret = img_loaders[fmt].load(data, len, image, pic);

--- a/src/refresh/vkpt/material.c
+++ b/src/refresh/vkpt/material.c
@@ -739,6 +739,41 @@ static void load_material_image(image_t** image, const char* filename, pbr_mater
 	}
 }
 
+static qboolean game_image_identical_to_base(const char* name)
+{
+	/* Check if a game image is actually different from the base version,
+	   as some games (eg rogue) ship image assets that are identical to the
+	   baseq2 version.
+	   If that is the case, ignore the game image, and just use everything
+	   from baseq2, especially overides/other images. */
+	qboolean result = false;
+
+	qhandle_t base_file = -1, game_file = -1;
+	if((FS_FOpenFile(name, &base_file, FS_MODE_READ | FS_PATH_BASE | FS_BUF_NONE) >= 0)
+		&& (FS_FOpenFile(name, &game_file, FS_MODE_READ | FS_PATH_GAME | FS_BUF_NONE) >= 0))
+	{
+		int64_t base_len = FS_Length(base_file), game_len = FS_Length(game_file);
+		if(base_len == game_len)
+		{
+			char *base_data = FS_Malloc(base_len);
+			char *game_data = FS_Malloc(game_len);
+			if(FS_Read(base_data, base_len, base_file) >= 0
+				&& FS_Read(game_data, game_len, game_file) >= 0)
+			{
+				result = memcmp(base_data, game_data, base_len) == 0;
+			}
+			Z_Free(base_data);
+			Z_Free(game_data);
+		}
+	}
+	if (base_file >= 0)
+		FS_FCloseFile(base_file);
+	if (game_file >= 0)
+		FS_FCloseFile(game_file);
+
+	return result;
+}
+
 pbr_material_t* MAT_Find(const char* name, imagetype_t type, imageflags_t flags)
 {
 	char mat_name_no_ext[MAX_QPATH];
@@ -771,10 +806,19 @@ pbr_material_t* MAT_Find(const char* name, imagetype_t type, imageflags_t flags)
 	   e.g. 'action' replaces models/weapons/v_blast with something
 	   looking completely differently.
 	   Using the material definition from baseq2 makes things look wrong.
-	   So try to detect if the game is overriding a texture from baseq2 and,
-	   if that is the case, ignore the material definition (if it's from
-	   baseq2 - to allow for a game-specific material definition). */
-	if (matdef && (matdef->image_flags & IF_SRC_MASK) == IF_SRC_BASE && is_game_custom() && FS_FileExistsEx(name, FS_PATH_GAME) != 0) {
+	   So try to detect if the game is overriding an image from baseq2
+	   with a different image and, if that is the case, ignore the material
+	   definition (if it's from baseq2 - to allow for a game-specific material
+	   definition).
+	   There's also the wrinkle that some games ship with a copy of an image
+	   that is identical in baseq2 (see game_image_identical_to_base()),
+	   in that case, _do_ use the material definition. */
+	if (matdef
+		&& (matdef->image_flags & IF_SRC_MASK) == IF_SRC_BASE
+		&& is_game_custom()
+		&& FS_FileExistsEx(name, FS_PATH_GAME) != 0
+		&& !game_image_identical_to_base(name))
+	{
 		matdef = NULL;
 		/* Forcing image to load from game prevents a normal or emissive map in baseq2
 		 * from being picked up. */

--- a/src/refresh/vkpt/material.c
+++ b/src/refresh/vkpt/material.c
@@ -761,6 +761,22 @@ pbr_material_t* MAT_Find(const char* name, imagetype_t type, imageflags_t flags)
 			matdef = map_mat;
 	}
 
+	/* Some games override baseq2 assets without changing the name -
+	   e.g. 'action' replaces models/weapons/v_blast with something
+	   looking completely differently.
+	   Using the material definition from baseq2 makes things look wrong.
+	   So try to detect if the game is overriding a texture from baseq2 and,
+	   if that is the case, ignore the material definition (if it's from
+	   baseq2 - to allow for a game-specific material definition). */
+	if (matdef && (matdef->image_flags & IF_SRC_MASK) == IF_SRC_BASE)
+	{
+		if(FS_FileExistsEx(name, FS_PATH_GAME) != 0) {
+			matdef = NULL;
+			/* Forcing image to load from game prevents a normal or emissive map in baseq2
+			 * from being picked up. */
+			flags = (flags & ~IF_SRC_MASK) | IF_SRC_GAME;
+		}
+	}
 	if (matdef)
 	{
 		memcpy(mat, matdef, sizeof(pbr_material_t));


### PR DESCRIPTION
Some games override baseq2 assets without changing the name -
e.g. 'action' replaces models/weapons/v_blast with something looking completely differently.
Using the material definition from baseq2 makes things look wrong.
So try to detect if the game is overriding a texture from baseq2 and, if that is the case, ignore the material definition (if it's from baseq2 - to allow for a game-specific material definition).

(I previously submitted something with the same intent as part of #116 [[2415da2](https://github.com/NVIDIA/Q2RTX/pull/116/commits/2415da21620e07aeada906780097512ac7689efd)], but it seems those changes got lost or ineffective during the material system overhaul.)