### PR TITLE
 Keep a small history of 'light counts' for each cluster used for sampling lights (for #226)

### DIFF
--- a/src/refresh/vkpt/main.c
+++ b/src/refresh/vkpt/main.c
@@ -334,7 +334,7 @@ vkpt_destroy_all(VkptInitFlags_t destroy_flags)
 	if ((VKPT_INIT_DEFAULT & destroy_flags) == destroy_flags)
 	{
 		destroy_transparency();
-		vkpt_light_stats_destroy();
+		vkpt_light_buffers_destroy();
 	}
 
 	return VK_SUCCESS;
@@ -4098,7 +4098,7 @@ R_BeginRegistration_RTX(const char *name)
 	bsp_world_model = bsp;
 	bsp_mesh_register_textures(bsp);
 	bsp_mesh_create_from_bsp(&vkpt_refdef.bsp_mesh_world, bsp, name);
-	vkpt_light_stats_create(&vkpt_refdef.bsp_mesh_world);
+	vkpt_light_buffers_create(&vkpt_refdef.bsp_mesh_world);
 	_VK(vkpt_vertex_buffer_upload_bsp_mesh(&vkpt_refdef.bsp_mesh_world));
 	vkpt_refdef.bsp_mesh_world_loaded = 1;
 	bsp = NULL;

--- a/src/refresh/vkpt/shader/light_lists.h
+++ b/src/refresh/vkpt/shader/light_lists.h
@@ -153,9 +153,12 @@ sample_polygonal_lights(
 
 	uint list_start = light_buffer.light_list_offsets[list_idx];
 	uint list_end   = light_buffer.light_list_offsets[list_idx + 1];
-	/* The light count we base light selection on may differ from actual count
-	 * to avoid gradient estimation breaking (see GH PR 227) */
-	uint light_count = light_buffer.sample_light_counts[list_idx];
+	/* The light count we base light selection on may differ from the current count
+	 * to avoid gradient estimation breaking (see comment on light_counts_history).
+	 * Obtain the frame number for the historical count from the RNG seed
+	 * (which is also the historical RNG seed) */
+	uint history_index = (rng_seed >> RNG_SEED_SHIFT_FRAME) % LIGHT_COUNT_HISTORY;
+	uint light_count = light_counts_history[history_index].sample_light_counts[list_idx];
 
 	float partitions = ceil(float(light_count) / float(MAX_BRUTEFORCE_SAMPLING));
 	rng.x *= partitions;

--- a/src/refresh/vkpt/shader/path_tracer_rgen.h
+++ b/src/refresh/vkpt/shader/path_tracer_rgen.h
@@ -39,6 +39,14 @@ uniform accelerationStructureEXT topLevelAS[TLAS_COUNT];
 
 #define DESATURATE_ENVIRONMENT_MAP 1
 
+/* RNG seeds contain 'X' and 'Y' values that are computed w/ a modulo BLUE_NOISE_RES,
+ * so the shift values can be chosen to fit BLUE_NOISE_RES - 1
+ * (see generate_rng_seed()) */
+#define RNG_SEED_SHIFT_X        0u
+#define RNG_SEED_SHIFT_Y        8u
+#define RNG_SEED_SHIFT_ISODD    16u
+#define RNG_SEED_SHIFT_FRAME    17u
+
 #define RNG_PRIMARY_OFF_X   0
 #define RNG_PRIMARY_OFF_Y   1
 #define RNG_PRIMARY_APERTURE_X   2
@@ -171,7 +179,8 @@ get_hit_barycentric(RayPayloadGeometry rp)
 float
 get_rng(uint idx)
 {
-	uvec3 p = uvec3(rng_seed, rng_seed >> 10, rng_seed >> 20);
+	uvec3 p = uvec3(rng_seed >> RNG_SEED_SHIFT_X, rng_seed >> RNG_SEED_SHIFT_Y, rng_seed >> RNG_SEED_SHIFT_ISODD);
+	p.z = (p.z >> 1) + (p.z & 1);
 	p.z = (p.z + idx);
 	p &= uvec3(BLUE_NOISE_RES - 1, BLUE_NOISE_RES - 1, NUM_BLUE_NOISE_TEX - 1);
 

--- a/src/refresh/vkpt/shader/primary_rays.rgen
+++ b/src/refresh/vkpt/shader/primary_rays.rgen
@@ -101,9 +101,10 @@ void generate_rng_seed(ivec2 ipos, bool is_odd_checkerboard)
 	uint frame_offset = frame_num / NUM_BLUE_NOISE_TEX;
 
 	rng_seed = 0;
-	rng_seed |= (uint(ipos.x + frame_offset) % BLUE_NOISE_RES) <<  0u;
-	rng_seed |= (uint(ipos.y + (frame_offset << 4)) % BLUE_NOISE_RES) << 10u;
-	rng_seed |= uint(frame_num + uint(is_odd_checkerboard)) << 20;
+	rng_seed |= (uint(ipos.x + frame_offset) % BLUE_NOISE_RES) << RNG_SEED_SHIFT_X;
+	rng_seed |= (uint(ipos.y + (frame_offset << 4)) % BLUE_NOISE_RES) << RNG_SEED_SHIFT_Y;
+	rng_seed |= uint(is_odd_checkerboard) << RNG_SEED_SHIFT_ISODD;
+	rng_seed |= uint(frame_num) << RNG_SEED_SHIFT_FRAME;
 
 	imageStore(IMG_ASVGF_RNG_SEED_A, ipos, uvec4(rng_seed));
 }

--- a/src/refresh/vkpt/shader/vertex_buffer.h
+++ b/src/refresh/vkpt/shader/vertex_buffer.h
@@ -24,6 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #define MAX_LIGHT_LISTS         (1 << 14)
 #define MAX_LIGHT_LIST_NODES    (1 << 19)
+#define LIGHT_COUNT_HISTORY     16
 
 #define MAX_IQM_MATRICES        32768
 
@@ -41,12 +42,13 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define PRIMITIVE_BUFFER_BINDING_IDX 0
 #define POSITION_BUFFER_BINDING_IDX 1
 #define LIGHT_BUFFER_BINDING_IDX 2
-#define IQM_MATRIX_BUFFER_BINDING_IDX 3
-#define READBACK_BUFFER_BINDING_IDX 4
-#define TONE_MAPPING_BUFFER_BINDING_IDX 5
-#define SUN_COLOR_BUFFER_BINDING_IDX 6
-#define SUN_COLOR_UBO_BINDING_IDX 7
-#define LIGHT_STATS_BUFFER_BINDING_IDX 8
+#define LIGHT_COUNTS_HISTORY_BUFFER_BINDING_IDX 3
+#define IQM_MATRIX_BUFFER_BINDING_IDX 4
+#define READBACK_BUFFER_BINDING_IDX 5
+#define TONE_MAPPING_BUFFER_BINDING_IDX 6
+#define SUN_COLOR_BUFFER_BINDING_IDX 7
+#define SUN_COLOR_UBO_BINDING_IDX 8
+#define LIGHT_STATS_BUFFER_BINDING_IDX 9
 
 #define VERTEX_BUFFER_WORLD 0
 #define VERTEX_BUFFER_INSTANCED 1
@@ -94,7 +96,6 @@ BEGIN_SHADER_STRUCT( LightBuffer )
 	vec4 light_polys[MAX_LIGHT_POLYS * LIGHT_POLY_VEC4S];
 	uint light_list_offsets[MAX_LIGHT_LISTS];
 	uint light_list_lights[MAX_LIGHT_LIST_NODES];
-	uint sample_light_counts[MAX_LIGHT_LISTS]; // light count in cluster used for sampling (may differ from actual light count!)
 	float light_styles[MAX_LIGHT_STYLES];
 	uint cluster_debug_mask[MAX_LIGHT_LISTS / 32];
 	uint sky_visibility[MAX_LIGHT_LISTS / 32];
@@ -196,6 +197,20 @@ layout(set = VERTEX_BUFFER_DESC_SET_IDX, binding = POSITION_BUFFER_BINDING_IDX) 
 layout(set = VERTEX_BUFFER_DESC_SET_IDX, binding = LIGHT_BUFFER_BINDING_IDX) readonly buffer LIGHT_BUFFER {
 	LightBuffer light_buffer;
 };
+
+/* History of light count in cluster, used for sampling.
+ * This is used to make gradient estimation work correctly:
+ * "The A-SVGF algorithm uses old random numbers to select lights for a subset of pixels,
+ * and expects to get the same result if the lighting didn't change."
+ * (quoted from discussion on GH PR 227).
+ * One way to achieve this is to also keep a history of light numbers and use that for
+ * sampling "old" data.
+ *
+ * We have multiple buffers b/c we may need to access the history for the current or any previous frame.
+ * That'd be harder to do with a light_buffer member since that is backed by alternating buffers */
+layout(set = VERTEX_BUFFER_DESC_SET_IDX, binding = LIGHT_COUNTS_HISTORY_BUFFER_BINDING_IDX) readonly buffer LIGHT_COUNTS_HISTORY_BUFFER {
+	uint sample_light_counts[];
+} light_counts_history[LIGHT_COUNT_HISTORY];
 
 layout(set = VERTEX_BUFFER_DESC_SET_IDX, binding = IQM_MATRIX_BUFFER_BINDING_IDX) readonly buffer IQM_MATRIX_BUFFER {
 	IqmMatrixBuffer iqm_matrix_buffer;

--- a/src/refresh/vkpt/shader/vertex_buffer.h
+++ b/src/refresh/vkpt/shader/vertex_buffer.h
@@ -94,6 +94,7 @@ BEGIN_SHADER_STRUCT( LightBuffer )
 	vec4 light_polys[MAX_LIGHT_POLYS * LIGHT_POLY_VEC4S];
 	uint light_list_offsets[MAX_LIGHT_LISTS];
 	uint light_list_lights[MAX_LIGHT_LIST_NODES];
+	uint sample_light_counts[MAX_LIGHT_LISTS]; // light count in cluster used for sampling (may differ from actual light count!)
 	float light_styles[MAX_LIGHT_STYLES];
 	uint cluster_debug_mask[MAX_LIGHT_LISTS / 32];
 	uint sky_visibility[MAX_LIGHT_LISTS / 32];

--- a/src/refresh/vkpt/vertex_buffer.c
+++ b/src/refresh/vkpt/vertex_buffer.c
@@ -464,12 +464,10 @@ vkpt_iqm_matrix_buffer_upload_staging(VkCommandBuffer cmd_buf)
 static int local_light_counts[MAX_MAP_LEAFS];
 static int cluster_light_counts[MAX_MAP_LEAFS];
 static int light_list_tails[MAX_MAP_LEAFS];
-static int max_cluster_model_lights[MAX_MAP_LEAFS];
 static int max_model_lights;
 
 void vkpt_light_buffer_reset_counts()
 {
-	memset(max_cluster_model_lights, 0, sizeof(max_cluster_model_lights));
 	max_model_lights = 0;
 }
 
@@ -521,13 +519,6 @@ inject_model_lights(bsp_mesh_t* bsp_mesh, bsp_t* bsp, int num_model_lights, ligh
 				}
 			}
 		}
-	}
-
-	// Update the max light counts per cluster
-
-	for (int c = 0; c < bsp_mesh->num_clusters; c++)
-	{
-		max_cluster_model_lights[c] = max(max_cluster_model_lights[c], cluster_light_counts[c]);
 	}
 
 	// Count the total required list size

