### PR TITLE
shader: Rename instances of 'spherical' to 'dynamic' (for lights)

### DIFF
--- a/src/refresh/vkpt/shader/path_tracer_rgen.h
+++ b/src/refresh/vkpt/shader/path_tracer_rgen.h
@@ -682,10 +682,10 @@ get_direct_illumination(
 	specular = vec3(0);
 
 	vec3 pos_on_light_polygonal;
-	vec3 pos_on_light_spherical;
+	vec3 pos_on_light_dynamic;
 
 	vec3 contrib_polygonal = vec3(0);
-	vec3 contrib_spherical = vec3(0);
+	vec3 contrib_dynamic = vec3(0);
 
 	float alpha = square(roughness);
 	float phong_exp = RoughnessSquareToSpecPower(alpha);
@@ -738,27 +738,27 @@ get_direct_illumination(
 			normal,
 			geo_normal,
 			max_solid_angle,
-			pos_on_light_spherical,
-			contrib_spherical,
+			pos_on_light_dynamic,
+			contrib_dynamic,
 			rng);
 	}
 
 	float spec_polygonal = phong(normal, normalize(pos_on_light_polygonal - position), view_direction, phong_exp) * phong_scale;
-	float spec_spherical = phong(normal, normalize(pos_on_light_spherical - position), view_direction, phong_exp) * phong_scale;
+	float spec_dynamic = phong(normal, normalize(pos_on_light_dynamic - position), view_direction, phong_exp) * phong_scale;
 
 	float l_polygonal  = luminance(abs(contrib_polygonal)) * mix(1, spec_polygonal, phong_weight);
-	float l_spherical = luminance(abs(contrib_spherical)) * mix(1, spec_spherical, phong_weight);
-	float l_sum = l_polygonal + l_spherical;
+	float l_dynamic = luminance(abs(contrib_dynamic)) * mix(1, spec_dynamic, phong_weight);
+	float l_sum = l_polygonal + l_dynamic;
 
 	bool null_light = (l_sum == 0);
 
-	float w = null_light ? 0.5 : l_polygonal / (l_polygonal + l_spherical);
+	float w = null_light ? 0.5 : l_polygonal / (l_polygonal + l_dynamic);
 
 	float rng2 = get_rng(RNG_NEE_LIGHT_TYPE(bounce));
 	is_polygonal = (rng2 < w);
 	vis = is_polygonal ? (1 / w) : (1 / (1 - w));
-	vec3 pos_on_light = null_light ? position : (is_polygonal ? pos_on_light_polygonal : pos_on_light_spherical);
-	vec3 contrib = is_polygonal ? contrib_polygonal : contrib_spherical;
+	vec3 pos_on_light = null_light ? position : (is_polygonal ? pos_on_light_polygonal : pos_on_light_dynamic);
+	vec3 contrib = is_polygonal ? contrib_polygonal : contrib_dynamic;
 
 	Ray shadow_ray = get_shadow_ray(position - view_direction * 0.01, pos_on_light, 0);
 	


### PR DESCRIPTION
Spherical lights used to be the only type of dynamic lights, but after spot light support has been added, they have been renamed to 'dynamic lights' in the code. Well, except these places.

(Only identifiers have been changed, no changes to logic.)