### PR TITLE
Fix Ogg music looping logic

### DIFF
--- a/src/client/sound/ogg.c
+++ b/src/client/sound/ogg.c
@@ -354,9 +354,12 @@ OGG_Update(void)
 
 		samples = stb_vorbis_get_samples_short_interleaved(ogg.vf, ogg.vf->channels, buffer,
 														   sizeof(buffer) / sizeof(short));
-		if (samples == 0 && (OGG_Play(), ogg.initialized))
-			samples = stb_vorbis_get_samples_short_interleaved(ogg.vf, ogg.vf->channels, buffer,
-															sizeof(buffer) / sizeof(short));
+		if (samples == 0) {
+			ogg_status = STOP;
+			if(OGG_Play(), ogg.initialized)
+				samples = stb_vorbis_get_samples_short_interleaved(ogg.vf, ogg.vf->channels, buffer,
+																sizeof(buffer) / sizeof(short));
+		}
 
 		if (samples <= 0)
 			break;


### PR DESCRIPTION
Not setting 'ogg_status == STOP' meant that the attempts to play the track again all resulted in no change, since OGG_PlayTrack() thought the track was already being played.