### PR TITLE
Fix an incorrect check 

### DIFF
--- a/src/common/msg.c
+++ b/src/common/msg.c
@@ -295,7 +295,7 @@ MSG_WriteBits
 */
 void MSG_WriteBits(int value, int bits)
 {
-    if (bits == 0 || bits < -31 || bits > 32) {
+    if (bits == 0 || bits < -31 || bits > 31) {
         Com_Error(ERR_FATAL, "MSG_WriteBits: bad bits: %d", bits);
     }
 


### PR DESCRIPTION
...introduced in 0f5ef84b9168ff483e9dd8a5ad43c19e74f1f83b

An input check condition required some tweaking which was missed when porting a commit.