### PR TITLE
Move identical image detection to filesystem

### DIFF
--- a/src/refresh/images.c
+++ b/src/refresh/images.c
@@ -999,24 +999,6 @@ static int _try_image_format(imageformat_t fmt, image_t *image, int try_src, byt
     if (!data) {
         return len;
     }
-    /* Don't prefer game image if it's identical to the base version
-       Some games (eg rogue) ship image assets that are identical to the
-       baseq2 version.
-       If that is the case, prefer the baseq2 copy - because those may have
-       override image and additional material images!
-     */
-    if (try_src == TRY_IMAGE_SRC_GAME) {
-        byte *data_base;
-        int len_base;
-        len_base = FS_LoadFileFlags(image->name, (void **)&data_base, FS_PATH_BASE);
-        if((len == len_base) && (memcmp(data, data_base, len) == 0)) {
-            // Identical data in game, pretend file doesn't exist
-            FS_FreeFile(data);
-            FS_FreeFile(data_base);
-            return Q_ERR_NOENT;
-        }
-        FS_FreeFile(data_base);
-    }
 
     // decompress the image
     ret = img_loaders[fmt].load(data, len, image, pic);


### PR DESCRIPTION
Previously, a check was added to reject "game" images if it was identical to the "base" image, to allow image overrides to be used in that case (commit cf65b63b5d3a1927565e89933c18cc23cb408811).
However, this clashes a bit with #201, as this detects a texture overriden by the game and so doesn't use the material definition from base. However, at the same time, loading the image from the game will be rejected as it's identical to the base image, leading to no image at all being loaded...

Both aspects are desireable - if a game just copies an image, it should use any high-res override and the material definition from baseq2, but if it's a different image, neither override nor existing material definition should be used.

I opted to approach the issue on a different level - the filesystem. Basically, if we find a file in a .pak that already exists in baseq2, we do the identity check there, and reject files in game .paks that are identical to the baseq2 version.
That way, the material system will never see any duplicated images and just use the baseq2 version and any override and material definition from there.