### PR TITLE
Update CPUSTRING for ppc64le

### DIFF
--- a/inc/shared/config.h
+++ b/inc/shared/config.h
@@ -20,6 +20,9 @@
 #elif __x86_64__
 #define CPUSTRING "x86_64"
 #define BUILDSTRING "Linux"
+#elif __powerpc64__ && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+#define CPUSTRING "ppc64le"
+#define BUILDSTRING "Linux"
 #else
 #define CPUSTRING "x86"
 #define BUILDSTRING "Linux"


### PR DESCRIPTION
## Description

On my Linux ppc64le machine, the `q2rtxded` does not look up correct `gameppc64le.so`

## Steps to reproduce:

```
./q2rtxded
```

Expected: `Loaded game library from /home/tle/Games/q2rtx/baseq2/gameppc64le.so`
Actual: `Can't access /home/tle/Work/Q2RTX/baseq2/gamex86.so: No such file or directory****`

## Solution

It turns out the `CPUSTRING` is not handled correctly for Linux ppc64le

Fixes https://github.com/NVIDIA/Q2RTX/issues/304