### PR TITLE
Also adjust /MD flag in CMAKE_CXX_FLAGS_* variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,14 @@ IF(MSVC)
     # Enable multi-processor compilation when using MSBuild
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /MP")
 
+    # Also adjust C++ flags, needed for 3rd party code
+    replace_msvcrt(CMAKE_CXX_FLAGS_DEBUG "/MTd")
+    replace_msvcrt(CMAKE_CXX_FLAGS_MINSIZEREL "/MT")
+    replace_msvcrt(CMAKE_CXX_FLAGS_RELEASE "/MT")
+    replace_msvcrt(CMAKE_CXX_FLAGS_RELWITHDEBINFO "/MT")
+
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
+
 ELSEIF(CMAKE_SYSTEM_PROCESSOR STREQUAL "AMD64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
 
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -msse -mfpmath=sse")


### PR DESCRIPTION
…to avoid a LNK4098 linker warning.

Specifically, adjusting the C++ flags is needed now b/c oal-soft uses it.