### PR TITLE
Add support for UNORM RGB8 output surface formats 

### DIFF
--- a/src/refresh/vkpt/main.c
+++ b/src/refresh/vkpt/main.c
@@ -554,6 +554,7 @@ static bool pick_surface_format_sdr(VkSurfaceFormatKHR *format, bool *write_srgb
 		bool write_srgb;
 	} acceptable_formats[] = {
 		{VK_FORMAT_R8G8B8A8_SRGB, false}, {VK_FORMAT_B8G8R8A8_SRGB, false},
+		{VK_FORMAT_R8G8B8A8_UNORM, true}, {VK_FORMAT_B8G8R8A8_UNORM, true},
 	};
 
 	for(int i = 0; i < LENGTH(acceptable_formats); i++) {

--- a/src/refresh/vkpt/shader/stretch_pic.frag
+++ b/src/refresh/vkpt/shader/stretch_pic.frag
@@ -26,6 +26,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #extension GL_EXT_nonuniform_qualifier    : enable
 
 layout(constant_id = 0) const uint spec_tone_mapping_hdr = 0;
+layout(constant_id = 1) const uint spec_output_srgb = 0;
 
 #define GLOBAL_TEXTURES_DESC_SET_IDX 1
 #include "global_textures.h"
@@ -55,5 +56,7 @@ main()
 		c.rgb *= ui_hdr_nits / 80;
 		c.rgb = apply_saturation_scale(c.rgb, tm_hdr_saturation_scale * 0.01);
 	}
+	if (spec_output_srgb != 0)
+		c.rgb = linear_to_srgb(c.rgb);
 	outColor = c;
 }

--- a/src/refresh/vkpt/shader/tone_mapping_apply.comp
+++ b/src/refresh/vkpt/shader/tone_mapping_apply.comp
@@ -36,6 +36,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #extension GL_EXT_nonuniform_qualifier    : enable
 
 layout(constant_id = 0) const uint spec_tone_mapping_hdr = 0;
+layout(constant_id = 1) const uint spec_output_srgb = 0;
 
 #include "utils.glsl"
 
@@ -220,5 +221,7 @@ void main()
     }
 
     // Write out to image:
+    if(spec_output_srgb != 0)
+        mapped_color = linear_to_srgb(mapped_color);
     imageStore(IMG_TAA_OUTPUT, ipos, vec4(mapped_color, 0));
 }

--- a/src/refresh/vkpt/vkpt.h
+++ b/src/refresh/vkpt/vkpt.h
@@ -182,6 +182,7 @@ typedef struct QVK_s {
 	VkSwapchainKHR              swap_chain;
 	VkSurfaceFormatKHR          surf_format;
 	bool                        surf_is_hdr;
+	bool                        surf_write_srgb;
 	bool                        surf_vsync;
 	VkPresentModeKHR            present_mode;
 	VkExtent2D                  extent_screen_images;


### PR DESCRIPTION
Accepting them during surface picking is not enough, we also need to do a `linear_to_srgb()` on the color value written for display.

Should help with https://github.com/NVIDIA/Q2RTX/issues/217, as Wayland on NVIDIA currently only exposes `UNORM` output surfaces.