### PR TITLE
Use exact number of cluster lights when assembling light lists in inject_model_lights()

### DIFF
--- a/src/refresh/vkpt/shader/light_lists.h
+++ b/src/refresh/vkpt/shader/light_lists.h
@@ -172,12 +172,6 @@ sample_polygonal_lights(
 		
 		uint current_idx = light_buffer.light_list_lights[n_idx];
 
-		if(current_idx == ~0u)
-		{
-			light_masses[i] = 0;
-			continue;
-		}
-
 		LightPolygon light = get_light_polygon(current_idx);
 
 		float m = projected_tri_area(light.positions, p, n, V, phong_exp, phong_scale, phong_weight);

--- a/src/refresh/vkpt/vertex_buffer.c
+++ b/src/refresh/vkpt/vertex_buffer.c
@@ -555,7 +555,8 @@ inject_model_lights(bsp_mesh_t* bsp_mesh, bsp_t* bsp, int num_model_lights, ligh
 					{
 						int other_cluster = j * 8 + k;
 						int list_index = light_list_tails[other_cluster]++;
-						assert(list_index < light_list_tails[other_cluster + 1]);
+						// assert we're not writing into the space reserved for following cluster
+						assert(list_index < dst_list_offsets[other_cluster + 1]);
 						dst_lists[list_index] = model_light_offset + nlight;
 					}
 				}

--- a/src/refresh/vkpt/vertex_buffer.c
+++ b/src/refresh/vkpt/vertex_buffer.c
@@ -555,7 +555,7 @@ inject_model_lights(bsp_mesh_t* bsp_mesh, bsp_t* bsp, int num_model_lights, ligh
 					{
 						int other_cluster = j * 8 + k;
 						int list_index = light_list_tails[other_cluster]++;
-						assert(list_index < light_list_tails[other_cluster] + 1);
+						assert(list_index < light_list_tails[other_cluster + 1]);
 						dst_lists[list_index] = model_light_offset + nlight;
 					}
 				}


### PR DESCRIPTION
Previously, space was made in the light list offsets that amounted to the maximum
number of lights in a cluster, seen over the lifetime of the map. Unfortunately,
this affect light sampling after a large spike of dynamic lights in a cluster,
possibly resulting in a more 'noisy' appearance - as described in #226.

However, the exact number of lights in a cluster was actually already counted
and can be used to tightly pack the light lists, avoiding the permanent effect
on sampling after a spike of dynamic lights.