### PR TITLE
Apply distortion effect on TRANS walls

### DIFF
--- a/src/refresh/vkpt/main.c
+++ b/src/refresh/vkpt/main.c
@@ -1594,7 +1594,7 @@ static pbr_material_t const * get_mesh_material(const entity_t* entity, const ma
 }
 
 static uint32_t compute_mesh_material_flags(const entity_t* entity, const model_t* model,
-	const maliasmesh_t* mesh, bool is_viewer_weapon, bool is_double_sided)
+	const maliasmesh_t* mesh, bool is_viewer_weapon, bool is_double_sided, float alpha)
 {
 	pbr_material_t const* material = get_mesh_material(entity, mesh);
 
@@ -1611,6 +1611,9 @@ static uint32_t compute_mesh_material_flags(const entity_t* entity, const model_
 
 	if (MAT_IsKind(material_id, MATERIAL_KIND_CHROME))
 		material_id = MAT_SetKind(material_id, MATERIAL_KIND_CHROME_MODEL);
+
+	if (MAT_IsKind(material_id, MATERIAL_KIND_TRANSPARENT) || (MAT_IsKind(material_id, MATERIAL_KIND_REGULAR) && (alpha < 1.0f)))
+		material_id = MAT_SetKind(material_id, MATERIAL_KIND_TRANSP_MODEL);
 
 	if (model->model_class == MCLASS_EXPLOSION)
 	{
@@ -1958,7 +1961,7 @@ static void process_regular_entity(
 			continue;
 		}
 
-		uint32_t material_id = compute_mesh_material_flags(entity, model, mesh, is_viewer_weapon, is_double_sided);
+		uint32_t material_id = compute_mesh_material_flags(entity, model, mesh, is_viewer_weapon, is_double_sided, alpha);
 
 		if (!material_id)
 			continue;

--- a/src/refresh/vkpt/material.c
+++ b/src/refresh/vkpt/material.c
@@ -1302,7 +1302,8 @@ bool MAT_IsTransparent(uint32_t material)
 	return MAT_IsKind(material, MATERIAL_KIND_SLIME)
 		|| MAT_IsKind(material, MATERIAL_KIND_WATER)
 		|| MAT_IsKind(material, MATERIAL_KIND_GLASS)
-		|| MAT_IsKind(material, MATERIAL_KIND_TRANSPARENT);
+		|| MAT_IsKind(material, MATERIAL_KIND_TRANSPARENT)
+		|| MAT_IsKind(material, MATERIAL_KIND_TRANSP_MODEL);
 }
 
 bool MAT_IsMasked(uint32_t material)

--- a/src/refresh/vkpt/shader/constants.h
+++ b/src/refresh/vkpt/shader/constants.h
@@ -64,10 +64,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define MATERIAL_KIND_SKY            0x70000000
 #define MATERIAL_KIND_INVISIBLE      0x80000000
 #define MATERIAL_KIND_EXPLOSION      0x90000000
-#define MATERIAL_KIND_TRANSPARENT    0xa0000000
+#define MATERIAL_KIND_TRANSPARENT    0xa0000000 // Transparent walls. Have a distortion effect applied.
 #define MATERIAL_KIND_SCREEN         0xb0000000
 #define MATERIAL_KIND_CAMERA         0xc0000000
 #define MATERIAL_KIND_CHROME_MODEL   0xd0000000
+#define MATERIAL_KIND_TRANSP_MODEL   0xe0000000 // Transparent models. No distortion, just "see through".
 
 #define MATERIAL_FLAG_LIGHT          0x08000000
 #define MATERIAL_FLAG_HANDEDNESS     0x02000000

--- a/src/refresh/vkpt/shader/path_tracer_rgen.h
+++ b/src/refresh/vkpt/shader/path_tracer_rgen.h
@@ -215,7 +215,8 @@ is_glass(uint material)
 bool
 is_transparent(uint material)
 {
-	return (material & MATERIAL_KIND_MASK) == MATERIAL_KIND_TRANSPARENT;
+	uint kind = material & MATERIAL_KIND_MASK;
+	return kind == MATERIAL_KIND_TRANSPARENT || kind == MATERIAL_KIND_TRANSP_MODEL;
 }
 
 bool

--- a/src/refresh/vkpt/shader/primary_rays.rgen
+++ b/src/refresh/vkpt/shader/primary_rays.rgen
@@ -302,6 +302,8 @@ main()
 	}
 
 	uint material_id = triangle.material_id;
+	// will be used in case of transparency, to retain difference between TRANSPARENT and TRANSP_MODEL
+	uint orig_material_kind = material_id & MATERIAL_KIND_MASK;
 
 	if((is_chrome(material_id) || is_screen(material_id) || is_camera(material_id)) && primary_roughness >= MAX_MIRROR_ROUGHNESS || is_transparent(material_id))
 	{
@@ -379,7 +381,7 @@ main()
 		else
 		{
 			// This field goes through the surface.
-			material_id = (material_id & ~MATERIAL_KIND_MASK) | MATERIAL_KIND_TRANSPARENT;
+			material_id = (material_id & ~MATERIAL_KIND_MASK) | orig_material_kind;
 			throughput *= 1.0 - triangle.alpha;
 		}
 	}

--- a/src/refresh/vkpt/shader/primary_rays.rgen
+++ b/src/refresh/vkpt/shader/primary_rays.rgen
@@ -303,7 +303,8 @@ main()
 
 	uint material_id = triangle.material_id;
 	// will be used in case of transparency, to retain difference between TRANSPARENT and TRANSP_MODEL
-	uint orig_material_kind = material_id & MATERIAL_KIND_MASK;
+	// default to TRANSP_MODEL so transparency on other material flags works (eg gunalpha)
+	uint transparency_kind = (material_id & MATERIAL_KIND_MASK) == MATERIAL_KIND_TRANSPARENT ? MATERIAL_KIND_TRANSPARENT : MATERIAL_KIND_TRANSP_MODEL;
 
 	if((is_chrome(material_id) || is_screen(material_id) || is_camera(material_id)) && primary_roughness >= MAX_MIRROR_ROUGHNESS || is_transparent(material_id))
 	{
@@ -381,7 +382,7 @@ main()
 		else
 		{
 			// This field goes through the surface.
-			material_id = (material_id & ~MATERIAL_KIND_MASK) | orig_material_kind;
+			material_id = (material_id & ~MATERIAL_KIND_MASK) | transparency_kind;
 			throughput *= 1.0 - triangle.alpha;
 		}
 	}

--- a/src/refresh/vkpt/shader/primary_rays.rgen
+++ b/src/refresh/vkpt/shader/primary_rays.rgen
@@ -303,7 +303,7 @@ main()
 
 	uint material_id = triangle.material_id;
 	// will be used in case of transparency, to retain difference between TRANSPARENT and TRANSP_MODEL
-	// default to TRANSP_MODEL so transparency on other material flags works (eg gunalpha)
+	// default to TRANSP_MODEL so transparency on other material kind works (needed for eg gunalpha)
 	uint transparency_kind = (material_id & MATERIAL_KIND_MASK) == MATERIAL_KIND_TRANSPARENT ? MATERIAL_KIND_TRANSPARENT : MATERIAL_KIND_TRANSP_MODEL;
 
 	if((is_chrome(material_id) || is_screen(material_id) || is_camera(material_id)) && primary_roughness >= MAX_MIRROR_ROUGHNESS || is_transparent(material_id))

--- a/src/refresh/vkpt/shader/reflect_refract.rgen
+++ b/src/refresh/vkpt/shader/reflect_refract.rgen
@@ -666,7 +666,7 @@ main()
 	primary_is_weapon = false;
 
 	// will be used in case of transparency, to retain difference between TRANSPARENT and TRANSP_MODEL
-	// default to TRANSP_MODEL so transparency on other material flags works (eg gunalpha)
+	// default to TRANSP_MODEL so transparency on other material kind works (needed for eg gunalpha)
 	uint transparency_kind = (material_id & MATERIAL_KIND_MASK) == MATERIAL_KIND_TRANSPARENT ? MATERIAL_KIND_TRANSPARENT : MATERIAL_KIND_TRANSP_MODEL;
 
 	if((is_chrome(material_id) || is_screen(material_id) || is_camera(material_id)) && primary_roughness >= MAX_MIRROR_ROUGHNESS || is_transparent(material_id))

--- a/src/refresh/vkpt/shader/reflect_refract.rgen
+++ b/src/refresh/vkpt/shader/reflect_refract.rgen
@@ -666,7 +666,8 @@ main()
 	primary_is_weapon = false;
 
 	// will be used in case of transparency, to retain difference between TRANSPARENT and TRANSP_MODEL
-	uint orig_material_kind = material_id & MATERIAL_KIND_MASK;
+	// default to TRANSP_MODEL so transparency on other material flags works (eg gunalpha)
+	uint transparency_kind = (material_id & MATERIAL_KIND_MASK) == MATERIAL_KIND_TRANSPARENT ? MATERIAL_KIND_TRANSPARENT : MATERIAL_KIND_TRANSP_MODEL;
 
 	if((is_chrome(material_id) || is_screen(material_id) || is_camera(material_id)) && primary_roughness >= MAX_MIRROR_ROUGHNESS || is_transparent(material_id))
 	{
@@ -731,7 +732,7 @@ main()
 			else
 			{
 				// This field goes through the surface.
-				material_id = (material_id & ~MATERIAL_KIND_MASK) | orig_material_kind;
+				material_id = (material_id & ~MATERIAL_KIND_MASK) | transparency_kind;
 				throughput *= 1.0 - triangle.alpha;
 			}
 		}
@@ -742,7 +743,7 @@ main()
 			uint primary_instance_index = imageLoad(IMG_PT_VISBUF_PRIM_A, ipos).x;
 			if (primary_instance_index == triangle.instance_index)
 			{
-				material_id = (material_id & ~MATERIAL_KIND_MASK) | orig_material_kind;
+				material_id = (material_id & ~MATERIAL_KIND_MASK) | transparency_kind;
 			}
 		}
 	}

