### PR TITLE
Store a material's "original" texture dimensions in special members

### DIFF
--- a/src/refresh/vkpt/bsp_mesh.c
+++ b/src/refresh/vkpt/bsp_mesh.c
@@ -169,13 +169,9 @@ create_poly(
 	assert(surf->numsurfedges < max_vertices);
 	
 	float sc[2] = { 1.f, 1.f };
-	if (texinfo->material)
-	{
-		image_t* image_diffuse = texinfo->material->image_base;
-		if (image_diffuse && image_diffuse->width && image_diffuse->height) {
-			sc[0] = 1.0f / (float)image_diffuse->width;
-			sc[1] = 1.0f / (float)image_diffuse->height;
-		}
+	if (texinfo->material && texinfo->material->original_width && texinfo->material->original_height) {
+		sc[0] = 1.0f / (float)texinfo->material->original_width;
+		sc[1] = 1.0f / (float)texinfo->material->original_height;
 	}
 	
 	for (int i = 0; i < surf->numsurfedges; i++) {

--- a/src/refresh/vkpt/bsp_mesh.c
+++ b/src/refresh/vkpt/bsp_mesh.c
@@ -1214,8 +1214,7 @@ collect_light_polys(bsp_mesh_t *wm, bsp_t *bsp, int model_idx, int* num_lights, 
 			continue;
 		}
 
-		image_t* image_diffuse = texinfo->material->image_base;
-		float tex_scale[2] = { 1.0f / image_diffuse->width, 1.0f / image_diffuse->height };
+		float tex_scale[2] = { 1.0f / texinfo->material->original_width, 1.0f / texinfo->material->original_height };
 
 		collect_one_light_poly(bsp, surf, texinfo, model_idx, plane,
 							   tex_scale, min_light_texcoord, max_light_texcoord,

--- a/src/refresh/vkpt/material.c
+++ b/src/refresh/vkpt/material.c
@@ -778,10 +778,14 @@ pbr_material_t* MAT_Find(const char* name, imagetype_t type, imageflags_t flags)
 				if (mat->image_base == R_NOTEXTURE) {
 					mat->image_base = NULL;
 				}
+				if(mat->image_base) {
+					mat->original_width = mat->image_base->width;
+					mat->original_height = mat->image_base->height;
+				}
 			}
 			else
 			{
-				IMG_GetDimensions(name, &mat->image_base->width, &mat->image_base->height);
+				IMG_GetDimensions(name, &mat->original_width, &mat->original_height);
 			}
 		}
 

--- a/src/refresh/vkpt/material.h
+++ b/src/refresh/vkpt/material.h
@@ -41,6 +41,8 @@ typedef struct pbr_material_s {
 	char filename_mask[MAX_QPATH];
 	char source_matfile[MAX_QPATH];
 	uint32_t source_line;
+	int original_width;
+	int original_height;
 	image_t * image_base;
 	image_t * image_normals;
 	image_t * image_emissive;


### PR DESCRIPTION
…instead of the image_base width & height.

This allows to re-use the same "base" texture for multiple materials, even if
the original textures have different dimensions/aspect ratios.

Previously, when doing so, the image's width/height members would be repeatedly
overwritten, and whatever original texture was loaded last, that dimensions
would "win". When the various original textures had different aspect ratios
some texture scaling factors would've been wrong (and the texture appear
distorted).

(This doesn't occur with Q2RTX materials, but I stumbled upon that when creating some custom materials.)