--- a/src/refresh/vkpt/vertex_buffer.c
+++ b/src/refresh/vkpt/vertex_buffer.c
@@ -478,6 +478,10 @@ static void copy_bsp_lights(bsp_mesh_t* bsp_mesh, LightBuffer *lbo)
 	// Copy the BSP light lists verbatim
 	memcpy(lbo->light_list_lights, bsp_mesh->cluster_lights, sizeof(uint32_t) * bsp_mesh->cluster_light_offsets[bsp_mesh->num_clusters]);
 	memcpy(lbo->light_list_offsets, bsp_mesh->cluster_light_offsets, sizeof(uint32_t) * (bsp_mesh->num_clusters + 1));
+	for (int c = 0; c < bsp_mesh->num_clusters; c++)
+	{
+		lbo->sample_light_counts[c] = bsp_mesh->cluster_light_offsets[c + 1] - bsp_mesh->cluster_light_offsets[c];
+	}
 }
 
 static void
@@ -527,7 +531,7 @@ inject_model_lights(bsp_mesh_t* bsp_mesh, bsp_t* bsp, int num_model_lights, ligh
 	int required_size = bsp_mesh->cluster_light_offsets[bsp_mesh->num_clusters];
 	for (int c = 0; c < bsp_mesh->num_clusters; c++)
 	{
-		required_size += max_cluster_model_lights[c];
+		required_size += cluster_light_counts[c];
 	}
 
 	// See if we have enough room in the interaction buffer
@@ -553,13 +557,12 @@ inject_model_lights(bsp_mesh_t* bsp_mesh, bsp_t* bsp, int num_model_lights, ligh
 		memcpy(dst_lists + tail, bsp_mesh->cluster_lights + bsp_mesh->cluster_light_offsets[c], sizeof(uint32_t) * original_size);
 		tail += original_size;
 		
-		assert(tail + max_cluster_model_lights[c] < MAX_LIGHT_LIST_NODES);
+		assert(tail + cluster_light_counts[c] < MAX_LIGHT_LIST_NODES);
 		
-		if (max_cluster_model_lights[c] > 0) {
-			memset(dst_lists + tail, 0xff, sizeof(uint32_t) * max_cluster_model_lights[c]);
-		}
 		light_list_tails[c] = tail;
-		tail += max_cluster_model_lights[c];
+		tail += cluster_light_counts[c];
+
+		lbo->sample_light_counts[c] = original_size + max_cluster_model_lights[c];
 	}
 	dst_list_offsets[bsp_mesh->num_clusters] = tail;
 
@@ -575,12 +578,26 @@ inject_model_lights(bsp_mesh_t* bsp_mesh, bsp_t* bsp, int num_model_lights, ligh
 					if (mask[j] & (1 << k))
 					{
 						int other_cluster = j * 8 + k;
-						dst_lists[light_list_tails[other_cluster]++] = model_light_offset + nlight;
+						int list_index = light_list_tails[other_cluster]++;
+						// assert we're not writing into the space reserved for following cluster
+						assert(list_index < dst_list_offsets[other_cluster + 1]);
+						dst_lists[list_index] = model_light_offset + nlight;
 					}
 				}
 			}
 		}
 	}
