### PR TITLE
Sync with Q2PRO: Generalize parsing BSPX extensions.

### DIFF
--- a/src/common/bsp.c
+++ b/src/common/bsp.c
@@ -751,6 +751,12 @@ LOAD(EntString)
 */
 
 typedef struct {
+    const char *name;
+    void (*load)(bsp_t *, const byte *, size_t);
+    size_t (*parse_header)(bsp_t *, const byte *, size_t);
+} xlump_info_t;
+
+typedef struct {
     int (*load)(bsp_t *, const byte *, size_t);
     const char *name;
     uint8_t lump;
@@ -1069,37 +1075,7 @@ bool BSP_SavePatchedPVS(bsp_t *bsp)
 }
 
 #if USE_REF
-static bool BSP_FindBspxLump(const byte *buf, uint32_t pos, uint32_t filelen, const char* name, const void** pLump, uint32_t* pLumpSize)
-{
-    pos = ALIGN(pos, 4);
-    if (pos > filelen - 8)
-        return false;
-    if (RL32(buf + pos) != BSPXHEADER)
-        return false;
-    pos += 8;
-
-    uint32_t numlumps = RL32(buf + pos - 4);
-    if (numlumps > (filelen - pos) / sizeof(xlump_t))
-        return false;
-
-    xlump_t *l = (xlump_t *)(buf + pos);
-    for (int i = 0; i < numlumps; i++, l++) {
-        uint32_t ofs = LittleLong(l->fileofs);
-        uint32_t len = LittleLong(l->filelen);
-        uint32_t end = ofs + len;
-        if (end < ofs || end > filelen)
-            continue;
-
-        if (!strcmp(l->name, name)) {
-            *pLump = buf + ofs;
-            *pLumpSize = len;
-            return true;
-        }
-    }
-    return false;
-}
-
-static void BSP_LoadBspxNormals(bsp_t* bsp, const byte* in, uint32_t data_size)
+static void BSP_LoadBspxNormals(bsp_t* bsp, const byte* in, size_t data_size)
 {
 	if (data_size < sizeof(uint32_t))
 		return;
@@ -1150,7 +1126,12 @@ static void BSP_LoadBspxNormals(bsp_t* bsp, const byte* in, uint32_t data_size)
 	}
 }
 
-static void BSP_ParseDecoupledLM(bsp_t *bsp, const byte *in, uint32_t filelen)
+static size_t BSP_ParseNormalsHeader(bsp_t* bsp, const byte* in, size_t data_size)
+{
+    return data_size;
+}
+
+static void BSP_ParseDecoupledLM(bsp_t *bsp, const byte *in, size_t filelen)
 {
     mface_t *out;
     uint32_t offset;
@@ -1180,35 +1161,52 @@ static void BSP_ParseDecoupledLM(bsp_t *bsp, const byte *in, uint32_t filelen)
     bsp->lm_decoupled = true;
 }
 
-static void BSP_ParseExtensions(bsp_t *bsp, const byte *buf, uint32_t pos, uint32_t filelen)
+static const xlump_info_t bspx_lumps[] = {
+    { "DECOUPLED_LM", BSP_ParseDecoupledLM },
+    { "FACENORMALS", BSP_LoadBspxNormals, BSP_ParseNormalsHeader }
+};
+
+// returns amount of extra data to allocate
+static size_t BSP_ParseExtensionHeader(bsp_t *bsp, lump_t *out, const byte *buf, uint32_t pos, uint32_t filelen)
 {
     pos = ALIGN(pos, 4);
     if (pos > filelen - 8)
-        return;
+        return 0;
     if (RL32(buf + pos) != BSPXHEADER)
-        return;
+        return 0;
     pos += 8;
 
     uint32_t numlumps = RL32(buf + pos - 4);
-    if (numlumps > (filelen - pos) / sizeof(xlump_t))
-        return;
+    if (numlumps > (filelen - pos) / sizeof(xlump_t)) {
+        Com_WPrintf("Bad BSPX header\n");
+        return 0;
+    }
 
+    size_t extrasize = 0;
     xlump_t *l = (xlump_t *)(buf + pos);
     for (int i = 0; i < numlumps; i++, l++) {
         uint32_t ofs = LittleLong(l->fileofs);
         uint32_t len = LittleLong(l->filelen);
         uint32_t end = ofs + len;
-        if (end < ofs || end > filelen)
+        if (end <= ofs || end > filelen)
             continue;
-
-        if (!strcmp(l->name, "DECOUPLED_LM")) {
-            BSP_ParseDecoupledLM(bsp, buf + ofs, len);
-            continue;
-        } else if (!strcmp(l->name, "FACENORMALS")) {
-            BSP_LoadBspxNormals(bsp, buf + ofs, len);
-            continue;
+        for (int j = 0; j < q_countof(bspx_lumps); j++) {
+            const xlump_info_t *e = &bspx_lumps[j];
+            if (strcmp(l->name, e->name))
+                continue;
+            if (out[j].filelen) {
+                Com_WPrintf("Duplicate %s lump\n", e->name);
+                break;
+            }
+            if (e->parse_header)
+                extrasize += e->parse_header(bsp, buf + ofs, len);
+            out[j].fileofs = ofs;
+            out[j].filelen = len;
+            break;
         }
     }
+
+    return extrasize;
 }
 
 #endif
@@ -1306,21 +1304,17 @@ int BSP_Load(const char *name, bsp_t **bsp_p)
         maxpos = max(maxpos, end);
     }
 
-#if USE_REF
-    const void* normal_lump_data = NULL;
-    uint32_t normal_lump_size = 0;
-    if (BSP_FindBspxLump(buf, maxpos, filelen, "FACENORMALS", &normal_lump_data, &normal_lump_size))
-    {
-        memsize += normal_lump_size;
-    }
-#endif
-
     // load into hunk
     len = strlen(name);
     bsp = Z_Mallocz(sizeof(*bsp) + len);
     memcpy(bsp->name, name, len + 1);
     bsp->refcount = 1;
     bsp->extended = extended;
+
+#if USE_REF
+    lump_t ext[q_countof(bspx_lumps)] = { 0 };
+    memsize += BSP_ParseExtensionHeader(bsp, ext, buf, maxpos, filelen);
+#endif
 
     Hunk_Begin(&bsp->hunk, memsize);
 
@@ -1355,7 +1349,12 @@ int BSP_Load(const char *name, bsp_t **bsp_p)
 	}
 
 #if USE_REF
-    BSP_ParseExtensions(bsp, buf, maxpos, filelen);
+    // load extension lumps
+    for (i = 0; i < q_countof(bspx_lumps); i++) {
+        if (ext[i].filelen) {
+            bspx_lumps[i].load(bsp, buf + ext[i].fileofs, ext[i].filelen);
+        }
+    }
 #endif
 
     Hunk_End(&bsp->hunk);


### PR DESCRIPTION
Split BSP_ParseExtensions() into two stages: header parsing to calculate amount of extra space to reserve on hunk, and actual lump loading.

Makes FACENORMALS parsing nicer.