### PR TITLE
Fix primitive overflow with pt_bsp_sky_lights > 1

### DIFF
--- a/src/refresh/vkpt/bsp_mesh.c
+++ b/src/refresh/vkpt/bsp_mesh.c
@@ -344,7 +344,7 @@ enum sky_class_e
 	SKY_CLASS_NODRAW_SKYLIGHT
 };
 
-enum sky_class_e classify_sky(int flags, int surf_flags)
+static inline enum sky_class_e classify_sky(int flags, int surf_flags)
 {
 	if (MAT_IsKind(flags, MATERIAL_KIND_SKY))
 		return SKY_CLASS_MATERIAL;


### PR DESCRIPTION
`NODRAW` surfaces would be double-collected by collecting with `filter_nodraw_sky_lights()`, exceeding the amount of allocated primitives.