### PR TITLE
Fix gcc warning that fov_scale may be used uninitialized

### DIFF
--- a/src/refresh/vkpt/main.c
+++ b/src/refresh/vkpt/main.c
@@ -2651,7 +2651,7 @@ prepare_ubo(refdef_t *fd, mleaf_t* viewleaf, const reference_mode_t* ref_mode, c
 	float vfov = fd->fov_y * (float)M_PI / 180.f;
 	float unscaled_aspect = (float)qvk.extent_unscaled.width / (float)qvk.extent_unscaled.height;
 	float rad_per_pixel;
-	float fov_scale[2];
+	float fov_scale[2] = { 0.f, 0.f };
 
 	switch (cvar_pt_projection->integer)
 	{


### PR DESCRIPTION
...which is actually true for `PROJECTION_CYLINDRICAL`.