### PR TITLE
Don't special handle RF_FRAMELERP on the client.

### DIFF
--- a/src/client/entities.c
+++ b/src/client/entities.c
@@ -64,7 +64,7 @@ entity_update_new(centity_t *ent, const entity_state_t *state, const vec_t *orig
 
     if (state->event == EV_PLAYER_TELEPORT ||
         state->event == EV_OTHER_TELEPORT ||
-        (state->renderfx & (RF_FRAMELERP | RF_BEAM))) {
+        (state->renderfx & RF_BEAM)) {
         // no lerping if teleported
         VectorCopy(origin, ent->lerp_origin);
         return;
@@ -575,12 +575,7 @@ static void CL_AddPacketEntities(void)
         ent.oldframe = cent->prev.frame;
         ent.backlerp = 1.0f - cl.lerpfrac;
 
-        if (renderfx & RF_FRAMELERP) {
-            // step origin discretely, because the frames
-            // do the animation properly
-            VectorCopy(cent->current.origin, ent.origin);
-            VectorCopy(cent->current.old_origin, ent.oldorigin);  // FIXME
-        } else if (renderfx & RF_BEAM) {
+        if (renderfx & RF_BEAM) {
             // interpolate start and end points for beams
             LerpVector(cent->prev.origin, cent->current.origin,
                        cl.lerpfrac, ent.origin);
@@ -664,7 +659,7 @@ static void CL_AddPacketEntities(void)
 
         // render effects (fullbright, translucent, etc)
         if ((effects & EF_COLOR_SHELL))
-            ent.flags = renderfx & RF_FRAMELERP;    // renderfx go on color shell entity
+            ent.flags = 0;  // renderfx go on color shell entity
         else
             ent.flags = renderfx;
 

--- a/src/refresh/gl/mesh.c
+++ b/src/refresh/gl/mesh.c
@@ -675,12 +675,7 @@ void GL_DrawAliasModel(const model_t *model)
     if (backlerp == 0)
         oldframenum = newframenum;
 
-    // interpolate origin, if necessarry
-    if (ent->flags & RF_FRAMELERP)
-        LerpVector2(ent->oldorigin, ent->origin,
-                    backlerp, frontlerp, origin);
-    else
-        VectorCopy(ent->origin, origin);
+    VectorCopy(ent->origin, origin);
 
     // cull the model, setup scale and translate vectors
     if (newframenum == oldframenum)


### PR DESCRIPTION
Purpose of this flag is unknown. It doesn't seem to do anything useful. Effectively, it just disables entity origin interpolation in CL_AddPacketEntities(), and requires the renderer to do interpolation instead. Use of RF_FRAMELERP also requires old_origin to be always valid. While Q2PRO server guarantees this, other servers may not.

RF_FRAMELERP is actually harmful: because lerp_origin is stepped discretely, effects like particle trails look odd on RF_FRAMELERP entities. Also, since Q2PRO renderer only interpolates origin if RF_FRAMELERP is set, interpolation of linked entities with this flag cleared is broken.

Simply remove special handling of RF_FRAMELERP from client and renderer.

Fixes choppy enemy movement in GL renderer, introduced by 5e2a2d30e8d2101e272a14eff4f93281230aed4f.