### PR TITLE
Allow more precise adjustments for DRS frames per second target

### DIFF
--- a/baseq2/q2rtx.menu
+++ b/baseq2/q2rtx.menu
@@ -81,7 +81,7 @@ begin resolution
     style --compact
 	toggle "dynamic resolution scaling" drs_enable
 	blank
-	range -f "%.0f FPS" --status "only effective in dynamic mode" "target frames per second" drs_target 30 200 10
+	range -f "%.0f FPS" --status "only effective in dynamic mode" "target frames per second" drs_target 30 250 1
 	range -f "%.0f%%" --status "only effective in dynamic mode" "minimum scale" drs_minscale 25 100 5
 	range -f "%.0f%%" --status "only effective in dynamic mode" "maximum scale" drs_maxscale 50 150 5
 	blank


### PR DESCRIPTION
FPS can now be adjusted in increments of 1 instead of 10 (useful for displays with "odd" frequencies such as [138 Hz](https://rog.asus.com/us/monitors/above-34-inches/rog-swift-oled-pg42uq-model/), 144 Hz, 165 Hz, …). The maximum FPS for the DRS target is now 250 to accomodate for 240 Hz displays, which is becoming a viable target on high-end GPUs and low settings.

The slider can be dragged with the mouse if you need to change its value quickly.