### PR TITLE
Sync with Q2PRO: Keep original mapcmd intact in SV_ParseMapCmd().

### DIFF
--- a/src/server/init.c
+++ b/src/server/init.c
@@ -301,7 +301,9 @@ bool SV_ParseMapCmd(mapcmd_t *cmd)
     else
         Cvar_Set("nextserver", "");
 
-    cmd->server = s;
+    // copy it off to keep original mapcmd intact
+    Q_strlcpy(cmd->server, s, sizeof(cmd->server));
+    s = cmd->server;
 
     // if there is a $, use the remainder as a spawnpoint
     ch = strchr(s, '$');
@@ -309,7 +311,7 @@ bool SV_ParseMapCmd(mapcmd_t *cmd)
         *ch = 0;
         cmd->spawnpoint = ch + 1;
     } else {
-        cmd->spawnpoint = cmd->buffer + strlen(cmd->buffer);
+        cmd->spawnpoint = s + strlen(s);
     }
 
     // now expand and try to load the map

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -455,8 +455,8 @@ typedef struct {
 } master_t;
 
 typedef struct {
-    char            buffer[MAX_QPATH];
-    char            *server;
+    char            buffer[MAX_QPATH];  // original mapcmd
+    char            server[MAX_QPATH];  // parsed map name
     char            *spawnpoint;
     server_state_t  state;
     int             loadgame;


### PR DESCRIPTION
It is written in server savegame file and should be kept intact.