### PR TITLE
Update .gitmodules pointing to the correct SDL2 repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,7 +7,7 @@
     url = https://github.com/curl/curl.git
 [submodule "extern/SDL2"]
     path = extern/SDL2
-    url = https://github.com/spurious/SDL-mirror.git
+    url = https://github.com/libsdl-org/SDL.git
 [submodule "extern/stb"]
 	path = extern/stb
 	url = https://github.com/nothings/stb.git


### PR DESCRIPTION
the old repository wasn't updated since 2021!
that is the correct repository with a lively activity