### PR TITLE
Sync with Q2PRO: Windows pthread support

### DIFF
--- a/inc/common/async.h
+++ b/inc/common/async.h
@@ -1,0 +1,40 @@
+/*
+Copyright (C) 2023 Andrey Nazarov
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#if USE_CLIENT
+
+typedef struct asyncwork_s {
+    void (*work_cb)(void *);
+    void (*done_cb)(void *);
+    void *cb_arg;
+    struct asyncwork_s *next;
+} asyncwork_t;
+
+void Com_QueueAsyncWork(asyncwork_t *work);
+void Com_CompleteAsyncWork(void);
+void Com_ShutdownAsyncWork(void);
+
+#else
+
+#define Com_QueueAsyncWork(work)    (void)0
+#define Com_CompleteAsyncWork()     (void)0
+#define Com_ShutdownAsyncWork()     (void)0
+
+#endif

--- a/inc/system/pthread.h
+++ b/inc/system/pthread.h
@@ -1,0 +1,100 @@
+/*
+Copyright (C) 2023 Andrey Nazarov
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#ifdef _WIN32
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <errno.h>
+
+#define PTHREAD_MUTEX_INITIALIZER   {0}
+#define PTHREAD_COND_INITIALIZER    {0}
+
+typedef void pthread_attr_t;
+typedef void pthread_mutexattr_t;
+typedef void pthread_condattr_t;
+typedef unsigned int pthread_t;
+
+typedef struct {
+    SRWLOCK srw;
+} pthread_mutex_t;
+
+typedef struct {
+    CONDITION_VARIABLE cond;
+} pthread_cond_t;
+
+static inline int pthread_mutex_init(pthread_mutex_t *mutex, const pthread_mutexattr_t *mutexattr)
+{
+    InitializeSRWLock(&mutex->srw);
+    return 0;
+}
+
+static inline int pthread_mutex_lock(pthread_mutex_t *mutex)
+{
+    AcquireSRWLockExclusive(&mutex->srw);
+    return 0;
+}
+
+static inline int pthread_mutex_trylock(pthread_mutex_t *mutex)
+{
+    return TryAcquireSRWLockExclusive(&mutex->srw) ? 0 : EBUSY;
+}
+
+static inline int pthread_mutex_unlock(pthread_mutex_t *mutex)
+{
+    ReleaseSRWLockExclusive(&mutex->srw);
+    return 0;
+}
+
+static inline int pthread_mutex_destroy(pthread_mutex_t *mutex)
+{
+    return 0;
+}
+
+static inline int pthread_cond_init(pthread_cond_t *cond, pthread_condattr_t *cond_attr)
+{
+    InitializeConditionVariable(&cond->cond);
+    return 0;
+}
+
+static inline int pthread_cond_signal(pthread_cond_t *cond)
+{
+    WakeConditionVariable(&cond->cond);
+    return 0;
+}
+
+static inline int pthread_cond_wait(pthread_cond_t *cond, pthread_mutex_t *mutex)
+{
+    return SleepConditionVariableSRW(&cond->cond, &mutex->srw, INFINITE, 0) ? 0 : ETIMEDOUT;
+}
+
+static inline int pthread_cond_destroy(pthread_cond_t *cond)
+{
+    return 0;
+}
+
+int pthread_create(pthread_t *thread, const pthread_attr_t *attr,
+                   void *(*start_routine)(void *), void *arg);
+
+int pthread_join(pthread_t thread, void **retval);
+
+#else
+#include <pthread.h>
+#endif

--- a/inc/system/system.h
+++ b/inc/system/system.h
@@ -73,22 +73,6 @@ bool Sys_GetAntiCheatAPI(void);
 bool Sys_SetNonBlock(int fd, bool nb);
 #endif
 
-#if USE_CLIENT
-typedef struct asyncwork_s {
-    void (*work_cb)(void *);
-    void (*done_cb)(void *);
-    void *cb_arg;
-    struct asyncwork_s *next;
-} asyncwork_t;
-
-void Sys_QueueAsyncWork(asyncwork_t *work);
-
-typedef struct qthread_s qthread_t;
-
-qthread_t *Sys_CreateThread(void (*func)(void *), void *arg);
-void Sys_JoinThread(qthread_t *t);
-#endif
-
 extern cvar_t   *sys_basedir;
 extern cvar_t   *sys_libdir;
 extern cvar_t   *sys_homedir;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -121,6 +121,7 @@ SET(SRC_CLIENT
 	client/sound/ogg.c
 	client/sound/qal/fixed.c
 #	client/sound/qal/dynamic.c
+	common/async.c
 )
 
 SET(SRC_CLIENT_HTTP
@@ -232,6 +233,7 @@ SET(SRC_WINDOWS
 	windows/ac.c
 	windows/debug.c
 	windows/hunk.c
+	windows/pthread.c
 	windows/system.c
 )
 

--- a/src/common/async.c
+++ b/src/common/async.c
@@ -1,0 +1,118 @@
+/*
+Copyright (C) 2023 Andrey Nazarov
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "shared/shared.h"
+#include "common/async.h"
+#include "common/zone.h"
+#include "system/pthread.h"
+
+static bool work_initialized;
+static bool work_terminate;
+static pthread_mutex_t work_lock;
+static pthread_cond_t work_cond;
+static pthread_t work_thread;
+static asyncwork_t *pend_head;
+static asyncwork_t *done_head;
+
+static void append_work(asyncwork_t **head, asyncwork_t *work)
+{
+    asyncwork_t *c, **p;
+    for (p = head, c = *head; c; p = &c->next, c = c->next)
+        ;
+    work->next = NULL;
+    *p = work;
+}
+
+static void *work_func(void *arg)
+{
+    pthread_mutex_lock(&work_lock);
+    while (1) {
+        while (!pend_head && !work_terminate)
+            pthread_cond_wait(&work_cond, &work_lock);
+
+        asyncwork_t *work = pend_head;
+        if (!work)
+            break;
+        pend_head = work->next;
+
+        pthread_mutex_unlock(&work_lock);
+        work->work_cb(work->cb_arg);
+        pthread_mutex_lock(&work_lock);
+
+        append_work(&done_head, work);
+    }
+    pthread_mutex_unlock(&work_lock);
+
+    return NULL;
+}
+
+void Com_QueueAsyncWork(asyncwork_t *work)
+{
+    if (!work_initialized) {
+        pthread_mutex_init(&work_lock, NULL);
+        pthread_cond_init(&work_cond, NULL);
+        if (pthread_create(&work_thread, NULL, work_func, NULL))
+            Com_Error(ERR_FATAL, "Couldn't create async work thread");
+        work_initialized = true;
+    }
+
+    pthread_mutex_lock(&work_lock);
+    append_work(&pend_head, Z_CopyStruct(work));
+    pthread_mutex_unlock(&work_lock);
+
+    pthread_cond_signal(&work_cond);
+}
+
+void Com_CompleteAsyncWork(void)
+{
+    asyncwork_t *work, *next;
+
+    if (!work_initialized)
+        return;
+    if (pthread_mutex_trylock(&work_lock))
+        return;
+    if (q_unlikely(done_head)) {
+        for (work = done_head; work; work = next) {
+            next = work->next;
+            if (work->done_cb)
+                work->done_cb(work->cb_arg);
+            Z_Free(work);
+        }
+        done_head = NULL;
+    }
+    pthread_mutex_unlock(&work_lock);
+}
+
+void Com_ShutdownAsyncWork(void)
+{
+    if (!work_initialized)
+        return;
+
+    pthread_mutex_lock(&work_lock);
+    work_terminate = true;
+    pthread_mutex_unlock(&work_lock);
+
+    pthread_cond_signal(&work_cond);
+
+    Q_assert(!pthread_join(work_thread, NULL));
+    Com_CompleteAsyncWork();
+
+    pthread_mutex_destroy(&work_lock);
+    pthread_cond_destroy(&work_cond);
+    work_initialized = false;
+}

--- a/src/common/common.c
+++ b/src/common/common.c
@@ -23,6 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "shared/shared.h"
 
+#include "common/async.h"
 #include "common/bsp.h"
 #include "common/cmd.h"
 #include "common/cmodel.h"
@@ -614,6 +615,7 @@ void Com_Quit(const char *reason, error_type_t type)
     NET_Shutdown();
     logfile_close();
     FS_Shutdown();
+    Com_ShutdownAsyncWork();
 
     Sys_Quit();
     // doesn't get there
@@ -1056,6 +1058,8 @@ void Qcommon_Frame(void)
     if (setjmp(com_abortframe)) {
         return;            // an ERR_DROP was thrown
     }
+
+    Com_CompleteAsyncWork();
 
 #if USE_CLIENT
     time_before = time_event = time_between = time_after = 0;

--- a/src/refresh/images.c
+++ b/src/refresh/images.c
@@ -23,6 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 //
 
 #include "shared/shared.h"
+#include "common/async.h"
 #include "common/common.h"
 #include "common/cvar.h"
 #include "common/files.h"
@@ -618,7 +619,7 @@ static void make_screenshot(const char *name, const char *ext,
             .done_cb = screenshot_done_cb,
             .cb_arg = Z_CopyStruct(&s),
         };
-        Sys_QueueAsyncWork(&work);
+        Com_QueueAsyncWork(&work);
     } else {
         screenshot_work_cb(&s);
         screenshot_done_cb(&s);
@@ -659,7 +660,7 @@ static void make_screenshot_hdr(const char *name, bool async)
             .done_cb = screenshot_done_cb,
             .cb_arg = Z_CopyStruct(&s),
         };
-        Sys_QueueAsyncWork(&work);
+        Com_QueueAsyncWork(&work);
     } else {
         screenshot_work_cb(&s);
         screenshot_done_cb(&s);

--- a/src/unix/system.c
+++ b/src/unix/system.c
@@ -63,147 +63,6 @@ static bool flush_logs;
 /*
 ===============================================================================
 
-ASYNC WORK QUEUE
-
-===============================================================================
-*/
-
-#if USE_CLIENT
-
-static bool work_initialized;
-static bool work_terminate;
-static pthread_mutex_t work_lock;
-static pthread_cond_t work_cond;
-static pthread_t work_thread;
-static asyncwork_t *pend_head;
-static asyncwork_t *done_head;
-
-static void append_work(asyncwork_t **head, asyncwork_t *work)
-{
-    asyncwork_t *c, **p;
-    for (p = head, c = *head; c; p = &c->next, c = c->next);
-    work->next = NULL;
-    *p = work;
-}
-
-static void complete_work(void)
-{
-    asyncwork_t *work, *next;
-
-    if (!work_initialized)
-        return;
-    if (pthread_mutex_trylock(&work_lock))
-        return;
-    if (q_unlikely(done_head)) {
-        for (work = done_head; work; work = next) {
-            next = work->next;
-            if (work->done_cb)
-                work->done_cb(work->cb_arg);
-            Z_Free(work);
-        }
-        done_head = NULL;
-    }
-    pthread_mutex_unlock(&work_lock);
-}
-
-static void *work_func(void *arg)
-{
-    pthread_mutex_lock(&work_lock);
-    while (1) {
-        while (!pend_head && !work_terminate)
-            pthread_cond_wait(&work_cond, &work_lock);
-
-        asyncwork_t *work = pend_head;
-        if (!work)
-            break;
-        pend_head = work->next;
-
-        pthread_mutex_unlock(&work_lock);
-        work->work_cb(work->cb_arg);
-        pthread_mutex_lock(&work_lock);
-
-        append_work(&done_head, work);
-    }
-    pthread_mutex_unlock(&work_lock);
-
-    return NULL;
-}
-
-static void shutdown_work(void)
-{
-    if (!work_initialized)
-        return;
-
-    pthread_mutex_lock(&work_lock);
-    work_terminate = true;
-    pthread_mutex_unlock(&work_lock);
-
-    pthread_cond_signal(&work_cond);
-
-    pthread_join(work_thread, NULL);
-    complete_work();
-
-    pthread_mutex_destroy(&work_lock);
-    pthread_cond_destroy(&work_cond);
-    work_initialized = false;
-}
-
-void Sys_QueueAsyncWork(asyncwork_t *work)
-{
-    if (!work_initialized) {
-        pthread_mutex_init(&work_lock, NULL);
-        pthread_cond_init(&work_cond, NULL);
-        if (pthread_create(&work_thread, NULL, work_func, NULL))
-            Sys_Error("Couldn't create async work thread");
-        work_initialized = true;
-    }
-
-    pthread_mutex_lock(&work_lock);
-    append_work(&pend_head, Z_CopyStruct(work));
-    pthread_mutex_unlock(&work_lock);
-
-    pthread_cond_signal(&work_cond);
-}
-
-struct qthread_s {
-    void (*func)(void *);
-    void *arg;
-    pthread_t handle;
-};
-
-static void *thread_func(void *arg)
-{
-    qthread_t *t = arg;
-    t->func(t->arg);
-    return NULL;
-}
-
-qthread_t *Sys_CreateThread(void (*func)(void *), void *arg)
-{
-    qthread_t *t = Z_Malloc(sizeof(*t));
-    t->func = func;
-    t->arg = arg;
-    if (pthread_create(&t->handle, NULL, thread_func, t)) {
-        Z_Free(t);
-        return NULL;
-    }
-    return t;
-}
-
-void Sys_JoinThread(qthread_t *t)
-{
-    pthread_join(t->handle, NULL);
-    Z_Free(t);
-}
-
-#else
-#define shutdown_work() (void)0
-#define complete_work() (void)0
-#endif
-
-/*
-===============================================================================
-
 GENERAL ROUTINES
 
 ===============================================================================
@@ -230,7 +89,6 @@ This function never returns.
 */
 void Sys_Quit(void)
 {
-    shutdown_work();
     tty_shutdown_input();
 #if USE_SDL
     SDL_Quit();
@@ -693,7 +551,6 @@ int main(int argc, char **argv)
 
     Qcommon_Init(argc, argv);
     while (!terminate) {
-        complete_work();
         if (flush_logs) {
             Com_FlushLogs();
             flush_logs = false;

--- a/src/unix/system.c
+++ b/src/unix/system.c
@@ -136,8 +136,9 @@ static void shutdown_work(void)
 
     pthread_mutex_lock(&work_lock);
     work_terminate = true;
-    pthread_cond_signal(&work_cond);
     pthread_mutex_unlock(&work_lock);
+
+    pthread_cond_signal(&work_cond);
 
     pthread_join(work_thread, NULL);
     complete_work();
@@ -159,8 +160,9 @@ void Sys_QueueAsyncWork(asyncwork_t *work)
 
     pthread_mutex_lock(&work_lock);
     append_work(&pend_head, Z_CopyStruct(work));
-    pthread_cond_signal(&work_cond);
     pthread_mutex_unlock(&work_lock);
+
+    pthread_cond_signal(&work_cond);
 }
 
 struct qthread_s {

--- a/src/windows/pthread.c
+++ b/src/windows/pthread.c
@@ -1,0 +1,96 @@
+/*
+Copyright (C) 2023 Andrey Nazarov
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "client.h"
+#include "shared/list.h"
+#include "system/pthread.h"
+#include <process.h>
+
+typedef struct {
+    list_t entry;
+    void *(*func)(void *);
+    void *arg, *ret;
+    HANDLE handle;
+    DWORD id;
+} winthread_t;
+
+static LIST_DECL(threads);
+static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+
+static winthread_t *find_thread(pthread_t thread)
+{
+    winthread_t *t;
+
+    LIST_FOR_EACH(winthread_t, t, &threads, entry)
+        if (t->id == thread)
+            return t;
+
+    return NULL;
+}
+
+static unsigned __stdcall thread_func(void *arg)
+{
+    winthread_t *t = arg;
+    t->ret = t->func(t->arg);
+    return 0;
+}
+
+int pthread_create(pthread_t *thread, const pthread_attr_t *attr,
+                   void *(*start_routine)(void *), void *arg)
+{
+    int ret = 0;
+    pthread_mutex_lock(&mutex);
+    winthread_t *t = malloc(sizeof(*t));
+    if (!t) {
+        ret = EAGAIN;
+        goto done;
+    }
+    t->func = start_routine;
+    t->arg = arg;
+    t->handle = (HANDLE)_beginthreadex(NULL, 0, thread_func, t, 0, thread);
+    if (!t->handle) {
+        free(t);
+        ret = EAGAIN;
+        goto done;
+    }
+    t->id = *thread;
+    List_Append(&threads, &t->entry);
+done:
+    pthread_mutex_unlock(&mutex);
+    return ret;
+}
+
+int pthread_join(pthread_t thread, void **retval)
+{
+    int ret = 0;
+    pthread_mutex_lock(&mutex);
+    winthread_t *t = find_thread(thread);
+    if (!t) {
+        ret = ESRCH;
+        goto done;
+    }
+    WaitForSingleObject(t->handle, INFINITE);
+    CloseHandle(t->handle);
+    List_Remove(&t->entry);
+    if (retval)
+        *retval = t->ret;
+    free(t);
+done:
+    pthread_mutex_unlock(&mutex);
+    return ret;
+}

--- a/src/windows/system.c
+++ b/src/windows/system.c
@@ -21,10 +21,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "common/field.h"
 #include "common/prompt.h"
 
-#if USE_CLIENT
-#include <process.h>
-#endif
-
 #if USE_WINSVC
 #include <winsvc.h>
 #include <setjmp.h>
@@ -772,150 +768,6 @@ fail:
 /*
 ===============================================================================
 
-ASYNC WORK QUEUE
-
-===============================================================================
-*/
-
-#if USE_CLIENT
-
-static bool work_initialized;
-static bool work_terminate;
-static CRITICAL_SECTION work_crit;
-static CONDITION_VARIABLE work_cond;
-static HANDLE work_thread;
-static asyncwork_t *pend_head;
-static asyncwork_t *done_head;
-
-static void append_work(asyncwork_t **head, asyncwork_t *work)
-{
-    asyncwork_t *c, **p;
-    for (p = head, c = *head; c; p = &c->next, c = c->next);
-    work->next = NULL;
-    *p = work;
-}
-
-static void complete_work(void)
-{
-    asyncwork_t *work, *next;
-
-    if (!work_initialized)
-        return;
-    if (!TryEnterCriticalSection(&work_crit))
-        return;
-    if (q_unlikely(done_head)) {
-        for (work = done_head; work; work = next) {
-            next = work->next;
-            if (work->done_cb)
-                work->done_cb(work->cb_arg);
-            Z_Free(work);
-        }
-        done_head = NULL;
-    }
-    LeaveCriticalSection(&work_crit);
-}
-
-static unsigned __stdcall work_func(void *arg)
-{
-    EnterCriticalSection(&work_crit);
-    while (1) {
-        while (!pend_head && !work_terminate)
-            SleepConditionVariableCS(&work_cond, &work_crit, INFINITE);
-
-        asyncwork_t *work = pend_head;
-        if (!work)
-            break;
-        pend_head = work->next;
-
-        LeaveCriticalSection(&work_crit);
-        work->work_cb(work->cb_arg);
-        EnterCriticalSection(&work_crit);
-
-        append_work(&done_head, work);
-    }
-    LeaveCriticalSection(&work_crit);
-
-    return 0;
-}
-
-static void shutdown_work(void)
-{
-    if (!work_initialized)
-        return;
-
-    EnterCriticalSection(&work_crit);
-    work_terminate = true;
-    LeaveCriticalSection(&work_crit);
-
-    WakeConditionVariable(&work_cond);
-
-    WaitForSingleObject(work_thread, INFINITE);
-    complete_work();
-
-    DeleteCriticalSection(&work_crit);
-    CloseHandle(work_thread);
-    work_initialized = false;
-}
-
-void Sys_QueueAsyncWork(asyncwork_t *work)
-{
-    if (!work_initialized) {
-        InitializeCriticalSection(&work_crit);
-        InitializeConditionVariable(&work_cond);
-        work_thread = (HANDLE)_beginthreadex(NULL, 0, work_func, NULL, 0, NULL);
-        if (!work_thread)
-            Sys_Error("Couldn't create async work thread");
-        work_initialized = true;
-    }
-
-    EnterCriticalSection(&work_crit);
-    append_work(&pend_head, Z_CopyStruct(work));
-    LeaveCriticalSection(&work_crit);
-
-    WakeConditionVariable(&work_cond);
-}
-
-struct qthread_s {
-    void (*func)(void *);
-    void *arg;
-    HANDLE handle;
-};
-
-static unsigned __stdcall thread_func(void *arg)
-{
-    qthread_t *t = arg;
-    t->func(t->arg);
-    return 0;
-}
-
-qthread_t *Sys_CreateThread(void (*func)(void *), void *arg)
-{
-    qthread_t *t = Z_Malloc(sizeof(*t));
-    t->func = func;
-    t->arg = arg;
-    t->handle = (HANDLE)_beginthreadex(NULL, 0, thread_func, t, 0, NULL);
-    if (!t->handle) {
-        Z_Free(t);
-        return NULL;
-    }
-    return t;
-}
-
-void Sys_JoinThread(qthread_t *t)
-{
-    WaitForSingleObject(t->handle, INFINITE);
-    CloseHandle(t->handle);
-    Z_Free(t);
-}
-
-#else
-#define shutdown_work() (void)0
-#define complete_work() (void)0
-#endif
-
-/*
-===============================================================================
-
 MISC
 
 ===============================================================================
@@ -1003,8 +855,6 @@ This function never returns.
 */
 void Sys_Quit(void)
 {
-    shutdown_work();
-
 #if USE_WINSVC
     if (statusHandle)
         longjmp(exitBuf, 1);
@@ -1379,10 +1229,8 @@ static int Sys_Main(int argc, char **argv)
     Qcommon_Init(argc, argv);
 
     // main program loop
-    while (!shouldExit) {
-        complete_work();
+    while (!shouldExit)
         Qcommon_Frame();
-    }
 
     Com_Quit(NULL, ERR_DISCONNECT);
     return 0;   // never gets here


### PR DESCRIPTION
Adds a pthread "emulation" for Windows.

A number of upstream changes make use of these threading changes, so this is a prerequisite for future porting of the former.