### PR TITLE
Sync with Q2PRO: Q_assert() and error codes

### DIFF
--- a/inc/common/error.h
+++ b/inc/common/error.h
@@ -58,20 +58,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define Q_ERR_NOT_COHERENT      _Q_ERR(22)  // Coherency check failed
 #define Q_ERR_BAD_COMPRESSION   _Q_ERR(23)  // Bad compression method
 
-// These values directly map to system errno.
-#define Q_ERR_NOENT             Q_ERR(ENOENT)
-#define Q_ERR_NAMETOOLONG       Q_ERR(ENAMETOOLONG)
-#define Q_ERR_INVAL             Q_ERR(EINVAL)
-#define Q_ERR_NOSYS             Q_ERR(ENOSYS)
-#define Q_ERR_SPIPE             Q_ERR(ESPIPE)
-#define Q_ERR_FBIG              Q_ERR(EFBIG)
-#define Q_ERR_ISDIR             Q_ERR(EISDIR)
-#define Q_ERR_AGAIN             Q_ERR(EAGAIN)
-#define Q_ERR_MFILE             Q_ERR(EMFILE)
-#define Q_ERR_EXIST             Q_ERR(EEXIST)
-#define Q_ERR_BADF              Q_ERR(EBADF)
-#define Q_ERR_PERM              Q_ERR(EPERM)
-
 // This macro converts system errno into quake error value.
 #define Q_ERRNO                 Q_ErrorNumber()
 

--- a/inc/common/error.h
+++ b/inc/common/error.h
@@ -29,34 +29,34 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define Q_ERR(e)        (e > -1 || e < -ERRNO_MAX ? -ERRNO_MAX : e)
 #endif
 
-#define _Q_ERR(e)       (-ERRNO_MAX - e)
+#define Q_ERR_(e)       (-ERRNO_MAX - e)
 
 // These values are extensions to system errno.
 #define Q_ERR_SUCCESS           0           // Success
-#define Q_ERR_FAILURE           _Q_ERR(0)   // Unspecified error
-#define Q_ERR_UNKNOWN_FORMAT    _Q_ERR(1)   // Unknown file format
-#define Q_ERR_INVALID_FORMAT    _Q_ERR(2)   // Invalid file format
-#define Q_ERR_BAD_EXTENT        _Q_ERR(3)   // Bad lump extent
-#define Q_ERR_ODD_SIZE          _Q_ERR(4)   // Odd lump size
-#define Q_ERR_TOO_MANY          _Q_ERR(5)   // Too many elements
-#define Q_ERR_TOO_FEW           _Q_ERR(6)   // Too few elements
-#define Q_ERR_BAD_INDEX         _Q_ERR(7)   // Index out of range
-#define Q_ERR_INVALID_PATH      _Q_ERR(8)   // Invalid quake path
-#define Q_ERR_NAMETOOSHORT      _Q_ERR(9)   // File name too short
-#define Q_ERR_UNEXPECTED_EOF    _Q_ERR(10)  // Unexpected end of file
-#define Q_ERR_FILE_TOO_SMALL    _Q_ERR(11)  // File too small
-#define Q_ERR_FILE_NOT_REGULAR  _Q_ERR(12)  // Not a regular file
-#define Q_ERR_BAD_RLE_PACKET    _Q_ERR(13)  // Bad run length packet
-#define Q_ERR_STRING_TRUNCATED  _Q_ERR(14)  // String truncation avoided
-#define Q_ERR_RUNAWAY_LOOP      _Q_ERR(15)  // Runaway loop avoided
-#define Q_ERR_INFINITE_LOOP     _Q_ERR(16)  // Infinite loop avoided
-#define Q_ERR_LIBRARY_ERROR     _Q_ERR(17)  // Library error
-#define Q_ERR_OUT_OF_SLOTS      _Q_ERR(18)  // Out of slots
-#define Q_ERR_BAD_ALIGN         _Q_ERR(19)  // Bad lump alignment
-#define Q_ERR_INFLATE_FAILED    _Q_ERR(20)  // Inflate failed
-#define Q_ERR_DEFLATE_FAILED    _Q_ERR(21)  // Deflate failed
-#define Q_ERR_NOT_COHERENT      _Q_ERR(22)  // Coherency check failed
-#define Q_ERR_BAD_COMPRESSION   _Q_ERR(23)  // Bad compression method
+#define Q_ERR_FAILURE           Q_ERR_(0)   // Unspecified error
+#define Q_ERR_UNKNOWN_FORMAT    Q_ERR_(1)   // Unknown file format
+#define Q_ERR_INVALID_FORMAT    Q_ERR_(2)   // Invalid file format
+#define Q_ERR_BAD_EXTENT        Q_ERR_(3)   // Bad lump extent
+#define Q_ERR_ODD_SIZE          Q_ERR_(4)   // Odd lump size
+#define Q_ERR_TOO_MANY          Q_ERR_(5)   // Too many elements
+#define Q_ERR_TOO_FEW           Q_ERR_(6)   // Too few elements
+#define Q_ERR_BAD_INDEX         Q_ERR_(7)   // Index out of range
+#define Q_ERR_INVALID_PATH      Q_ERR_(8)   // Invalid quake path
+#define Q_ERR_NAMETOOSHORT      Q_ERR_(9)   // File name too short
+#define Q_ERR_UNEXPECTED_EOF    Q_ERR_(10)  // Unexpected end of file
+#define Q_ERR_FILE_TOO_SMALL    Q_ERR_(11)  // File too small
+#define Q_ERR_FILE_NOT_REGULAR  Q_ERR_(12)  // Not a regular file
+#define Q_ERR_BAD_RLE_PACKET    Q_ERR_(13)  // Bad run length packet
+#define Q_ERR_STRING_TRUNCATED  Q_ERR_(14)  // String truncation avoided
+#define Q_ERR_RUNAWAY_LOOP      Q_ERR_(15)  // Runaway loop avoided
+#define Q_ERR_INFINITE_LOOP     Q_ERR_(16)  // Infinite loop avoided
+#define Q_ERR_LIBRARY_ERROR     Q_ERR_(17)  // Library error
+#define Q_ERR_OUT_OF_SLOTS      Q_ERR_(18)  // Out of slots
+#define Q_ERR_BAD_ALIGN         Q_ERR_(19)  // Bad lump alignment
+#define Q_ERR_INFLATE_FAILED    Q_ERR_(20)  // Inflate failed
+#define Q_ERR_DEFLATE_FAILED    Q_ERR_(21)  // Deflate failed
+#define Q_ERR_NOT_COHERENT      Q_ERR_(22)  // Coherency check failed
+#define Q_ERR_BAD_COMPRESSION   Q_ERR_(23)  // Bad compression method
 
 // This macro converts system errno into quake error value.
 #define Q_ERRNO                 Q_ErrorNumber()

