### PR TITLE
Fix uninitialized VkPhysicalDeviceGroupProperties

### DIFF
--- a/src/refresh/vkpt/main.c
+++ b/src/refresh/vkpt/main.c
@@ -931,6 +931,8 @@ init_vulkan()
 
 	VkDeviceGroupDeviceCreateInfo device_group_create_info;
 	VkPhysicalDeviceGroupProperties device_group_info;
+	device_group_info.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES;
+	device_group_info.pNext = NULL;
 
 	if(num_device_groups > 0) {
 		// we always use the first group


### PR DESCRIPTION
pPhysicalDeviceGroupProperties must be a valid pointer to an array of pPhysicalDeviceGroupCount VkPhysicalDeviceGroupProperties structures, so the caller is responsible for initializing the base fields.

Fix crash with gfxreconstruct. (https://github.com/LunarG/gfxreconstruct/pull/902)