### PR TITLE
Tweak how NODRAW/SKY surfaces are filtered.

### DIFF
--- a/doc/client.md
+++ b/doc/client.md
@@ -851,10 +851,15 @@ Controls if the Depth of Field effect should be used in various rendering modes:
 Enables the laser beam effects. Default value is 1.
 
 #### `pt_enable_nodraw`
-When this cvar is set to 1, all BSP surfaces marked with the `SURF_NODRAW` flag
-will be removed from the world at map load time. Should be enabled on some 
-maps outside of the base Quake 2 game where such surfaces are used to provide 
-fake indoor lighting, normally appearing as sky blocks in the middle of a room.
+When this cvar is set to 1, BSP surfaces marked with the `SURF_NODRAW` flag
+will be removed from the world at map load time, with the exception of those
+with a "SKY" type material specified in the materials database.
+Should be enabled on some maps outside of the base Quake 2 game where such
+surfaces are used to provide fake indoor lighting, normally appearing as sky
+blocks in the middle of a room.
+If set to 2, removes all `SURF_NODRAW` surfaces, including those with a
+"proper" sky surface. Should be used if such fake lighting blocks keep
+showing up.
 Default value is 0.
 
 #### `pt_enable_particles`

--- a/src/refresh/vkpt/bsp_mesh.c
+++ b/src/refresh/vkpt/bsp_mesh.c
@@ -403,12 +403,12 @@ static int filter_static_sky(int flags, int surf_flags)
 {
 	enum sky_class_e sky_class = classify_sky(flags, surf_flags);
 
+	if (sky_class == SKY_CLASS_MATERIAL && cvar_pt_enable_nodraw->integer < 2)
+		return 1;
+
 	if (((surf_flags & SURF_NODRAW) && cvar_pt_enable_nodraw->integer) || (sky_class == SKY_CLASS_NODRAW_SKYLIGHT))
 		return 0;
 	
-	if (sky_class == SKY_CLASS_MATERIAL)
-		return 1;
-
 	return 0;
 }
 
@@ -661,22 +661,31 @@ collect_surfaces(uint32_t *prim_ctr, bsp_mesh_t *wm, bsp_t *bsp, int model_idx, 
 		
 		// custom transparent surfaces
 		if (surf_flags & SURF_SKY)
+		{
+			/* Sky: apply filtering _before_ changing the material kind, so we can detect
+			 * materials manually marked as SKY. */
+			if (!filter(material_id, surf_flags))
+				continue;
+
 			material_id = MAT_SetKind(material_id, MATERIAL_KIND_SKY);
+		}
+		else
+		{
+			if (MAT_IsKind(material_id, MATERIAL_KIND_REGULAR) && (surf_flags & SURF_TRANS_MASK) && !(material_id & MATERIAL_FLAG_LIGHT))
+				material_id = MAT_SetKind(material_id, MATERIAL_KIND_TRANSPARENT);
 
-		if (MAT_IsKind(material_id, MATERIAL_KIND_REGULAR) && (surf_flags & SURF_TRANS_MASK) && !(material_id & MATERIAL_FLAG_LIGHT))
-			material_id = MAT_SetKind(material_id, MATERIAL_KIND_TRANSPARENT);
+			if (MAT_IsKind(material_id, MATERIAL_KIND_SCREEN) && (surf_flags & SURF_TRANS_MASK))
+				material_id = MAT_SetKind(material_id, MATERIAL_KIND_GLASS);
 
-		if (MAT_IsKind(material_id, MATERIAL_KIND_SCREEN) && (surf_flags & SURF_TRANS_MASK))
-			material_id = MAT_SetKind(material_id, MATERIAL_KIND_GLASS);
+			if (surf_flags & SURF_WARP)
+				material_id |= MATERIAL_FLAG_WARP;
 
-		if (surf_flags & SURF_WARP)
-			material_id |= MATERIAL_FLAG_WARP;
+			if (surf_flags & SURF_FLOWING)
+				material_id |= MATERIAL_FLAG_FLOWING;
 
-		if (surf_flags & SURF_FLOWING)
-			material_id |= MATERIAL_FLAG_FLOWING;
-
-		if (!filter(material_id, surf_flags))
-			continue;
+			if (!filter(material_id, surf_flags))
+				continue;
+		}
 
 		if ((material_id & MATERIAL_FLAG_LIGHT) && surf->texinfo->material->light_styles)
 		{


### PR DESCRIPTION
The way material kind adjustment & filtering interacted caused, in practice, all "sky" surfaces to be removed if pt_enable_nodraw was set. However, I observed that "fake sky blocks" for lighting would have a meterial that's not a default "sky" material, but something else. In these cases, it would be better to keep "real" sky surfaces (so they eg continue providing lighting) but remove the "fake lighting" surfaces; I changed the material kind adjustment & filtering to work like this. The old behavior is provided by setting pt_enable_nodraw to 2.