--- a/src/refresh/vkpt/shader/reflect_refract.rgen
+++ b/src/refresh/vkpt/shader/reflect_refract.rgen
@@ -303,6 +303,26 @@ main()
 		// One ray stops at the primary surface, the other goes through it.
 
 		correct_motion_vector = 2;
+
+		// Apply a very light distortion effect to TRANS walls (but not models with alpha)
+		if((material_id & MATERIAL_KIND_MASK) == MATERIAL_KIND_TRANSPARENT)
+		{
+			// This is the ray that goes through.
+			float index_of_refraction = 1.005;
+
+			// Assume infinitely thin glass, compute dual refraction:
+			// ray goes into the glass with the normal map, goes out on the other side which is flat.
+			vec3 refracted1 = refract(direction, normal, 1.0 / index_of_refraction);
+			vec3 refracted2 = refract(refracted1, geo_normal, index_of_refraction);
+
+			if(length(refracted2) > 0)
+			{
+				// If this refraction path is possible, follow it.
+				// Otherwise, just go through the glass unaffected.
+				direction = refracted2;
+				include_player_model = false; // hide the player model from refractions
+			}
+		}
 	}
 	else
 	{
@@ -645,6 +665,9 @@ main()
 
 	primary_is_weapon = false;
 
+	// will be used in case of transparency, to retain difference between TRANSPARENT and TRANSP_MODEL
+	uint orig_material_kind = material_id & MATERIAL_KIND_MASK;
+
 	if((is_chrome(material_id) || is_screen(material_id) || is_camera(material_id)) && primary_roughness >= MAX_MIRROR_ROUGHNESS || is_transparent(material_id))
 	{
 		material_id = (material_id & ~MATERIAL_KIND_MASK) | MATERIAL_KIND_REGULAR;
@@ -708,7 +731,7 @@ main()
 			else
 			{
 				// This field goes through the surface.
-				material_id = (material_id & ~MATERIAL_KIND_MASK) | MATERIAL_KIND_TRANSPARENT;
+				material_id = (material_id & ~MATERIAL_KIND_MASK) | orig_material_kind;
 				throughput *= 1.0 - triangle.alpha;
 			}
 		}
@@ -719,7 +742,7 @@ main()
 			uint primary_instance_index = imageLoad(IMG_PT_VISBUF_PRIM_A, ipos).x;
 			if (primary_instance_index == triangle.instance_index)
 			{
-				material_id = (material_id & ~MATERIAL_KIND_MASK) | MATERIAL_KIND_TRANSPARENT;
+				material_id = (material_id & ~MATERIAL_KIND_MASK) | orig_material_kind;
 			}
 		}
 	}


### PR DESCRIPTION
...to make them look a bit more interesting.
Some maps use a TRANS flag with various "random" textures which are not intended to be used as "glass" and don't have the GLASS material kind set, and even with that, may look bad due to their colors not working well as "throughput" colors.
So keep them acting as a "non-physical see-through material", but apply some distortion to the "through" ray.

Before:
![quake001](https://github.com/NVIDIA/Q2RTX/assets/4117506/370ad7c9-2292-4832-978c-5b719c928f83)
After:
![quake000](https://github.com/NVIDIA/Q2RTX/assets/4117506/cd8b363e-5bd6-4650-b712-052b3dcf0d3e)
(Location is in xatrix' xcompnd1 map.)