### PR TITLE
Always obtain sky color if reflection hit nothing

### DIFF
--- a/src/refresh/vkpt/shader/reflect_refract.rgen
+++ b/src/refresh/vkpt/shader/reflect_refract.rgen
@@ -521,13 +521,10 @@ main()
 		// Reflection ray hit the sky - store an empty surface into the G-buffer,
 		// blend the environment under the transparency.
 
-		if(found_intersection(ray_payload_geometry))
-		{
-			vec3 env = env_map(direction, false);
-			env *= global_ubo.pt_env_scale;
-			
-			transparent = alpha_blend(transparent, vec4(env * throughput, 1));
-		}
+		vec3 env = env_map(direction, false);
+		env *= global_ubo.pt_env_scale;
+
+		transparent = alpha_blend(transparent, vec4(env * throughput, 1));
 
 		material_id = (primary_medium << MATERIAL_LIGHT_STYLE_SHIFT) & MATERIAL_LIGHT_STYLE_MASK;
 


### PR DESCRIPTION
This fixes sky not showing up behind transparent surfaces if `pt_enable_nodraw` is set to 1.

FWIW, I suspect that the `found_intersection(...)` check was there for a reason?
Do you remember why and/or recall any scenarios when getting the sky color may look ugly?