### PR TITLE
GH workflow: Add prerequisites to allow Wayland support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
         submodules: true
 
     - name: Install prerequisites
-      run: sudo apt-get update && sudo apt-get install libopenal-dev mesa-common-dev libxrandr-dev libvulkan-dev
+      run: sudo apt-get update && sudo apt-get install libdecor-0-dev libegl-dev libopenal-dev libvulkan-dev libwayland-dev libxkbcommon-dev libxrandr-dev mesa-common-dev
       
     - name: Configure
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCONFIG_BUILD_GLSLANG=ON


### PR DESCRIPTION
This change was originally part of #221 earlier (discussed in https://github.com/NVIDIA/Q2RTX/pull/221#issuecomment-1124440829), but was somehow lost along the way.
Anyway, (re-)adding those dependencies makes the workflow builds support Wayland.