### PR TITLE
Wayland support

### DIFF
--- a/src/refresh/vkpt/draw.c
+++ b/src/refresh/vkpt/draw.c
@@ -524,8 +524,8 @@ vkpt_draw_create_pipelines()
 		.srcColorBlendFactor = VK_BLEND_FACTOR_SRC_ALPHA,
 		.dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA,
 		.colorBlendOp        = VK_BLEND_OP_ADD,
-		.srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE,
-		.dstAlphaBlendFactor = VK_BLEND_FACTOR_ZERO,
+		.srcAlphaBlendFactor = VK_BLEND_FACTOR_SRC_ALPHA,
+		.dstAlphaBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA,
 		.alphaBlendOp        = VK_BLEND_OP_ADD,
 	};
 

--- a/src/unix/video.c
+++ b/src/unix/video.c
@@ -459,6 +459,13 @@ bool VID_Init(graphics_api_t api)
     }
 
     VID_SetMode();
+
+    /* Explicitly set an "active" state to ensure at least one frame is displayed.
+       Required for Wayland (on Fedora 36/GNOME/NVIDIA driver 510.68.02/SDL 2.0.22) -
+       without that, we never get a window event and thus the activation state sticks
+       at ACT_MINIMIZED, never rendering anything. */
+    CL_Activate(ACT_RESTORED);
+
     return true;
 
 fail:


### PR DESCRIPTION
Adds a bunch of fixes to make Q2RTX run on Wayland. Hopefully fixes #217.

Note that this contains some changes (dcd28504cd3b122e77962ae2152e41a8858d4f84, 269ad3cec304ac230d88f48988b9e7670d69ba6b) that may actually be issues somewhere in the software stack I used (Wayland on NVIDIA) - they may not be necessary for Wayland on AMD, but I can't test that.