### PR TITLE
Added Panini Projection to pt_projection

### DIFF
--- a/baseq2/q2rtx.menu
+++ b/baseq2/q2rtx.menu
@@ -133,7 +133,7 @@ begin video
     pairs "full screen display" vid_display $vid_displaylist
     toggle "vertical sync" vid_vsync
     pairs "FPS counter" scr_fps "off" 0 "show FPS" 1 "show FPS and resolution scale" 2
-    range -f "%.0f deg" "field of view" fov 60 120 5
+    range -f "%.0f deg" "field of view" fov 60 160 5
     blank
 
     ifeq vid_rtx 1
@@ -159,7 +159,7 @@ begin video
         pairs "texture filtering" pt_nearest "anisotropic" 0 "mixed" 1 "nearest (noisy)" 2
         pairs --status "experimental feature - simulates reflection and refraction effects in thick glass" \
             "thick glass refraction" pt_thick_glass "disabled" 0 "photo mode only" 1 "enabled" 2
-        pairs projection pt_projection perspective 0 cylindrical 1 equirectangular 2 mercator 3 stereographic 4
+        pairs projection pt_projection perspective 0 cylindrical 1 equirectangular 2 mercator 3 stereographic 4 panini 5
         blank
 		pairs "multi-gpu support" sli "disabled" 0 "when available" 1
         pairs "ray tracing API" ray_tracing_api "automatic selection" "auto" "prefer KHR_ray_query" "query"  "prefer KHR_ray_tracing_pipeline" "pipeline"

--- a/baseq2/q2rtx.menu
+++ b/baseq2/q2rtx.menu
@@ -159,7 +159,7 @@ begin video
         pairs "texture filtering" pt_nearest "anisotropic" 0 "mixed" 1 "nearest (noisy)" 2
         pairs --status "experimental feature - simulates reflection and refraction effects in thick glass" \
             "thick glass refraction" pt_thick_glass "disabled" 0 "photo mode only" 1 "enabled" 2
-        pairs projection pt_projection perspective 0 cylindrical 1 equirectangular 2 mercator 3 stereographic 4 panini 5
+        pairs projection pt_projection perspective 0 panini 1 stereographic 2 cylindrical 3 equirectangular 4 mercator 5
         blank
 		pairs "multi-gpu support" sli "disabled" 0 "when available" 1
         pairs "ray tracing API" ray_tracing_api "automatic selection" "auto" "prefer KHR_ray_query" "query"  "prefer KHR_ray_tracing_pipeline" "pipeline"

--- a/doc/client.md
+++ b/doc/client.md
@@ -911,11 +911,11 @@ Size of new particles, before they fade out, in world units. Default value is 0.
 Selects the projection to use for rendering. Default value is 0.
 
 - 0 — regular perspective projection
-- 1 — cylindrical projection
-- 2 — equirectangular projection
-- 3 — mercator projection
-- 4 — stereographic projection
-- 5 — panini (cylindrical stereographic) projection
+- 1 — panini (cylindrical stereographic) projection
+- 2 — stereographic projection
+- 3 — cylindrical projection
+- 4 — equirectangular projection
+- 5 — mercator projection
 
 #### `pt_reflect_refract`
 Number of reflection or refraction bounces to trace. Default value is 2.

--- a/doc/client.md
+++ b/doc/client.md
@@ -915,6 +915,7 @@ Selects the projection to use for rendering. Default value is 0.
 - 2 — equirectangular projection
 - 3 — mercator projection
 - 4 — stereographic projection
+- 5 — panini (cylindrical stereographic) projection
 
 #### `pt_reflect_refract`
 Number of reflection or refraction bounces to trace. Default value is 2.

--- a/src/refresh/vkpt/main.c
+++ b/src/refresh/vkpt/main.c
@@ -2669,7 +2669,11 @@ prepare_ubo(refdef_t *fd, mleaf_t* viewleaf, const reference_mode_t* ref_mode, c
 		fov_scale[0] = fov_scale[1] * unscaled_aspect;
 		break;
 	case PROJECTION_STEREOGRAPHIC:
-		fov_scale[1] = tanf(vfov / 2.f * 0.5f);
+		fov_scale[1] = tanf(vfov / 2.f * STEREOGRAPHIC_ANGLE);
+		fov_scale[0] = fov_scale[1] * unscaled_aspect;
+		break;
+	case PROJECTION_PANINI:
+		fov_scale[1] = tanf(vfov / 2.f);
 		fov_scale[0] = fov_scale[1] * unscaled_aspect;
 		break;
 	}