--- a/inc/common/files.h
+++ b/inc/common/files.h
@@ -121,7 +121,7 @@ qhandle_t FS_EasyOpenFile(char *buf, size_t size, unsigned mode,
                           const char *dir, const char *name, const char *ext);
 
 #define FS_FileExistsEx(path, flags) \
-    (FS_LoadFileEx(path, NULL, flags, TAG_FREE) != Q_ERR_NOENT)
+    (FS_LoadFileEx(path, NULL, flags, TAG_FREE) != Q_ERR(ENOENT))
 #define FS_FileExists(path) \
     FS_FileExistsEx(path, 0)
 

--- a/inc/shared/shared.h
+++ b/inc/shared/shared.h
@@ -113,6 +113,9 @@ q_noreturn q_printf(2, 3);
 #define Com_WPrintf(...) Com_LPrintf(PRINT_WARNING, __VA_ARGS__)
 #define Com_EPrintf(...) Com_LPrintf(PRINT_ERROR, __VA_ARGS__)
 
+#define Q_assert(expr) \
+    do { if (!(expr)) Com_Error(ERR_FATAL, "%s: assertion `%s' failed", __func__, #expr); } while (0)
+
 // game print flags
 #define PRINT_LOW           0       // pickup messages
 #define PRINT_MEDIUM        1       // death messages

--- a/src/client/ascii.c
+++ b/src/client/ascii.c
@@ -316,7 +316,7 @@ static void SCR_ScoreShot_f(void)
             if (f) {
                 break;
             }
-            if (ret != Q_ERR_EXIST) {
+            if (ret != Q_ERR(EEXIST)) {
                 Com_EPrintf("Couldn't exclusively open %s for writing: %s\n",
                             path, Q_ErrorString(ret));
                 return;

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -988,7 +988,7 @@ void HTTP_CleanupDownloads(void);
 #define HTTP_Init()                     (void)0
 #define HTTP_Shutdown()                 (void)0
 #define HTTP_SetServer(url)             (void)0
-#define HTTP_QueueDownload(path, type)  Q_ERR_NOSYS
+#define HTTP_QueueDownload(path, type)  Q_ERR(ENOSYS)
 #define HTTP_RunDownloads()             (void)0
 #define HTTP_CleanupDownloads()         (void)0
 #endif

--- a/src/client/download.c
+++ b/src/client/download.c
@@ -375,9 +375,9 @@ static bool inflate_udp_download(byte *data, int size, int decompressed_size)
     int         ret;
 
     // initialize stream if not done yet
-    if (z->state == NULL && inflateInit2(z, -MAX_WBITS) != Z_OK)
-        Com_Error(ERR_FATAL, "%s: inflateInit2() failed", __func__);
-    
+    if (!z->state)
+        Q_assert(inflateInit2(z, -MAX_WBITS) == Z_OK);
+
     if (!size)
         return true;
 

--- a/src/client/download.c
+++ b/src/client/download.c
@@ -55,7 +55,7 @@ int CL_QueueDownload(const char *path, dltype_t type)
         // avoid sending duplicate requests
         if (!FS_pathcmp(path, q->path)) {
             Com_DPrintf("%s: %s [DUP]\n", __func__, path);
-            return Q_ERR_EXIST;
+            return Q_ERR(EEXIST);
         }
     }
 
@@ -193,7 +193,7 @@ void CL_LoadDownloadIgnores(void)
     // load new list
     len = FS_LoadFile(CL_DOWNLOAD_IGNORES, (void **)&raw);
     if (!raw) {
-        if (len != Q_ERR_NOENT)
+        if (len != Q_ERR(ENOENT))
             Com_EPrintf("Couldn't load %s: %s\n",
                         CL_DOWNLOAD_IGNORES, Q_ErrorString(len));
         return;
@@ -273,7 +273,7 @@ static bool start_udp_download(dlqueue_t *q)
         else
 #endif
             CL_ClientCommand(va("download \"%s\" %d", q->path, (int)ret));
-    } else if (ret == Q_ERR_NOENT) {  // it doesn't exist
+    } else if (ret == Q_ERR(ENOENT)) {  // it doesn't exist
         Com_DPrintf("[UDP] Downloading %s\n", q->path);
 #if USE_ZLIB
         if (cls.serverProtocol == PROTOCOL_VERSION_R1Q2)
@@ -519,7 +519,7 @@ static int check_file_len(const char *path, size_t len, dltype_t type)
 
     // check for oversize path
     if (len >= MAX_QPATH)
-        return Q_ERR_NAMETOOLONG;
+        return Q_ERR(ENAMETOOLONG);
 
     // normalize path
     len = FS_NormalizePath(buffer, path);
@@ -550,17 +550,17 @@ static int check_file_len(const char *path, size_t len, dltype_t type)
 
     if (FS_FileExists(buffer))
         // it exists, no need to download
-        return Q_ERR_EXIST;
+        return Q_ERR(EEXIST);
 
     if (valid == PATH_MIXED_CASE)
         // convert to lower case to make download server happy
         Q_strlwr(buffer);
 
     if (CL_IgnoreDownload(buffer))
-        return Q_ERR_PERM;
+        return Q_ERR(EPERM);
 
     ret = HTTP_QueueDownload(buffer, type);
-    if (ret != Q_ERR_NOSYS)
+    if (ret != Q_ERR(ENOSYS))
         return ret;
 
     // queue and start legacy UDP download

--- a/src/client/http.c
+++ b/src/client/http.c
@@ -526,7 +526,7 @@ void HTTP_SetServer(const char *url)
 HTTP_QueueDownload
 
 Called from the precache check to queue a download. Return value of
-Q_ERR_NOSYS will cause standard UDP downloading to be used instead.
+Q_ERR(ENOSYS) will cause standard UDP downloading to be used instead.
 ===============
 */
 int HTTP_QueueDownload(const char *path, dltype_t type)
@@ -538,7 +538,7 @@ int HTTP_QueueDownload(const char *path, dltype_t type)
 
     // no http server (or we got booted)
     if (!curl_multi)
-        return Q_ERR_NOSYS;
+        return Q_ERR(ENOSYS);
 
     // first download queued, so we want the mod filelist
     need_list = LIST_EMPTY(&cls.download.queue);

--- a/src/client/keys.c
+++ b/src/client/keys.c
@@ -622,9 +622,7 @@ void Key_Event(unsigned key, bool down, unsigned time)
     char    *kb;
     char    cmd[MAX_STRING_CHARS];
 
-    if (key >= 256) {
-        Com_Error(ERR_FATAL, "%s: bad key", __func__);
-    }
+    Q_assert(key < 256);
 
     Com_DDDPrintf("%u: %c%s\n", time,
                   down ? '+' : '-', Key_KeynumToString(key));

--- a/src/client/locs.c
+++ b/src/client/locs.c
@@ -70,7 +70,7 @@ void LOC_LoadLocations(void)
 
     ret = FS_LoadFile(path, (void **)&buffer);
     if (!buffer) {
-        if (ret != Q_ERR_NOENT) {
+        if (ret != Q_ERR(ENOENT)) {
             Com_EPrintf("Couldn't load %s: %s\n", path, Q_ErrorString(ret));
         }
         return;

--- a/src/client/main.c
+++ b/src/client/main.c
@@ -3370,9 +3370,7 @@ void CL_Init(void)
     IN_Init();
 
 #if USE_ZLIB
-    if (inflateInit2(&cls.z, -MAX_WBITS) != Z_OK) {
-        Com_Error(ERR_FATAL, "%s: inflateInit2() failed", __func__);
-    }
+    Q_assert(inflateInit2(&cls.z, -MAX_WBITS) == Z_OK);
 #endif
 
     CL_LoadDownloadIgnores();

--- a/src/client/ui/menu.c
+++ b/src/client/ui/menu.c
@@ -43,9 +43,7 @@ Action_Init
 */
 static void Action_Init(menuAction_t *a)
 {
-    if (!a->generic.name) {
-        Com_Error(ERR_FATAL, "Action_Init: NULL a->generic.name");
-    }
+    Q_assert(a->generic.name);
 
     if ((a->generic.uiFlags & UI_CENTER) != UI_CENTER) {
         a->generic.x += RCOLUMN_OFFSET;
@@ -104,9 +102,7 @@ Static_Init
 */
 static void Static_Init(menuStatic_t *s)
 {
-    if (!s->generic.name) {
-        Com_Error(ERR_FATAL, "Static_Init: NULL s->generic.name");
-    }
+    Q_assert(s->generic.name);
 
     if (!s->maxChars) {
         s->maxChars = MAX_STRING_CHARS;
@@ -195,9 +191,7 @@ static void Keybind_Init(menuKeybind_t *k)
 {
     size_t len;
 
-    if (!k->generic.name) {
-        Com_Error(ERR_FATAL, "Keybind_Init: NULL k->generic.name");
-    }
+    Q_assert(k->generic.name);
 
     k->generic.uiFlags &= ~(UI_LEFT | UI_RIGHT);
 
@@ -1784,10 +1778,8 @@ Menu_AddItem
 */
 void Menu_AddItem(menuFrameWork_t *menu, void *item)
 {
-    if (menu->nitems >= MAX_MENU_ITEMS) {
-        Com_Error(ERR_FATAL, "Menu_AddItem: too many items");
-    }
-    
+    Q_assert(menu->nitems < MAX_MENU_ITEMS);
+
     if (!menu->nitems) {
         menu->items = UI_Malloc(MIN_MENU_ITEMS * sizeof(void *));
     } else {
@@ -1889,8 +1881,7 @@ void Menu_Init(menuFrameWork_t *menu)
             Bitmap_Init(item);
             break;
         default:
-            Com_Error(ERR_FATAL, "Menu_Init: unknown item type");
-            break;
+            Q_assert(!"unknown item type");
         }
     }
 
@@ -2288,8 +2279,7 @@ void Menu_Draw(menuFrameWork_t *menu)
             Bitmap_Draw(item);
             break;
         default:
-            Com_Error(ERR_FATAL, "Menu_Draw: unknown item type");
-            break;
+            Q_assert(!"unknown item type");
         }
 
         if (ui_debug->integer) {

--- a/src/client/ui/script.c
+++ b/src/client/ui/script.c
@@ -677,7 +677,7 @@ static bool Parse_File(const char *path, int depth)
 
     ret = FS_LoadFile(path, (void **)&raw);
     if (!raw) {
-        if (ret != Q_ERR_NOENT || depth) {
+        if (ret != Q_ERR(ENOENT) || depth) {
             Com_WPrintf("Couldn't %s %s: %s\n", depth ? "include" : "load",
                         path, Q_ErrorString(ret));
         }

--- a/src/client/ui/ui.c
+++ b/src/client/ui/ui.c
@@ -144,8 +144,7 @@ void UI_PopMenu(void)
 {
     menuFrameWork_t *menu;
 
-    if (uis.menuDepth < 1)
-        Com_Error(ERR_FATAL, "UI_PopMenu: depth < 1");
+    Q_assert(uis.menuDepth > 0);
 
     menu = uis.layers[--uis.menuDepth];
     if (menu->pop) {
@@ -234,8 +233,7 @@ void UI_OpenMenu(uiMenu_t type)
     case UIMENU_NONE:
         break;
     default:
-        Com_Error(ERR_FATAL, "UI_OpenMenu: bad menu");
-        break;
+        Q_assert(!"bad menu");
     }
 
     UI_PushMenu(menu);

--- a/src/common/bsp.c
+++ b/src/common/bsp.c
@@ -1571,7 +1571,7 @@ int BSP_Load(const char *name, bsp_t **bsp_p)
     *bsp_p = NULL;
 
     if (!*name)
-        return Q_ERR_NOENT;
+        return Q_ERR(ENOENT);
 
     if ((bsp = BSP_Find(name)) != NULL) {
         Com_PageInMemory(bsp->hunk.base, bsp->hunk.cursize);

--- a/src/common/bsp.c
+++ b/src/common/bsp.c
@@ -1310,9 +1310,7 @@ void BSP_Free(bsp_t *bsp)
     if (!bsp) {
         return;
     }
-    if (bsp->refcount <= 0) {
-        Com_Error(ERR_FATAL, "%s: negative refcount", __func__);
-    }
+    Q_assert(bsp->refcount > 0);
     if (--bsp->refcount == 0) {
 		if (bsp->pvs2_matrix)
 		{
@@ -1567,8 +1565,8 @@ int BSP_Load(const char *name, bsp_t **bsp_p)
     size_t          lumpcount[HEADER_LUMPS];
     size_t          memsize;
 
-    if (!name || !bsp_p)
-        Com_Error(ERR_FATAL, "%s: NULL", __func__);
+    Q_assert(name);
+    Q_assert(bsp_p);
 
     *bsp_p = NULL;
 

--- a/src/common/cmd.c
+++ b/src/common/cmd.c
@@ -1617,7 +1617,7 @@ int Cmd_ExecuteFile(const char *path, unsigned flags)
     // sanity check file size after stripping off comments
     len = COM_Compress(f);
     if (len > CMD_BUFFER_SIZE) {
-        ret = Q_ERR_FBIG;
+        ret = Q_ERR(EFBIG);
         goto finish;
     }
 
@@ -1663,7 +1663,7 @@ static void Cmd_Exec_f(void)
     }
 
     if (FS_NormalizePathBuffer(buffer, Cmd_Argv(1), sizeof(buffer)) >= sizeof(buffer)) {
-        ret = Q_ERR_NAMETOOLONG;
+        ret = Q_ERR(ENAMETOOLONG);
         goto fail;
     }
 
@@ -1675,7 +1675,7 @@ static void Cmd_Exec_f(void)
     ret = Cmd_ExecuteFile(buffer, 0);
 
     // try with .cfg extension
-    if (ret == Q_ERR_NOENT && COM_CompareExtension(buffer, ".cfg") && strlen(buffer) < sizeof(buffer) - 4) {
+    if (ret == Q_ERR(ENOENT) && COM_CompareExtension(buffer, ".cfg") && strlen(buffer) < sizeof(buffer) - 4) {
         strcat(buffer, ".cfg");
         ret = Cmd_ExecuteFile(buffer, 0);
     }

--- a/src/common/common.c
+++ b/src/common/common.c
@@ -850,7 +850,7 @@ void Com_AddConfigFile(const char *name, unsigned flags)
     ret = Cmd_ExecuteFile(name, flags);
     if (ret == Q_ERR_SUCCESS) {
         Cbuf_Execute(&cmd_buffer);
-    } else if (ret != Q_ERR_NOENT) {
+    } else if (ret != Q_ERR(ENOENT)) {
         Com_WPrintf("Couldn't exec %s: %s\n", name, Q_ErrorString(ret));
     }
 }

--- a/src/common/cvar.c
+++ b/src/common/cvar.c
@@ -259,9 +259,8 @@ cvar_t *Cvar_Get(const char *var_name, const char *var_value, int flags)
     unsigned hash;
     size_t length;
 
-    if (!var_name) {
-        Com_Error(ERR_FATAL, "Cvar_Get: NULL var_name");
-    }
+    Q_assert(var_name);
+
     if (!var_value) {
         return Cvar_FindVar(var_name);
     }

--- a/src/common/error.c
+++ b/src/common/error.c
@@ -46,8 +46,6 @@ static const char *const error_table[] = {
     "Bad compression method",
 };
 
-static const int num_errors = q_countof(error_table);
-
 const char *Q_ErrorString(int error)
 {
     int e;
@@ -65,8 +63,11 @@ const char *Q_ErrorString(int error)
         return strerror(e);
     }
 
-    e = _Q_ERR(error);
+    e = Q_ERR_(error);
+    if (e >= q_countof(error_table)) {
+        e = 0;
+    }
 
-    return error_table[e >= num_errors ? 0 : e];
+    return error_table[e];
 }
 

--- a/src/common/field.c
+++ b/src/common/field.c
@@ -79,9 +79,7 @@ bool IF_KeyEvent(inputField_t *field, int key)
     if (!field->maxChars) {
         return false;
     }
-    if (field->cursorPos >= field->maxChars) {
-        Com_Error(ERR_FATAL, "%s: bad cursorPos", __func__);
-    }
+    Q_assert(field->cursorPos < field->maxChars);
 
     if (key == K_DEL) {
         if (field->text[field->cursorPos]) {
@@ -202,9 +200,7 @@ bool IF_CharEvent(inputField_t *field, int key)
     if (!field->maxChars) {
         return false;
     }
-    if (field->cursorPos >= field->maxChars) {
-        Com_Error(ERR_FATAL, "%s: bad cursorPos", __func__);
-    }
+    Q_assert(field->cursorPos < field->maxChars);
 
     if (key < 32 || key > 127) {
         return false;   // non printable
@@ -251,9 +247,7 @@ int IF_Draw(inputField_t *field, int x, int y, int flags, qhandle_t font)
         return 0;
     }
 
-    if (cursorPos >= field->maxChars) {
-        Com_Error(ERR_FATAL, "%s: bad cursorPos", __func__);
-    }
+    Q_assert(cursorPos < field->maxChars);
 
     // scroll horizontally
     if (cursorPos >= field->visibleChars) {

--- a/src/common/files.c
+++ b/src/common/files.c
@@ -451,9 +451,6 @@ static file_t *file_for_handle(qhandle_t f)
     if (file->type == FS_FREE)
         return NULL;
 
-    if (file->type < FS_FREE || file->type >= FS_BAD)
-        Com_Error(ERR_FATAL, "%s: bad file type", __func__);
-
     return file;
 }
 
@@ -909,7 +906,7 @@ static int64_t open_file_write(file_t *file, const char *name)
         strcpy(mode_str, "r+");
         break;
     default:
-        Com_Error(ERR_FATAL, "%s: bad mode", __func__);
+        Q_assert(!"bad mode");
     }
 
     // open in binary mode by default
@@ -1017,9 +1014,7 @@ static void open_zip_file(file_t *file)
     } else {
         z->zalloc = FS_zalloc;
         z->zfree = FS_zfree;
-        if (inflateInit2(z, -MAX_WBITS) != Z_OK) {
-            Com_Error(ERR_FATAL, "%s: inflateInit2() failed", __func__);
-        }
+        Q_assert(inflateInit2(z, -MAX_WBITS) == Z_OK);
     }
 
     z->avail_in = z->avail_out = 0;
@@ -1644,7 +1639,7 @@ int FS_Write(const void *buf, size_t len, qhandle_t f)
         break;
 #endif
     default:
-        Com_Error(ERR_FATAL, "%s: bad file type", __func__);
+        Q_assert(!"bad file type");
     }
 
     return len;
@@ -1661,9 +1656,8 @@ int64_t FS_FOpenFile(const char *name, qhandle_t *f, unsigned mode)
     qhandle_t handle;
     int64_t ret;
 
-    if (!name || !f) {
-        Com_Error(ERR_FATAL, "%s: NULL", __func__);
-    }
+    Q_assert(name);
+    Q_assert(f);
 
     *f = 0;
 
@@ -1824,9 +1818,7 @@ int FS_LoadFileEx(const char *path, void **buffer, unsigned flags, memtag_t tag)
     int64_t len;
     int read;
 
-    if (!path) {
-        Com_Error(ERR_FATAL, "%s: NULL", __func__);
-    }
+    Q_assert(path);
 
     if (buffer) {
         *buffer = NULL;
@@ -2024,9 +2016,7 @@ static void pack_put(pack_t *pack)
     if (!pack) {
         return;
     }
-    if (!pack->refcount) {
-        Com_Error(ERR_FATAL, "%s: refcount already zero", __func__);
-    }
+    Q_assert(pack->refcount > 0);
     if (!--pack->refcount) {
         FS_DPrintf("Freeing packfile %s\n", pack->filename);
         pack_free(pack);

--- a/src/common/msg.c
+++ b/src/common/msg.c
@@ -92,8 +92,7 @@ void MSG_WriteChar(int c)
     byte    *buf;
 
 #ifdef PARANOID
-    if (c < -128 || c > 127)
-        Com_Error(ERR_FATAL, "MSG_WriteChar: range error");
+    Q_assert(c >= -128 && c <= 127);
 #endif
 
     buf = SZ_GetSpace(&msg_write, 1);
@@ -110,8 +109,7 @@ void MSG_WriteByte(int c)
     byte    *buf;
 
 #ifdef PARANOID
-    if (c < 0 || c > 255)
-        Com_Error(ERR_FATAL, "MSG_WriteByte: range error");
+    Q_assert(c >= 0 && c <= 255);
 #endif
 
     buf = SZ_GetSpace(&msg_write, 1);
@@ -128,8 +126,7 @@ void MSG_WriteShort(int c)
     byte    *buf;
 
 #ifdef PARANOID
-    if (c < ((short)0x8000) || c > (short)0x7fff)
-        Com_Error(ERR_FATAL, "MSG_WriteShort: range error");
+    Q_assert(c >= -0x8000 && c <= 0x7fff);
 #endif
 
     buf = SZ_GetSpace(&msg_write, 2);

--- a/src/common/net/chan.c
+++ b/src/common/net/chan.c
@@ -167,7 +167,7 @@ void Netchan_OutOfBand(netsrc_t sock, const netadr_t *address,
 
 static size_t NetchanOld_TransmitNextFragment(netchan_t *netchan)
 {
-    Com_Error(ERR_FATAL, "%s: not implemented", __func__);
+    Q_assert(!"not implemented");
     return 0;
 }
 
@@ -847,7 +847,7 @@ netchan_t *Netchan_Setup(netsrc_t sock, netchan_type_t type,
         netchan = NetchanNew_Setup(sock, adr, qport, maxpacketlen);
         break;
     default:
-        Com_Error(ERR_FATAL, "Netchan_Setup: bad type");
+        Q_assert(!"bad type");
         netchan = NULL;
     }
 

--- a/src/common/net/net.c
+++ b/src/common/net/net.c
@@ -243,7 +243,7 @@ char *NET_BaseAdrToString(const netadr_t *a)
         else
             return strcpy(s, "<invalid>");
     default:
-        Com_Error(ERR_FATAL, "%s: bad address type", __func__);
+        Q_assert(!"bad address type");
     }
 
     return NULL;
@@ -943,7 +943,7 @@ bool NET_SendPacket(netsrc_t sock, const void *data,
         s = udp6_sockets[sock];
         break;
     default:
-        Com_Error(ERR_FATAL, "%s: bad address type", __func__);
+        Q_assert(!"bad address type");
     }
 
     if (s == -1)

--- a/src/refresh/gl/hq2x.c
+++ b/src/refresh/gl/hq2x.c
@@ -182,7 +182,7 @@ static q_noinline uint32_t hq2x_blend(int rule, uint32_t E, uint32_t A, uint32_t
     case 16:
         return same(B, D) ? blend_14_1_1(E, D, B) : E;
     default:
-        Com_Error(ERR_FATAL, "%s: bad rule %d", __func__, rule);
+        Q_assert(!"bad rule");
         return 0;
     }
 }
@@ -349,8 +349,7 @@ static q_noinline void hq4x_blend(int rule, uint32_t *p00, uint32_t *p01, uint32
         *p11 = E;
         break;
     default:
-        Com_Error(ERR_FATAL, "%s: bad rule %d", __func__, rule);
-        break;
+        Q_assert(!"bad rule");
     }
 }
 

--- a/src/refresh/gl/main.c
+++ b/src/refresh/gl/main.c
@@ -439,7 +439,7 @@ static void GL_DrawEntities(int mask)
         case MOD_EMPTY:
             break;
         default:
-            Com_Error(ERR_FATAL, "%s: bad model type", __func__);
+            Q_assert(!"bad model type");
         }
 
         if (gl_showorigins->integer) {
@@ -513,9 +513,7 @@ void R_RenderFrame_GL(refdef_t *fd)
 {
     GL_Flush2D();
 
-    if (!gl_static.world.cache && !(fd->rdflags & RDF_NOWORLDMODEL)) {
-        Com_Error(ERR_FATAL, "%s: NULL worldmodel", __func__);
-    }
+    Q_assert(gl_static.world.cache || (fd->rdflags & RDF_NOWORLDMODEL));
 
     glr.drawframe++;
 

--- a/src/refresh/images.c
+++ b/src/refresh/images.c
@@ -1062,7 +1062,7 @@ static int try_other_formats(imageformat_t orig, image_t *image, int try_src, by
         }
 
         ret = try_image_format(fmt, image, try_src, pic);
-        if (ret != Q_ERR_NOENT) {
+        if (ret != Q_ERR(ENOENT)) {
             return ret; // found something
         }
     }
@@ -1070,7 +1070,7 @@ static int try_other_formats(imageformat_t orig, image_t *image, int try_src, by
     // fall back to 8-bit formats
     fmt = (image->type == IT_WALL) ? IM_WAL : IM_PCX;
     if (fmt == orig) {
-        return Q_ERR_NOENT; // don't retry twice
+        return Q_ERR(ENOENT); // don't retry twice
     }
 
     return try_image_format(fmt, image, try_src, pic);
@@ -1100,7 +1100,7 @@ int IMG_GetDimensions(const char* name, int* width, int* height)
     qhandle_t f;
     FS_FOpenFile(name, &f, FS_MODE_READ);
     if (!f)
-        return Q_ERR_NOENT;
+        return Q_ERR(ENOENT);
 
     if (format == IM_WAL)
     {
@@ -1183,7 +1183,7 @@ load_img(const char *name, image_t *image)
 {
     byte            *pic;
     imageformat_t   fmt;
-    int             ret = Q_ERR_INVAL;
+    int             ret = Q_ERR(EINVAL);
 
 	size_t len = strlen(name);
 
@@ -1222,7 +1222,7 @@ load_img(const char *name, image_t *image)
 
         // first try with original extension
         ret = _try_image_format(fmt, image, try_location, &pic);
-        if (ret == Q_ERR_NOENT) {
+        if (ret == Q_ERR(ENOENT)) {
             // retry with remaining extensions
             ret = try_other_formats(fmt, image, try_location, &pic);
         }
@@ -1274,7 +1274,7 @@ static int try_load_image_candidate(image_t *image, const char *orig_name, size_
     {
         // unknown extension, but give it a chance to load anyway
         ret = try_other_formats(IM_MAX, image, try_location, pic_p);
-        if (ret == Q_ERR_NOENT)
+        if (ret == Q_ERR(ENOENT))
         {
             // not found, change error to invalid path
             ret = Q_ERR_INVALID_PATH;
@@ -1289,7 +1289,7 @@ static int try_load_image_candidate(image_t *image, const char *orig_name, size_
     {
         // first try with original extension
         ret = _try_image_format(fmt, image, try_location, pic_p);
-        if (ret == Q_ERR_NOENT && !(flags & IF_EXACT))
+        if (ret == Q_ERR(ENOENT) && !(flags & IF_EXACT))
         {
             // retry with remaining extensions
             ret = try_other_formats(fmt, image, try_location, pic_p);
@@ -1324,7 +1324,7 @@ static int find_or_load_image(const char *name, size_t len,
     image_t         *image;
     byte            *pic;
     unsigned        hash;
-    int             ret = Q_ERR_NOENT;
+    int             ret = Q_ERR(ENOENT);
 
     *image_p = NULL;
 
@@ -1432,7 +1432,7 @@ image_t *IMG_Find(const char *name, imagetype_t type, imageflags_t flags)
     }
 
     // don't spam about missing images
-    if (ret != Q_ERR_NOENT) {
+    if (ret != Q_ERR(ENOENT)) {
         Com_EPrintf("Couldn't load %s: %s\n", name, Q_ErrorString(ret));
     }
 
@@ -1553,7 +1553,7 @@ qhandle_t R_RegisterImage(const char *name, imagetype_t type,
     // no images = not initialized
     if (!r_numImages) {
         if (err_p)
-            *err_p = Q_ERR_AGAIN;
+            *err_p = Q_ERR(EAGAIN);
         return 0;
     }
 
@@ -1570,7 +1570,7 @@ qhandle_t R_RegisterImage(const char *name, imagetype_t type,
     }
 
     if (len >= sizeof(fullname)) {
-        err = Q_ERR_NAMETOOLONG;
+        err = Q_ERR(ENAMETOOLONG);
         goto fail;
     }
 
@@ -1585,7 +1585,7 @@ fail:
     // don't spam about missing images
     if (err_p)
         *err_p = err;
-    else if (err != Q_ERR_NOENT)
+    else if (err != Q_ERR(ENOENT))
         Com_EPrintf("Couldn't load %s: %s\n", fullname, Q_ErrorString(err));
 
     return 0;

--- a/src/refresh/images.c
+++ b/src/refresh/images.c
@@ -1421,15 +1421,10 @@ image_t *IMG_Find(const char *name, imagetype_t type, imageflags_t flags)
     size_t len;
     int ret;
 
-    if (!name) {
-        Com_Error(ERR_FATAL, "%s: NULL", __func__);
-    }
+    Q_assert(name);
 
-    // this should never happen
     len = strlen(name);
-    if (len >= MAX_QPATH) {
-        Com_Error(ERR_FATAL, "%s: oversize name", __func__);
-    }
+    Q_assert(len < MAX_QPATH);
 
     ret = find_or_load_image(name, len, type, flags, &image);
     if (image) {
@@ -1531,10 +1526,7 @@ IMG_ForHandle
 */
 image_t *IMG_ForHandle(qhandle_t h)
 {
-    if (h < 0 || h >= r_numImages) {
-        Com_Error(ERR_FATAL, "%s: %d out of range", __func__, h);
-    }
-
+    Q_assert(h >= 0 && h < r_numImages);
     return &r_images[h];
 }
 
@@ -1789,10 +1781,7 @@ void IMG_Init(void)
 {
     int i;
 
-    if (r_numImages) {
-        Com_Error(ERR_FATAL, "%s: %d images not freed", __func__, r_numImages);
-    }
-
+    Q_assert(!r_numImages);
 
     r_override_textures = Cvar_Get("r_override_textures", "1", CVAR_FILES);
     r_texture_formats = Cvar_Get("r_texture_formats", "pjt", 0);

--- a/src/refresh/models.c
+++ b/src/refresh/models.c
@@ -377,7 +377,7 @@ qhandle_t R_RegisterModel(const char *name)
 		filelen = FS_LoadFile(normalized, (void **)&rawdata);
 		if (!rawdata) {
 			// don't spam about missing models
-			if (filelen == Q_ERR_NOENT) {
+			if (filelen == Q_ERR(ENOENT)) {
 				return 0;
 			}
 

--- a/src/refresh/models.c
+++ b/src/refresh/models.c
@@ -458,10 +458,7 @@ model_t *MOD_ForHandle(qhandle_t h)
         return NULL;
     }
 
-    if (h < 0 || h > r_numModels) {
-        Com_Error(ERR_DROP, "%s: %d out of range", __func__, h);
-    }
-
+    Q_assert(h > 0 && h <= r_numModels);
     model = &r_models[h - 1];
     if (!model->type) {
         return NULL;
@@ -478,10 +475,7 @@ static void MOD_PutTest_f(void)
 
 void MOD_Init(void)
 {
-    if (r_numModels) {
-        Com_Error(ERR_FATAL, "%s: %d models not freed", __func__, r_numModels);
-    }
-
+    Q_assert(!r_numModels);
     Cmd_AddCommand("modellist", MOD_List_f);
     Cmd_AddCommand("puttest", MOD_PutTest_f);
 

--- a/src/refresh/vkpt/models.c
+++ b/src/refresh/vkpt/models.c
@@ -863,7 +863,7 @@ void MOD_Reference_RTX(model_t *model)
 	case MOD_EMPTY:
 		break;
 	default:
-		Com_Error(ERR_FATAL, "%s: bad model type", __func__);
+		Q_assert(!"bad model type");
 	}
 
 	model->registration_sequence = registration_sequence;

--- a/src/server/ac.c
+++ b/src/server/ac.c
@@ -396,7 +396,7 @@ static bool AC_ParseFile(const char *path, ac_parse_t parse, int depth)
 
     ret = FS_LoadFile(path, (void **)&raw);
     if (!raw) {
-        if (ret != Q_ERR_NOENT || depth) {
+        if (ret != Q_ERR(ENOENT) || depth) {
             Com_WPrintf("ANTICHEAT: Could not %s %s: %s\n",
                         depth ? "include" : "load", path, Q_ErrorString(ret));
         }

--- a/src/server/game.c
+++ b/src/server/game.c
@@ -699,9 +699,7 @@ static qboolean PF_AreasConnected(int area1, int area2)
 
 static void *PF_TagMalloc(unsigned size, unsigned tag)
 {
-    if (tag + TAG_MAX < tag) {
-        Com_Error(ERR_FATAL, "%s: bad tag", __func__);
-    }
+    Q_assert(tag + TAG_MAX > tag);
     if (!size) {
         return NULL;
     }
@@ -710,9 +708,7 @@ static void *PF_TagMalloc(unsigned size, unsigned tag)
 
 static void PF_FreeTags(unsigned tag)
 {
-    if (tag + TAG_MAX < tag) {
-        Com_Error(ERR_FATAL, "%s: bad tag", __func__);
-    }
+    Q_assert(tag + TAG_MAX > tag);
     Z_FreeTags(tag + TAG_MAX);
 }
 

--- a/src/server/init.c
+++ b/src/server/init.c
@@ -100,20 +100,20 @@ static void override_entity_string(const char *server)
     }
 
     if (Q_concat(buffer, sizeof(buffer), path, server, ".ent") >= sizeof(buffer)) {
-        ret = Q_ERR_NAMETOOLONG;
+        ret = Q_ERR(ENAMETOOLONG);
         goto fail1;
     }
 
     ret = SV_LoadFile(buffer, (void **)&str);
     if (!str) {
-        if (ret == Q_ERR_NOENT) {
+        if (ret == Q_ERR(ENOENT)) {
             return;
         }
         goto fail1;
     }
 
     if (ret > MAX_MAP_ENTSTRING) {
-        ret = Q_ERR_FBIG;
+        ret = Q_ERR(EFBIG);
         goto fail2;
     }
 
@@ -281,7 +281,7 @@ bool SV_ParseMapCmd(mapcmd_t *cmd)
 {
     char        expanded[MAX_QPATH];
     char        *s, *ch;
-    int         ret = Q_ERR_NAMETOOLONG;
+    int         ret = Q_ERR(ENAMETOOLONG);
 
     s = cmd->buffer;
 

--- a/src/server/init.c
+++ b/src/server/init.c
@@ -429,10 +429,8 @@ void SV_InitGame(unsigned mvd_spawn)
 #if USE_ZLIB
     svs.z.zalloc = SV_zalloc;
     svs.z.zfree = SV_zfree;
-    if (deflateInit2(&svs.z, Z_DEFAULT_COMPRESSION, Z_DEFLATED,
-                     -MAX_WBITS, 9, Z_DEFAULT_STRATEGY) != Z_OK) {
-        Com_Error(ERR_FATAL, "%s: deflateInit2() failed", __func__);
-    }
+    Q_assert(deflateInit2(&svs.z, Z_DEFAULT_COMPRESSION, Z_DEFLATED,
+             -MAX_WBITS, 9, Z_DEFAULT_STRATEGY) == Z_OK);
 #endif
 
     // init game

--- a/src/server/send.c
+++ b/src/server/send.c
@@ -441,9 +441,7 @@ static inline void free_msg_packet(client_t *client, message_packet_t *msg)
     List_Remove(&msg->entry);
 
     if (msg->cursize > MSG_TRESHOLD) {
-        if (msg->cursize > client->msg_dynamic_bytes) {
-            Com_Error(ERR_FATAL, "%s: bad packet size", __func__);
-        }
+        Q_assert(msg->cursize <= client->msg_dynamic_bytes);
         client->msg_dynamic_bytes -= msg->cursize;
         Z_Free(msg);
     } else {
@@ -481,11 +479,10 @@ static void add_msg_packet(client_t     *client,
         return; // already dropped
     }
 
+    Q_assert(len <= MAX_MSGLEN);
+
     if (len > MSG_TRESHOLD) {
-        if (len > MAX_MSGLEN) {
-            Com_Error(ERR_FATAL, "%s: oversize packet", __func__);
-        }
-        if (client->msg_dynamic_bytes + len > MAX_MSGLEN) {
+        if (client->msg_dynamic_bytes > MAX_MSGLEN - len) {
             Com_WPrintf("%s: %s: out of dynamic memory\n",
                         __func__, client->name);
             goto overflowed;

--- a/src/shared/shared.c
+++ b/src/shared/shared.c
@@ -145,9 +145,7 @@ char *COM_SkipPath(const char *pathname)
 {
     char    *last;
 
-    if (!pathname) {
-        Com_Error(ERR_FATAL, "%s: NULL", __func__);
-    }
+    Q_assert(pathname);
 
     last = (char *)pathname;
     while (*pathname) {
@@ -185,9 +183,7 @@ char *COM_FileExtension(const char *in)
 {
     const char *last, *s;
 
-    if (!in) {
-        Com_Error(ERR_FATAL, "%s: NULL", __func__);
-    }
+    Q_assert(in);
 
     for (last = s = in + strlen(in); s != in; s--) {
         if (*s == '/') {
@@ -711,9 +707,7 @@ size_t Q_strlcat(char *dst, const char *src, size_t size)
 {
     size_t len = strlen(dst);
 
-    if (len >= size) {
-        Com_Error(ERR_FATAL, "%s: already overflowed", __func__);
-    }
+    Q_assert(len < size);
 
     return len + Q_strlcpy(dst + len, src, size - len);
 }
@@ -762,12 +756,9 @@ size_t Q_vsnprintf(char *dest, size_t size, const char *fmt, va_list argptr)
 {
     int ret;
 
-    if (size > INT_MAX)
-        Com_Error(ERR_FATAL, "%s: bad buffer size", __func__);
-
+    Q_assert(size <= INT_MAX);
     ret = vsnprintf(dest, size, fmt, argptr);
-    if (ret < 0)
-        Com_Error(ERR_FATAL, "%s: bad return value", __func__);
+    Q_assert(ret >= 0);
 
     return ret;
 }


### PR DESCRIPTION
Q2PRO changed how some error codes were defined, and introduced `Q_assert'  for error checks that would result in a fatal error.