### PR TITLE
Sync with Q2PRO: Protocol extension for large clientnums

### DIFF
--- a/inc/common/protocol.h
+++ b/inc/common/protocol.h
@@ -47,7 +47,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define PROTOCOL_VERSION_Q2PRO_SERVER_STATE     1019    // r1302
 #define PROTOCOL_VERSION_Q2PRO_EXTENDED_LAYOUT  1020    // r1354
 #define PROTOCOL_VERSION_Q2PRO_ZLIB_DOWNLOADS   1021    // r1358
-#define PROTOCOL_VERSION_Q2PRO_CURRENT          1021    // r1358
+#define PROTOCOL_VERSION_Q2PRO_CLIENTNUM_SHORT  1022    // r2161
+#define PROTOCOL_VERSION_Q2PRO_CURRENT          1022    // r2161
 
 #define PROTOCOL_VERSION_MVD_MINIMUM            2009    // r168
 #define PROTOCOL_VERSION_MVD_CURRENT            2010    // r177
@@ -63,6 +64,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define MVD_SUPPORTED(x) \
     ((x) >= PROTOCOL_VERSION_MVD_MINIMUM && \
      (x) <= PROTOCOL_VERSION_MVD_CURRENT)
+
+#define VALIDATE_CLIENTNUM(x) \
+    ((x) >= -1 && (x) < MAX_EDICTS - 1)
 
 //=========================================
 

--- a/src/client/entities.c
+++ b/src/client/entities.c
@@ -947,9 +947,6 @@ static int shell_effect_hack(void)
     centity_t   *ent;
     int         flags = 0;
 
-    if (cl.frame.clientNum == CLIENTNUM_NONE)
-        return 0;
-
     ent = &cl_entities[cl.frame.clientNum + 1];
     if (ent->serverframe != cl.frame.number)
         return 0;
@@ -1171,9 +1168,6 @@ static void CL_FinishViewValues(void)
     centity_t *ent;
 
     if (cl_player_model->integer != CL_PLAYER_MODEL_THIRD_PERSON)
-        goto first;
-
-    if (cl.frame.clientNum == CLIENTNUM_NONE)
         goto first;
 
     ent = &cl_entities[cl.frame.clientNum + 1];

--- a/src/client/main.c
+++ b/src/client/main.c
@@ -2151,13 +2151,6 @@ static size_t CL_Ups_m(char *buffer, size_t size)
 {
     vec3_t vel;
 
-    if (cl.frame.clientNum == CLIENTNUM_NONE) {
-        if (size) {
-            *buffer = 0;
-        }
-        return 0;
-    }
-
     if (!cls.demo.playback && cl.frame.clientNum == cl.clientNum &&
         cl_predict->integer) {
         VectorCopy(cl.predicted_velocity, vel);

--- a/src/client/parse.c
+++ b/src/client/parse.c
@@ -637,7 +637,7 @@ static void CL_ParseServerData(void)
 
         // make sure clientNum is in range
         if (cl.clientNum < 0 || cl.clientNum >= MAX_CLIENTS) {
-            cl.clientNum = CLIENTNUM_NONE;
+            cl.clientNum = -1;
         }
     }
 }

--- a/src/client/sound/main.c
+++ b/src/client/sound/main.c
@@ -839,7 +839,7 @@ void S_Update(void)
 
     // set listener entity number
     // other parameters should be already set up by CL_CalcViewValues
-    if (cls.state != ca_active || cl.clientNum == -1 || cl.frame.clientNum == CLIENTNUM_NONE) {
+    if (cls.state != ca_active || cl.clientNum == -1) {
         listener_entnum = -1;
     } else {
         listener_entnum = cl.frame.clientNum + 1;


### PR DESCRIPTION
"When GMF_CLIENTNUM feature was introduced, it was expected that client
POV number will only be set to valid client slot numbers in range [0,
255). Therefore, clientNum has been transmitted as a byte, with 255
(CLIENTNUM_NONE) reserved for a special case to indicate no current POV
number (this has always been buggy, see below).

However, one might want to set client POV to any entity >= 256, not just
client entitites (to view the game from monster POV, for example). Thus,
make clientNum strictly mean ‘number of POV entity minus 1’ and transmit
it as a short in range [-1, MAX_EDICTS - 1).

To accomodate older Q2PRO clients, reset clientNum to client slot number
and zero out POV entity modelindex if clientNum is >= 255.

clientNum == -1 is legal, and can happen e.g. when playing a MVD without
dummy MVD observer spawned. -1 maps to 255 (CLIENTNUM_NONE) upon reading
on older Q2PRO clients. This is buggy, as it will make entity 256
invisible, but there doesn't seem to be a proper fix. Mapping -1 to
client slot number will make random _player_ entity invisible instead,
which is worse. So don't change anything about -1.

For newer Q2PRO clients clientNum == -1 will be transmitted as literal
-1. This will map to entity 0 (world) and things will work as expected.

This was (and still is) a huge mess. Fixes https://github.com/skullernet/q2pro/issues/260."