### PR TITLE
 materials: Make fallback radiance (used when no BSP radiance given) an explicit attribute

### DIFF
--- a/src/refresh/vkpt/material.c
+++ b/src/refresh/vkpt/material.c
@@ -1124,12 +1124,57 @@ static void material_completer(genctx_t* ctx, int argnum)
 		for (int i = 0; i < c_NumAttributes; i++)
 			Prompt_AddMatch(ctx, c_Attributes[i].name);
 	}
-	else if (argnum > 2 && strcmp(Cmd_Argv(1), "save") == 0)
+	else if (argnum == 2)
 	{
-		// extra arguments for 'save'
-		
-		Prompt_AddMatch(ctx, "all");
-		Prompt_AddMatch(ctx, "force");
+		if(strcmp(Cmd_Argv(1), "save") == 0)
+		{
+			// extra arguments for 'save'
+			Prompt_AddMatch(ctx, "all");
+			Prompt_AddMatch(ctx, "force");
+		}
+		else if((strcmp(Cmd_Argv(1), "print") == 0) || (strcmp(Cmd_Argv(1), "which") == 0))
+		{
+			// Nothing to complete for these
+		}
+		else
+		{
+			// Material property completion
+			struct MaterialAttribute const* t = NULL;
+			for (int i = 0; i < c_NumAttributes; ++i)
+			{
+				if (strcmp(Cmd_Argv(1), c_Attributes[i].name) == 0)
+				{
+					t = &c_Attributes[i];
+					break;
+				}
+			}
+
+			if(!t)
+				return;
+
+			// Attribute-specific completions
+			switch(t->index)
+			{
+			case MAT_KIND:
+				for (int i = 0; i < nMaterialKinds; ++i)
+				{
+					// Use lower-case for completion, that is what you'd typically type
+					char kind[32];
+					Q_strlcpy(kind, materialKinds[i].name, sizeof(kind));
+					Q_strlwr(kind);
+					Prompt_AddMatch(ctx, kind);
+				}
+				return;
+			}
+
+			// Type-specific completions
+			if(t->type == ATTR_BOOL)
+			{
+				Prompt_AddMatch(ctx, "0");
+				Prompt_AddMatch(ctx, "1");
+				return;
+			}
+		}
 	}
 }
 

--- a/src/refresh/vkpt/material.c
+++ b/src/refresh/vkpt/material.c
@@ -278,29 +278,48 @@ static pbr_material_t* find_material_sorted(const char* name, pbr_material_t* fi
 	return NULL;
 }
 
+enum AttributeIndex
+{
+	MAT_BUMP_SCALE,
+	MAT_ROUGHNESS_OVERRIDE,
+	MAT_METALNESS_FACTOR,
+	MAT_EMISSIVE_FACTOR,
+	MAT_KIND,
+	MAT_IS_LIGHT,
+	MAT_BASE_FACTOR,
+	MAT_TEXTURE_BASE,
+	MAT_TEXTURE_NORMALS,
+	MAT_TEXTURE_EMISSIVE,
+	MAT_LIGHT_STYLES,
+	MAT_BSP_RADIANCE,
+	MAT_TEXTURE_MASK,
+	MAT_SYNTH_EMISSIVE,
+	MAT_EMISSIVE_THRESHOLD,
+	MAT_SPECULAR_FACTOR,
+};
 enum AttributeType { ATTR_BOOL, ATTR_FLOAT, ATTR_STRING, ATTR_INT };
 
 static struct MaterialAttribute {
-	int index;
+	enum AttributeIndex index;
 	const char* name;
 	enum AttributeType type;
 } c_Attributes[] = {
-	{0, "bump_scale", ATTR_FLOAT},
-	{1, "roughness_override", ATTR_FLOAT},
-	{2, "metalness_factor", ATTR_FLOAT},
-	{3, "emissive_factor", ATTR_FLOAT},
-	{4, "kind", ATTR_STRING},
-	{5, "is_light", ATTR_BOOL},
-	{6, "base_factor", ATTR_FLOAT},
-	{7, "texture_base", ATTR_STRING},
-	{8, "texture_normals", ATTR_STRING},
-	{9, "texture_emissive", ATTR_STRING},
-	{10, "light_styles", ATTR_BOOL},
-	{11, "bsp_radiance", ATTR_BOOL},
-	{12, "texture_mask", ATTR_STRING},
-	{13, "synth_emissive", ATTR_BOOL},
-	{14, "emissive_threshold", ATTR_INT},
-	{15, "specular_factor", ATTR_FLOAT},
+	{MAT_BUMP_SCALE, "bump_scale", ATTR_FLOAT},
+	{MAT_ROUGHNESS_OVERRIDE, "roughness_override", ATTR_FLOAT},
+	{MAT_METALNESS_FACTOR, "metalness_factor", ATTR_FLOAT},
+	{MAT_EMISSIVE_FACTOR, "emissive_factor", ATTR_FLOAT},
+	{MAT_KIND, "kind", ATTR_STRING},
+	{MAT_IS_LIGHT, "is_light", ATTR_BOOL},
+	{MAT_BASE_FACTOR, "base_factor", ATTR_FLOAT},
+	{MAT_TEXTURE_BASE, "texture_base", ATTR_STRING},
+	{MAT_TEXTURE_NORMALS, "texture_normals", ATTR_STRING},
+	{MAT_TEXTURE_EMISSIVE, "texture_emissive", ATTR_STRING},
+	{MAT_LIGHT_STYLES, "light_styles", ATTR_BOOL},
+	{MAT_BSP_RADIANCE, "bsp_radiance", ATTR_BOOL},
+	{MAT_TEXTURE_MASK, "texture_mask", ATTR_STRING},
+	{MAT_SYNTH_EMISSIVE, "synth_emissive", ATTR_BOOL},
+	{MAT_EMISSIVE_THRESHOLD, "emissive_threshold", ATTR_INT},
+	{MAT_SPECULAR_FACTOR, "specular_factor", ATTR_FLOAT},
 };
 
 static int c_NumAttributes = sizeof(c_Attributes) / sizeof(struct MaterialAttribute);
