### PR TITLE
Add 'skyautorotate' worldspawn property as found in rerelease game.

### DIFF
--- a/inc/refresh/refresh.h
+++ b/inc/refresh/refresh.h
@@ -300,7 +300,7 @@ qhandle_t R_RegisterRawImage(const char *name, int width, int height, byte* pic,
                           imageflags_t flags);
 void R_UnregisterImage(qhandle_t handle);
 
-extern void    (*R_SetSky)(const char *name, float rotate, const vec3_t axis);
+extern void    (*R_SetSky)(const char *name, float rotate, int autorotate, const vec3_t axis);
 extern void    (*R_EndRegistration)(void);
 
 #define R_RegisterPic(name)     R_RegisterImage(name, IT_PIC, IF_PERMANENT | IF_SRGB, NULL)

--- a/src/baseq2/g_local.h
+++ b/src/baseq2/g_local.h
@@ -343,6 +343,7 @@ typedef struct {
     // world vars
     char        *sky;
     float       skyrotate;
+    int         skyautorotate;
     vec3_t      skyaxis;
     char        *nextmap;
 

--- a/src/baseq2/g_spawn.c
+++ b/src/baseq2/g_spawn.c
@@ -319,6 +319,7 @@ static const spawn_field_t temp_fields[] = {
     {"gravity", STOFS(gravity), F_LSTRING},
     {"sky", STOFS(sky), F_LSTRING},
     {"skyrotate", STOFS(skyrotate), F_FLOAT},
+    {"skyautorotate", STOFS(skyautorotate), F_INT},
     {"skyaxis", STOFS(skyaxis), F_VECTOR},
     {"minyaw", STOFS(minyaw), F_FLOAT},
     {"maxyaw", STOFS(maxyaw), F_FLOAT},
@@ -471,6 +472,7 @@ void ED_ParseEdict(const char **data, edict_t *ent)
 
     init = false;
     memset(&st, 0, sizeof(st));
+    st.skyautorotate = 1;
 
 // go through all the dictionary pairs
     while (1) {
@@ -870,7 +872,7 @@ void SP_worldspawn(edict_t *ent)
     else
         gi.configstring(CS_SKY, "unit1_");
 
-    gi.configstring(CS_SKYROTATE, va("%f", st.skyrotate));
+    gi.configstring(CS_SKYROTATE, va("%f %d", st.skyrotate, st.skyautorotate));
 
     gi.configstring(CS_SKYAXIS, va("%f %f %f",
                                    st.skyaxis[0], st.skyaxis[1], st.skyaxis[2]));

--- a/src/client/precache.c
+++ b/src/client/precache.c
@@ -303,17 +303,18 @@ CL_SetSky
 */
 void CL_SetSky(void)
 {
-    float       rotate;
+    float       rotate = 0;
+    int         autorotate = 1;
     vec3_t      axis;
 
-    rotate = atof(cl.configstrings[CS_SKYROTATE]);
+    sscanf(cl.configstrings[CS_SKYROTATE], "%f %d", &rotate, &autorotate);
     if (sscanf(cl.configstrings[CS_SKYAXIS], "%f %f %f",
                &axis[0], &axis[1], &axis[2]) != 3) {
         Com_DPrintf("Couldn't parse CS_SKYAXIS\n");
         VectorClear(axis);
     }
 
-    R_SetSky(cl.configstrings[CS_SKY], rotate, axis);
+    R_SetSky(cl.configstrings[CS_SKY], rotate, autorotate, axis);
 }
 
 /*

--- a/src/client/refresh.c
+++ b/src/client/refresh.c
@@ -408,7 +408,7 @@ refcfg_t r_config;
 ref_type_t(*R_Init)(bool total) = NULL;
 void(*R_Shutdown)(bool total) = NULL;
 void(*R_BeginRegistration)(const char *map) = NULL;
-void(*R_SetSky)(const char *name, float rotate, const vec3_t axis) = NULL;
+void(*R_SetSky)(const char *name, float rotate, int autorotate, const vec3_t axis) = NULL;
 void(*R_EndRegistration)(void) = NULL;
 void(*R_RenderFrame)(refdef_t *fd) = NULL;
 void(*R_LightPoint)(const vec3_t origin, vec3_t light) = NULL;

--- a/src/client/screen.c
+++ b/src/client/screen.c
@@ -1047,7 +1047,7 @@ static void SCR_Sky_f(void)
     } else
         VectorSet(axis, 0, 0, 1);
 
-    R_SetSky(name, rotate, axis);
+    R_SetSky(name, rotate, 1, axis);
 }
 
 /*

--- a/src/refresh/gl/gl.h
+++ b/src/refresh/gl/gl.h
@@ -552,7 +552,7 @@ void R_LightPoint_GL(const vec3_t origin, vec3_t color);
 void R_AddSkySurface(mface_t *surf);
 void R_ClearSkyBox(void);
 void R_DrawSkyBox(void);
-void R_SetSky_GL(const char *name, float rotate, const vec3_t axis);
+void R_SetSky_GL(const char *name, float rotate, int autorotate, const vec3_t axis);
 
 /*
  * gl_mesh.c

--- a/src/refresh/gl/sky.c
+++ b/src/refresh/gl/sky.c
@@ -19,6 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "gl.h"
 
 static float    skyrotate;
+static int      skyautorotate;
 static vec3_t   skyaxis;
 static int      sky_images[6];
 
@@ -248,7 +249,7 @@ void R_AddSkySurface(mface_t *fa)
     surfedge = fa->firstsurfedge;
     if (skyrotate) {
         if (!skyfaces)
-            SetupRotationMatrix(skymatrix, skyaxis, glr.fd.time * skyrotate);
+            SetupRotationMatrix(skymatrix, skyaxis, (skyautorotate ? glr.fd.time : 1.f) * skyrotate);
 
         for (i = 0; i < fa->numsurfedges; i++, surfedge++) {
             vert = surfedge->edge->v[surfedge->vert];
@@ -369,6 +370,7 @@ static void R_UnsetSky(void)
     int i;
 
     skyrotate = 0;
+    skyautorotate = 0;
     for (i = 0; i < 6; i++) {
         sky_images[i] = TEXNUM_BLACK;
     }
@@ -379,7 +381,7 @@ static void R_UnsetSky(void)
 R_SetSky
 ============
 */
-void R_SetSky_GL(const char *name, float rotate, const vec3_t axis)
+void R_SetSky_GL(const char *name, float rotate, int autorotate, const vec3_t axis)
 {
     int     i;
     char    pathname[MAX_QPATH];
@@ -393,6 +395,7 @@ void R_SetSky_GL(const char *name, float rotate, const vec3_t axis)
     }
 
     skyrotate = rotate;
+    skyautorotate = autorotate;
     VectorNormalize2(axis, skyaxis);
 
     for (i = 0; i < 6; i++) {

--- a/src/refresh/vkpt/main.c
+++ b/src/refresh/vkpt/main.c
@@ -124,6 +124,7 @@ int num_accumulated_frames = 0;
 static bool frame_ready = false;
 
 static float sky_rotation = 0.f;
+static int sky_autorotate = 0;
 static vec3_t sky_axis = { 0.f };
 
 #define NUM_TAA_SAMPLES 128
@@ -2531,7 +2532,7 @@ prepare_sky_matrix(float time, vec3_t sky_matrix[3])
 {
 	if (sky_rotation != 0.f)
 	{
-		SetupRotationMatrix(sky_matrix, sky_axis, time * sky_rotation);
+		SetupRotationMatrix(sky_matrix, sky_axis, (sky_autorotate ? time : 1.f) * sky_rotation);
 	}
 	else
 	{
@@ -4013,7 +4014,7 @@ IMG_ReadPixelsHDR_RTX(int *width, int *height)
 }
 
 void
-R_SetSky_RTX(const char *name, float rotate, const vec3_t axis)
+R_SetSky_RTX(const char *name, float rotate, int autorotate, const vec3_t axis)
 {
 	int     i;
 	char    pathname[MAX_QPATH];
@@ -4023,6 +4024,7 @@ R_SetSky_RTX(const char *name, float rotate, const vec3_t axis)
 	byte *data = NULL;
 
 	sky_rotation = rotate;
+	sky_autorotate = autorotate;
 	VectorNormalize2(axis, sky_axis);
 
 	int avg_color[3] = { 0 };


### PR DESCRIPTION
This is necessary to stop the sky in some rerelease maps, eg base1,
from spinning: these maps set a 'skyrotate' value, but explicitly
disable it with the new 'skyautorotate'.