--- a/src/refresh/vkpt/main.c
+++ b/src/refresh/vkpt/main.c
@@ -2656,6 +2656,14 @@ prepare_ubo(refdef_t *fd, mleaf_t* viewleaf, const reference_mode_t* ref_mode, c
 	switch (cvar_pt_projection->integer)
 	{
 	default:
+	case PROJECTION_PANINI:
+		fov_scale[1] = tanf(vfov / 2.f);
+		fov_scale[0] = fov_scale[1] * unscaled_aspect;
+		break;
+	case PROJECTION_STEREOGRAPHIC:
+		fov_scale[1] = tanf(vfov / 2.f * STEREOGRAPHIC_ANGLE);
+		fov_scale[0] = fov_scale[1] * unscaled_aspect;
+		break;
 	case PROJECTION_CYLINDRICAL:
 		rad_per_pixel = atanf(tanf(fd->fov_y * (float)M_PI / 360.f) / ((float)qvk.extent_unscaled.height * 0.5f));
 		ubo->cylindrical_hfov = rad_per_pixel * (float)qvk.extent_unscaled.width;
@@ -2666,14 +2674,6 @@ prepare_ubo(refdef_t *fd, mleaf_t* viewleaf, const reference_mode_t* ref_mode, c
 		break;
 	case PROJECTION_MERCATOR:
 		fov_scale[1] = logf(tanf((float)M_PI * 0.25f + (vfov / 2.f) * 0.5f));
-		fov_scale[0] = fov_scale[1] * unscaled_aspect;
-		break;
-	case PROJECTION_STEREOGRAPHIC:
-		fov_scale[1] = tanf(vfov / 2.f * STEREOGRAPHIC_ANGLE);
-		fov_scale[0] = fov_scale[1] * unscaled_aspect;
-		break;
-	case PROJECTION_PANINI:
-		fov_scale[1] = tanf(vfov / 2.f);
 		fov_scale[0] = fov_scale[1] * unscaled_aspect;
 		break;
 	}

--- a/src/refresh/vkpt/main.c
+++ b/src/refresh/vkpt/main.c
@@ -2655,7 +2655,6 @@ prepare_ubo(refdef_t *fd, mleaf_t* viewleaf, const reference_mode_t* ref_mode, c
 
 	switch (cvar_pt_projection->integer)
 	{
-	default:
 	case PROJECTION_PANINI:
 		fov_scale[1] = tanf(vfov / 2.f);
 		fov_scale[0] = fov_scale[1] * unscaled_aspect;

--- a/src/refresh/vkpt/shader/constants.h
+++ b/src/refresh/vkpt/shader/constants.h
@@ -175,11 +175,13 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 // Projection modes
 #define PROJECTION_RECTILINEAR      0
-#define PROJECTION_CYLINDRICAL      1
-#define PROJECTION_EQUIRECTANGULAR  2
-#define PROJECTION_MERCATOR         3
-#define PROJECTION_STEREOGRAPHIC    4
-#define PROJECTION_PANINI           5
+#define PROJECTION_PANINI           1
+#define PROJECTION_STEREOGRAPHIC    2
+#define PROJECTION_CYLINDRICAL      3
+#define PROJECTION_EQUIRECTANGULAR  4
+#define PROJECTION_MERCATOR         5
+
+
 
 // Projection constants
 #define STEREOGRAPHIC_ANGLE			0.5

--- a/src/refresh/vkpt/shader/constants.h
+++ b/src/refresh/vkpt/shader/constants.h
@@ -179,5 +179,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define PROJECTION_EQUIRECTANGULAR  2
 #define PROJECTION_MERCATOR         3
 #define PROJECTION_STEREOGRAPHIC    4
+#define PROJECTION_PANINI           5
+
+// Projection constants
+#define STEREOGRAPHIC_ANGLE			0.5
+#define PANINI_D			        1.0		// 0.0 -> rectilinear, 1.0 -> cylindrical stereographic, +inf -> cylindrical orthographic
 
 #endif /*_CONSTANTS_H_*/

--- a/src/refresh/vkpt/shader/projection.glsl
+++ b/src/refresh/vkpt/shader/projection.glsl
@@ -158,7 +158,7 @@ bool stereographic_forward(vec3 view_pos, out vec2 screen_pos, out float distanc
 	}
 	else
 	{
-		float r = tan(theta * 0.5f);
+		float r = tan(theta * STEREOGRAPHIC_ANGLE);
 		float c = r / sqrt(x * x + y * y);
 		screen_pos.x = x * c;
 		screen_pos.y = y * c;
@@ -174,13 +174,42 @@ vec3 stereographic_reverse(vec2 screen_pos, float distance, bool previous)
 	float x = screen_pos.x;
 	float y = screen_pos.y;
 	float r = sqrt(x * x + y * y);
-	float theta = atan(r) / 0.5f;
+	float theta = atan(r) / STEREOGRAPHIC_ANGLE;
 	float s = sin(theta);
 	view_dir.x = x / r * s;
 	view_dir.y = -y / r * s;
 	view_dir.z = cos(theta);
 	return view_dir * distance;
 }
+
+bool panini_forward(vec3 view_pos, out vec2 screen_pos, out float distance, bool previous)
+{
+	float lat, lon;
+	distance = length(view_pos);
+	view_pos = normalize(view_pos);
+	view_to_lonlat(view_pos, lon, lat);
+	float S = (PANINI_D + 1.0) / (PANINI_D + cos(lon));
+	screen_pos.x = S * sin(lon);
+	screen_pos.y = S * tan(lat);
+	screen_pos = screen_pos / get_projection_fov_scale(previous) * 0.5 + 0.5;
+	return true;
+}
+
+vec3 panini_reverse(vec2 screen_pos, float distance, bool previous)
+{
+	const float c_D = PANINI_D;		// Stereo
+	vec3 view_dir;
+	screen_pos = (screen_pos * 2.0 - 1.0) * get_projection_fov_scale(previous);
+	float k = screen_pos.x * screen_pos.x / ((c_D + 1.0) * (c_D + 1.0));
+	float dscr = k * k * c_D * c_D - (k + 1) * (k * c_D * c_D - 1.0);
+	float clon = (-k * c_D + sqrt(dscr)) / (k + 1.0);
+	float S = (c_D + 1.0) / (c_D + clon);
+	float lon = atan(screen_pos.x, S * clon);
+	float lat = atan(screen_pos.y, S);
+	lonlat_to_view(lon, lat, view_dir);
+	return view_dir * distance;
+}
+
 
 bool projection_view_to_screen(vec3 view_pos, out vec2 screen_pos, out float distance, bool previous)
 {
@@ -197,6 +226,8 @@ bool projection_view_to_screen(vec3 view_pos, out vec2 screen_pos, out float dis
 		mercator_forward(view_pos, screen_pos, distance, previous); break;
 	case PROJECTION_STEREOGRAPHIC:
 		stereographic_forward(view_pos, screen_pos, distance, previous); break;
+	case PROJECTION_PANINI:
+		panini_forward(view_pos, screen_pos, distance, previous); break;
 	}
 	return true;
 }
@@ -216,5 +247,7 @@ vec3 projection_screen_to_view(vec2 screen_pos, float distance, bool previous)
 		return mercator_reverse(screen_pos, distance, previous);
 	case PROJECTION_STEREOGRAPHIC:
 		return stereographic_reverse(screen_pos, distance, previous);
+	case PROJECTION_PANINI:
+		return panini_reverse(screen_pos, distance, previous);
 	}
 }

--- a/src/refresh/vkpt/shader/projection.glsl
+++ b/src/refresh/vkpt/shader/projection.glsl
@@ -218,16 +218,16 @@ bool projection_view_to_screen(vec3 view_pos, out vec2 screen_pos, out float dis
 	default:
 	case PROJECTION_RECTILINEAR:
 		rectilinear_forward(view_pos, screen_pos, distance, previous); break;
+	case PROJECTION_PANINI:
+		panini_forward(view_pos, screen_pos, distance, previous); break;
+	case PROJECTION_STEREOGRAPHIC:
+		stereographic_forward(view_pos, screen_pos, distance, previous); break;
 	case PROJECTION_CYLINDRICAL:
 		cylindrical_forward(view_pos, screen_pos, distance, previous); break;
 	case PROJECTION_EQUIRECTANGULAR:
 		equirectangular_forward(view_pos, screen_pos, distance, previous); break;
 	case PROJECTION_MERCATOR:
 		mercator_forward(view_pos, screen_pos, distance, previous); break;
-	case PROJECTION_STEREOGRAPHIC:
-		stereographic_forward(view_pos, screen_pos, distance, previous); break;
-	case PROJECTION_PANINI:
-		panini_forward(view_pos, screen_pos, distance, previous); break;
 	}
 	return true;
 }
@@ -239,15 +239,15 @@ vec3 projection_screen_to_view(vec2 screen_pos, float distance, bool previous)
 	default:
 	case PROJECTION_RECTILINEAR:
 		return rectlinear_reverse(screen_pos, distance, previous);
+	case PROJECTION_PANINI:
+		return panini_reverse(screen_pos, distance, previous);
+	case PROJECTION_STEREOGRAPHIC:
+		return stereographic_reverse(screen_pos, distance, previous);
 	case PROJECTION_CYLINDRICAL:
 		return cylindrical_reverse(screen_pos, distance, previous);
 	case PROJECTION_EQUIRECTANGULAR:
 		return equirectangular_reverse(screen_pos, distance, previous);
 	case PROJECTION_MERCATOR:
 		return mercator_reverse(screen_pos, distance, previous);
-	case PROJECTION_STEREOGRAPHIC:
-		return stereographic_reverse(screen_pos, distance, previous);
-	case PROJECTION_PANINI:
-		return panini_reverse(screen_pos, distance, previous);
 	}
 }


### PR DESCRIPTION
Added the Panini projection, specifically the "cylindrical stereographic" version with the parameter D = 1.0

D can be any value in order to seamlessly scale between projections:
D = 0 gives the rectilinear projection
D = +inf should give the "cylindrical
orthographic projection"

More info in this paper on why Panini is natural for the human eye:
http://dx.doi.org/10.2312/COMPAESTH/COMPAESTH10/009-016

Question:
Perhaps the Panini and Stereographic projections should be given a lower pt_projection values, as these are the most useful next to rectilinear? Cylindrical, mercator, etc. are just for demonstration, but very disorienting to use in an actual game.