+
+#if defined(_DEBUG)
+	// Verify tight packing
+	for (int c = 0; c < bsp_mesh->num_clusters; c++)
+	{
+		int list_start = dst_list_offsets[c];
+		int list_end = dst_list_offsets[c + 1];
+		int original_size = bsp_mesh->cluster_light_offsets[c + 1] - bsp_mesh->cluster_light_offsets[c];
+		assert(list_end - list_start == original_size + cluster_light_counts[c]);
+	}
+#endif
 }
 
 static inline void

--- a/src/refresh/vkpt/vkpt.h
+++ b/src/refresh/vkpt/vkpt.h
@@ -259,6 +259,7 @@ typedef struct QVK_s {
 	BufferResource_t            buf_light;
 	BufferResource_t            buf_light_staging[MAX_FRAMES_IN_FLIGHT];
 	BufferResource_t            buf_light_stats[NUM_LIGHT_STATS_BUFFERS];
+	BufferResource_t            buf_light_counts_history[LIGHT_COUNT_HISTORY];
 	
 	BufferResource_t            buf_iqm_matrices;
 	BufferResource_t            buf_iqm_matrices_staging[MAX_FRAMES_IN_FLIGHT];
@@ -627,8 +628,8 @@ VkResult vkpt_vertex_buffer_upload_models();
 void vkpt_light_buffer_reset_counts();
 VkResult vkpt_light_buffer_upload_to_staging(bool render_world, bsp_mesh_t *bsp_mesh, bsp_t* bsp, int num_model_lights, light_poly_t* transformed_model_lights, const float* sky_radiance);
 VkResult vkpt_light_buffer_upload_staging(VkCommandBuffer cmd_buf);
-VkResult vkpt_light_stats_create(bsp_mesh_t *bsp_mesh);
-VkResult vkpt_light_stats_destroy();
+VkResult vkpt_light_buffers_create(bsp_mesh_t *bsp_mesh);
+VkResult vkpt_light_buffers_destroy();
 bool vkpt_model_is_static(const model_t* model);
 const model_vbo_t* vkpt_get_model_vbo(const model_t* model);
 


### PR DESCRIPTION
This is a different approach at addressing #226 after the changes #227 fell short in other scenarios.

I introduced a small _history_ of "cluster light counts" used for light selection.
Now, if light sampling is performed with an "old" RNG seed, we can pull out the light count used at that time from that history we're keeping around (based on the frame number, which is conveniently stored in the RNG seed as well).

This seems to work quite well - it fixes both the problem from #226 but crucially doesn't seem to make things worse if the number of lights in a cluster changes, as previously visible in e.g. the single-player entrance of the `security` map.
(Actually, I'd like to argue that `security` looks _better_ now, as now the "flashing" at the start, due to jumps in the max light count, is completely absent with this change!)

Other changes:
* Since we don't need the "max light count" any more, cluster lights are tightly packed (again)
* The frame number was _almost_ already contained in the RNG seed; I changed it to contain the unadulterated frame number, and for that I packed it a bit "tighter" as well.