@@ -388,11 +407,11 @@ static int set_material_attribute(pbr_material_t* mat, const char* attribute, co
 
 	switch (t->index)
 	{
-	case 0: mat->bump_scale = fvalue; break;
-	case 1: mat->roughness_override = fvalue; break;
-	case 2: mat->metalness_factor = fvalue; break;
-	case 3: mat->emissive_factor = fvalue; break;
-	case 4: {
+	case MAT_BUMP_SCALE: mat->bump_scale = fvalue; break;
+	case MAT_ROUGHNESS_OVERRIDE: mat->roughness_override = fvalue; break;
+	case MAT_METALNESS_FACTOR: mat->metalness_factor = fvalue; break;
+	case MAT_EMISSIVE_FACTOR: mat->emissive_factor = fvalue; break;
+	case MAT_KIND: {
 		uint32_t kind = getMaterialKind(svalue);
 		if (kind != 0)
 			mat->flags = MAT_SetKind(mat->flags, kind);
@@ -406,43 +425,43 @@ static int set_material_attribute(pbr_material_t* mat, const char* attribute, co
 		}
 		if (reload_flags) *reload_flags |= RELOAD_MAP;
 	} break;
-	case 5:
+	case MAT_IS_LIGHT:
 		mat->flags = bvalue == true ? mat->flags | MATERIAL_FLAG_LIGHT : mat->flags & ~(MATERIAL_FLAG_LIGHT);
 		if (reload_flags) *reload_flags |= RELOAD_MAP;
 		break;
-	case 6:
+	case MAT_BASE_FACTOR:
 		mat->base_factor = fvalue;
 		break;
-	case 7:
+	case MAT_TEXTURE_BASE:
 		set_material_texture(mat, svalue, mat->filename_base, &mat->image_base, IF_SRGB, !sourceFile);
 		break;
-	case 8:
+	case MAT_TEXTURE_NORMALS:
 		set_material_texture(mat, svalue, mat->filename_normals, &mat->image_normals, IF_NONE, !sourceFile);
 		break;
-	case 9:
+	case MAT_TEXTURE_EMISSIVE:
 		set_material_texture(mat, svalue, mat->filename_emissive, &mat->image_emissive, IF_SRGB, !sourceFile);
 		break;
-	case 10:
+	case MAT_LIGHT_STYLES:
 		mat->light_styles = bvalue;
 		if (reload_flags) *reload_flags |= RELOAD_MAP;
 		break;
-	case 11:
+	case MAT_BSP_RADIANCE:
 		mat->bsp_radiance = bvalue;
 		if (reload_flags) *reload_flags |= RELOAD_MAP;
 		break;
-	case 12:
+	case MAT_TEXTURE_MASK:
 		set_material_texture(mat, svalue, mat->filename_mask, &mat->image_mask, IF_NONE, !sourceFile);
 		if (reload_flags) *reload_flags |= RELOAD_MAP;
 		break;
-	case 13:
+	case MAT_SYNTH_EMISSIVE:
 		mat->synth_emissive = bvalue;
 		if (reload_flags) *reload_flags |= RELOAD_EMISSIVE;
 		break;
-	case 14:
+	case MAT_EMISSIVE_THRESHOLD:
 		mat->emissive_threshold = ivalue;
 		if (reload_flags) *reload_flags |= RELOAD_EMISSIVE;
 		break;
-	case 15: mat->specular_factor = fvalue; break;
+	case MAT_SPECULAR_FACTOR: mat->specular_factor = fvalue; break;
 	default:
 		assert(!"unknown PBR MAT attribute index");
 	}

--- a/src/refresh/vkpt/material.h
+++ b/src/refresh/vkpt/material.h
@@ -57,6 +57,7 @@ typedef struct pbr_material_s {
 	int next_frame;
 	bool light_styles;
 	bool bsp_radiance;
+	float default_radiance;
 	imageflags_t image_flags;
 	imagetype_t image_type;
 	bool synth_emissive;


### PR DESCRIPTION
The previous approach decided on the fallback radiance value based on whether the emissive image was fake or not.

However, there are cases where having a synthesized emissive texture to be "always emissive" is beneficial -
e.g. the material was sometimes used as an emissive surface, but in other cases manually placed lights were used (and the "BSP radiance" is 0).
Since we don't support point lights, having the surface take over lighting duties here is helpful.

(If you want a practical example: `textures/dark_1/0text_59` on xatrix' `xswamp` map.)

This PR also contains non-related developer and user quality of life changes.