### PR TITLE
Sync with Q2PRO: Water warp effect

### DIFF
--- a/doc/client.md
+++ b/doc/client.md
@@ -1113,7 +1113,7 @@ Default value is 1 (enabled).
 
 #### `gl_waterwarp`
 Enable screen warping effect when underwater. Only effective when using
-GLSL backend. Default value is 1 (enabled).
+GLSL backend. Default value is 0 (disabled).
 
 #### `gl_fontshadow`
 Specifies font shadow width, in pixels, ranging from 0 to 2. Default value

--- a/doc/client.md
+++ b/doc/client.md
@@ -1111,6 +1111,10 @@ Default value is 1 (downsampling enabled).
 Enable skybox texturing. 0 means to draw sky box in solid black color.
 Default value is 1 (enabled).
 
+#### `gl_waterwarp`
+Enable screen warping effect when underwater. Only effective when using
+GLSL backend. Default value is 1 (enabled).
+
 #### `gl_fontshadow`
 Specifies font shadow width, in pixels, ranging from 0 to 2. Default value
 is 0 (no shadow).

--- a/doc/client.md
+++ b/doc/client.md
@@ -958,6 +958,9 @@ Switch for the experimental thick glass refraction feature. Default value is 0.
 Extinction coefficient scaler for water, slime and lava. Higher values make water thicker.
 Default value is 0.5.
 
+#### `pt_waterwarp`
+Enable post-processing warping screen effect when underwater. Default value is 0 (disabled).
+
 #### `sky_amb_phase_g` 
 Controls the eccentricity of the scattering phase function for the ambient light 
 scattering in the clouds. Default value is 0.3.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -324,7 +324,7 @@ set(SRC_SHADERS
 	refresh/vkpt/shader/sky_buffer_resolve.comp
 	refresh/vkpt/shader/stretch_pic.frag
 	refresh/vkpt/shader/stretch_pic.vert
-	refresh/vkpt/shader/final_blit_lanczos.frag
+	refresh/vkpt/shader/final_blit.frag
 	refresh/vkpt/shader/final_blit.vert
 	refresh/vkpt/shader/fsr_easu_fp16.comp
 	refresh/vkpt/shader/fsr_easu_fp32.comp

--- a/src/refresh/gl/gl.h
+++ b/src/refresh/gl/gl.h
@@ -59,7 +59,8 @@ typedef struct {
     void (*init)(void);
     void (*shutdown)(void);
     void (*clear_state)(void);
-    void (*update)(void);
+    void (*setup_2d)(void);
+    void (*setup_3d)(void);
 
     void (*load_proj_matrix)(const GLfloat *matrix);
     void (*load_view_matrix)(const GLfloat *matrix);
@@ -86,6 +87,9 @@ typedef struct {
         GLuint      bufnum;
         vec_t       size;
     } world;
+    GLuint          warp_texture;
+    GLuint          warp_renderbuffer;
+    GLuint          warp_framebuffer;
     GLuint          u_bufnum;
     GLuint          programs[MAX_PROGRAMS];
     GLuint          texnums[NUM_TEXNUMS];
@@ -115,6 +119,9 @@ typedef struct {
     GLfloat         entmatrix[16];
     lightpoint_t    lightpoint;
     int             num_beams;
+    int             framebuffer_width;
+    int             framebuffer_height;
+    bool            framebuffer_ok;
 } glRefdef_t;
 
 enum {
@@ -203,6 +210,7 @@ extern cvar_t *gl_lockpvs;
 extern cvar_t *gl_lightmap;
 extern cvar_t *gl_fullbright;
 extern cvar_t *gl_vertexlight;
+extern cvar_t *gl_showerrors;
 
 typedef enum {
     CULL_OUT,
@@ -344,6 +352,8 @@ typedef struct {
         GLfloat     modulate;
         GLfloat     add;
         GLfloat     intensity;
+        GLfloat     w_amp[2];
+        GLfloat     w_phase[2];
         GLfloat     scroll[2];
         GLfloat     pad[2];
     } u_block;
@@ -442,7 +452,7 @@ void GL_DrawOutlines(GLsizei count, QGL_INDEX_TYPE *indices);
 void GL_Ortho(GLfloat xmin, GLfloat xmax, GLfloat ymin, GLfloat ymax, GLfloat znear, GLfloat zfar);
 void GL_Frustum(GLfloat fov_x, GLfloat fov_y, GLfloat reflect_x);
 void GL_Setup2D(void);
-void GL_Setup3D(void);
+void GL_Setup3D(bool waterwarp);
 void GL_ClearState(void);
 void GL_InitState(void);
 void GL_ShutdownState(void);
@@ -509,6 +519,8 @@ void Scrap_Upload(void);
 
 void GL_InitImages(void);
 void GL_ShutdownImages(void);
+
+bool GL_InitWarpTexture(void);
 
 extern cvar_t *gl_intensity;
 

--- a/src/refresh/gl/main.c
+++ b/src/refresh/gl/main.c
@@ -788,7 +788,7 @@ static void GL_Register(void)
     gl_fontshadow = Cvar_Get("gl_fontshadow", "0", 0);
     gl_shaders = Cvar_Get("gl_shaders", (gl_config.caps & QGL_CAP_SHADER) ? "1" : "0", CVAR_REFRESH);
     gl_use_hd_assets = Cvar_Get("gl_use_hd_assets", "0", CVAR_FILES);
-    gl_waterwarp = Cvar_Get("gl_waterwarp", "1", 0);
+    gl_waterwarp = Cvar_Get("gl_waterwarp", "0", 0);
     vid_vsync = Cvar_Get("vid_vsync", "0", CVAR_ARCHIVE);
     vid_vsync->changed = vid_vsync_changed;
 

--- a/src/refresh/gl/main.c
+++ b/src/refresh/gl/main.c
@@ -48,6 +48,7 @@ cvar_t *gl_doublelight_entities;
 cvar_t *gl_fontshadow;
 cvar_t *gl_shaders;
 cvar_t *gl_use_hd_assets;
+cvar_t *gl_waterwarp;
 cvar_t *vid_vsync;
 
 // development variables
@@ -78,6 +79,8 @@ cvar_t *gl_polyblend;
 cvar_t *gl_showerrors;
 
 // ==============================================================================
+
+static const vec_t quad_tc[8] = { 0, 1, 0, 0, 1, 1, 1, 0 };
 
 static void GL_SetupFrustum(void)
 {
@@ -313,7 +316,6 @@ void GL_RotateForEntity(void)
 
 static void GL_DrawSpriteModel(const model_t *model)
 {
-    static const vec_t tcoords[8] = { 0, 1, 0, 0, 1, 1, 1, 0 };
     const entity_t *e = glr.ent;
     const mspriteframe_t *frame = &model->spriteframes[(unsigned)e->frame % model->numframes];
     const image_t *image = frame->image;
@@ -361,7 +363,7 @@ static void GL_DrawSpriteModel(const model_t *model)
     VectorAdd3(e->origin, down, right, points[2]);
     VectorAdd3(e->origin, up, right, points[3]);
 
-    GL_TexCoordPointer(2, 0, tcoords);
+    GL_TexCoordPointer(2, 0, quad_tc);
     GL_VertexPointer(3, 0, &points[0][0]);
     qglDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 }
@@ -523,6 +525,25 @@ bool GL_ShowErrors(const char *func)
     return true;
 }
 
+static void GL_WaterWarp(void)
+{
+    GL_ForceTexture(0, gl_static.warp_texture);
+    GL_StateBits(GLS_DEPTHTEST_DISABLE | GLS_DEPTHMASK_FALSE |
+                 GLS_CULL_DISABLE | GLS_TEXTURE_REPLACE | GLS_WARP_ENABLE);
+    GL_ArrayBits(GLA_VERTEX | GLA_TC);
+
+    vec_t points[8] = {
+        glr.fd.x,                glr.fd.y,
+        glr.fd.x,                glr.fd.y + glr.fd.height,
+        glr.fd.x + glr.fd.width, glr.fd.y,
+        glr.fd.x + glr.fd.width, glr.fd.y + glr.fd.height,
+    };
+
+    GL_TexCoordPointer(2, 0, quad_tc);
+    GL_VertexPointer(2, 0, points);
+    qglDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+}
+
 void R_RenderFrame_GL(refdef_t *fd)
 {
     GL_Flush2D();
@@ -543,7 +564,22 @@ void R_RenderFrame_GL(refdef_t *fd)
         lm.dirty = false;
     }
 
-    GL_Setup3D();
+    bool waterwarp = (glr.fd.rdflags & RDF_UNDERWATER) && gl_static.use_shaders && gl_waterwarp->integer;
+
+    if (waterwarp) {
+        if (glr.fd.width != glr.framebuffer_width || glr.fd.height != glr.framebuffer_height) {
+            glr.framebuffer_ok = GL_InitWarpTexture();
+            glr.framebuffer_width = glr.fd.width;
+            glr.framebuffer_height = glr.fd.height;
+        }
+        waterwarp = glr.framebuffer_ok;
+    }
+
+    if (waterwarp) {
+        qglBindFramebuffer(GL_FRAMEBUFFER, gl_static.warp_framebuffer);
+    }
+
+    GL_Setup3D(waterwarp);
 
     if (gl_cull_nodes->integer) {
         GL_SetupFrustum();
@@ -565,8 +601,16 @@ void R_RenderFrame_GL(refdef_t *fd)
         GL_DrawAlphaFaces();
     }
 
+    if (waterwarp) {
+        qglBindFramebuffer(GL_FRAMEBUFFER, 0);
+    }
+
     // go back into 2D mode
     GL_Setup2D();
+
+    if (waterwarp) {
+        GL_WaterWarp();
+    }
 
     if (gl_polyblend->integer && glr.fd.blend[3] != 0) {
         GL_Blend();
@@ -744,6 +788,7 @@ static void GL_Register(void)
     gl_fontshadow = Cvar_Get("gl_fontshadow", "0", 0);
     gl_shaders = Cvar_Get("gl_shaders", (gl_config.caps & QGL_CAP_SHADER) ? "1" : "0", CVAR_REFRESH);
     gl_use_hd_assets = Cvar_Get("gl_use_hd_assets", "0", CVAR_FILES);
+    gl_waterwarp = Cvar_Get("gl_waterwarp", "1", 0);
     vid_vsync = Cvar_Get("vid_vsync", "0", CVAR_ARCHIVE);
     vid_vsync->changed = vid_vsync_changed;
 

--- a/src/refresh/gl/qgl.c
+++ b/src/refresh/gl/qgl.c
@@ -220,7 +220,17 @@ static const glsection_t sections[] = {
         .ver_gl = QGL_VER(3, 0),
         .ver_es = QGL_VER(2, 0),
         .functions = (const glfunction_t []) {
+            QGL_FN(BindFramebuffer),
+            QGL_FN(BindRenderbuffer),
+            QGL_FN(CheckFramebufferStatus),
+            QGL_FN(DeleteFramebuffers),
+            QGL_FN(DeleteRenderbuffers),
+            QGL_FN(FramebufferRenderbuffer),
+            QGL_FN(FramebufferTexture2D),
+            QGL_FN(GenFramebuffers),
+            QGL_FN(GenRenderbuffers),
             QGL_FN(GenerateMipmap),
+            QGL_FN(RenderbufferStorage),
             { NULL }
         }
     },

--- a/src/refresh/gl/qgl.h
+++ b/src/refresh/gl/qgl.h
@@ -127,8 +127,18 @@ QGLAPI void (APIENTRYP qglVertexAttrib4f)(GLuint index, GLfloat x, GLfloat y, GL
 QGLAPI void (APIENTRYP qglVertexAttribPointer)(GLuint index, GLint size, GLenum type, GLboolean normalized, GLsizei stride, const void *pointer);
 
 // GL 3.0
+QGLAPI void (APIENTRYP qglBindFramebuffer)(GLenum target, GLuint framebuffer);
+QGLAPI void (APIENTRYP qglBindRenderbuffer)(GLenum target, GLuint renderbuffer);
+QGLAPI GLenum (APIENTRYP qglCheckFramebufferStatus)(GLenum target);
+QGLAPI void (APIENTRYP qglDeleteFramebuffers)(GLsizei n, const GLuint *framebuffers);
+QGLAPI void (APIENTRYP qglDeleteRenderbuffers)(GLsizei n, const GLuint *renderbuffers);
+QGLAPI void (APIENTRYP qglFramebufferRenderbuffer)(GLenum target, GLenum attachment, GLenum renderbuffertarget, GLuint renderbuffer);
+QGLAPI void (APIENTRYP qglFramebufferTexture2D)(GLenum target, GLenum attachment, GLenum textarget, GLuint texture, GLint level);
+QGLAPI void (APIENTRYP qglGenFramebuffers)(GLsizei n, GLuint *framebuffers);
+QGLAPI void (APIENTRYP qglGenRenderbuffers)(GLsizei n, GLuint *renderbuffers);
 QGLAPI void (APIENTRYP qglGenerateMipmap)(GLenum target);
 QGLAPI const GLubyte *(APIENTRYP qglGetStringi)(GLenum name, GLuint index);
+QGLAPI void (APIENTRYP qglRenderbufferStorage)(GLenum target, GLenum internalformat, GLsizei width, GLsizei height);
 
 // GL 3.1
 QGLAPI void (APIENTRYP qglBindBufferBase)(GLenum target, GLuint index, GLuint buffer);

--- a/src/refresh/gl/state.c
+++ b/src/refresh/gl/state.c
@@ -168,6 +168,9 @@ void GL_Setup2D(void)
         draw.scissor = false;
     }
 
+    if (gl_static.backend.setup_2d)
+        gl_static.backend.setup_2d();
+
     gl_static.backend.load_view_matrix(NULL);
 }
 
@@ -246,13 +249,16 @@ static void GL_RotateForViewer(void)
     GL_ForceMatrix(matrix);
 }
 
-void GL_Setup3D(void)
+void GL_Setup3D(bool waterwarp)
 {
-    qglViewport(glr.fd.x, r_config.height - (glr.fd.y + glr.fd.height),
-                glr.fd.width, glr.fd.height);
+    if (waterwarp)
+        qglViewport(0, 0, glr.fd.width, glr.fd.height);
+    else
+        qglViewport(glr.fd.x, r_config.height - (glr.fd.y + glr.fd.height),
+                    glr.fd.width, glr.fd.height);
 
-    if (gl_static.backend.update)
-        gl_static.backend.update();
+    if (gl_static.backend.setup_3d)
+        gl_static.backend.setup_3d();
 
     GL_Frustum(glr.fd.fov_x, glr.fd.fov_y, 1.0f);
 

--- a/src/refresh/gl/surf.c
+++ b/src/refresh/gl/surf.c
@@ -912,9 +912,7 @@ void GL_LoadWorld(const char *name)
     bsp_t *bsp;
     mtexinfo_t *info;
     mface_t *surf;
-    int ret;
-    imageflags_t flags;
-    int i;
+    int i, ret;
 
     ret = BSP_Load(name, &bsp);
     if (!bsp) {
@@ -948,11 +946,7 @@ void GL_LoadWorld(const char *name)
 
     // register all texinfo
     for (i = 0, info = bsp->texinfo; i < bsp->numtexinfo; i++, info++) {
-        if (info->c.flags & SURF_WARP)
-            flags = IF_TURBULENT;
-        else
-            flags = IF_NONE;
-
+        imageflags_t flags = (info->c.flags & SURF_WARP) ? IF_TURBULENT : IF_NONE;
         Q_concat(buffer, sizeof(buffer), "textures/", info->name, ".wal");
         FS_NormalizePath(buffer);
         info->image = IMG_Find(buffer, IT_WALL, flags);

--- a/src/refresh/vkpt/fsr.c
+++ b/src/refresh/vkpt/fsr.c
@@ -317,5 +317,5 @@ VkResult vkpt_fsr_do(VkCommandBuffer cmd_buf)
 VkResult vkpt_fsr_final_blit(VkCommandBuffer cmd_buf)
 {
 	int output_image = cvar_flt_fsr_rcas->integer != 0 ? VKPT_IMG_FSR_RCAS_OUTPUT : VKPT_IMG_FSR_EASU_OUTPUT;
-	return vkpt_final_blit(cmd_buf, output_image, qvk.extent_unscaled, false);
+	return vkpt_final_blit(cmd_buf, output_image, qvk.extent_unscaled, false, false);
 }

--- a/src/refresh/vkpt/fsr.c
+++ b/src/refresh/vkpt/fsr.c
@@ -314,8 +314,8 @@ VkResult vkpt_fsr_do(VkCommandBuffer cmd_buf)
 	return VK_SUCCESS;
 }
 
-VkResult vkpt_fsr_final_blit(VkCommandBuffer cmd_buf)
+VkResult vkpt_fsr_final_blit(VkCommandBuffer cmd_buf, bool warp)
 {
 	int output_image = cvar_flt_fsr_rcas->integer != 0 ? VKPT_IMG_FSR_RCAS_OUTPUT : VKPT_IMG_FSR_EASU_OUTPUT;
-	return vkpt_final_blit(cmd_buf, output_image, qvk.extent_unscaled, false, false);
+	return vkpt_final_blit(cmd_buf, output_image, qvk.extent_unscaled, false, warp);
 }

--- a/src/refresh/vkpt/fsr.c
+++ b/src/refresh/vkpt/fsr.c
@@ -317,5 +317,5 @@ VkResult vkpt_fsr_do(VkCommandBuffer cmd_buf)
 VkResult vkpt_fsr_final_blit(VkCommandBuffer cmd_buf)
 {
 	int output_image = cvar_flt_fsr_rcas->integer != 0 ? VKPT_IMG_FSR_RCAS_OUTPUT : VKPT_IMG_FSR_EASU_OUTPUT;
-	return vkpt_final_blit_simple(cmd_buf, qvk.images[output_image], qvk.extent_unscaled);
+	return vkpt_final_blit(cmd_buf, output_image, qvk.extent_unscaled, false);
 }

--- a/src/refresh/vkpt/main.c
+++ b/src/refresh/vkpt/main.c
@@ -71,6 +71,7 @@ cvar_t* cvar_pt_freecam = NULL;
 cvar_t *cvar_pt_nearest = NULL;
 cvar_t *cvar_pt_bilerp_chars = NULL;
 cvar_t *cvar_pt_bilerp_pics = NULL;
+cvar_t *cvar_pt_waterwarp = NULL;
 cvar_t *cvar_drs_enable = NULL;
 cvar_t *cvar_drs_target = NULL;
 cvar_t *cvar_drs_minscale = NULL;
@@ -3469,13 +3470,14 @@ R_EndFrame_RTX(void)
 
 	if (frame_ready)
 	{
+		bool waterwarp = (vkpt_refdef.fd->rdflags & RDF_UNDERWATER) && cvar_pt_waterwarp->integer;
 		if (vkpt_fsr_is_enabled() && !qvk.frame_menu_mode)
 		{
-			vkpt_fsr_final_blit(cmd_buf);
+			vkpt_fsr_final_blit(cmd_buf, waterwarp);
 		}
 		else if (qvk.effective_aa_mode == AA_MODE_UPSCALE)
 		{
-			vkpt_final_blit(cmd_buf, VKPT_IMG_TAA_OUTPUT, qvk.extent_taa_output, false, false);
+			vkpt_final_blit(cmd_buf, VKPT_IMG_TAA_OUTPUT, qvk.extent_taa_output, false, waterwarp);
 		}
 		else
 		{
@@ -3485,9 +3487,9 @@ R_EndFrame_RTX(void)
 
 			if (extents_equal(qvk.extent_render, qvk.extent_unscaled) ||
 				(extents_equal(qvk.extent_render, extent_unscaled_half) && drs_effective_scale == 0)) // don't do nearest filter 2x upscale with DRS enabled
-				vkpt_final_blit(cmd_buf, VKPT_IMG_TAA_OUTPUT, qvk.extent_taa_output, false, false);
+				vkpt_final_blit(cmd_buf, VKPT_IMG_TAA_OUTPUT, qvk.extent_taa_output, false, waterwarp);
 			else
-				vkpt_final_blit(cmd_buf, VKPT_IMG_TAA_OUTPUT, qvk.extent_taa_output, true, false);
+				vkpt_final_blit(cmd_buf, VKPT_IMG_TAA_OUTPUT, qvk.extent_taa_output, true, waterwarp);
 		}
 
 		frame_ready = false;
@@ -3703,6 +3705,9 @@ R_Init_RTX(bool total)
 	cvar_pt_bilerp_chars = Cvar_Get("pt_bilerp_chars", "0", CVAR_ARCHIVE);
 	cvar_pt_bilerp_pics = Cvar_Get("pt_bilerp_pics", "0", CVAR_ARCHIVE);
 	cvar_pt_bilerp_chars->changed = cvar_pt_bilerp_pics->changed = pt_nearest_changed;
+
+	// waterwarp effect
+	cvar_pt_waterwarp = Cvar_Get("pt_waterwarp", "0", CVAR_ARCHIVE);
 
 #ifdef VKPT_DEVICE_GROUPS
 	cvar_sli = Cvar_Get("sli", "1", CVAR_REFRESH | CVAR_ARCHIVE);

--- a/src/refresh/vkpt/main.c
+++ b/src/refresh/vkpt/main.c
@@ -3475,7 +3475,7 @@ R_EndFrame_RTX(void)
 		}
 		else if (qvk.effective_aa_mode == AA_MODE_UPSCALE)
 		{
-			vkpt_final_blit_simple(cmd_buf, qvk.images[VKPT_IMG_TAA_OUTPUT], qvk.extent_taa_output);
+			vkpt_final_blit(cmd_buf, VKPT_IMG_TAA_OUTPUT, qvk.extent_taa_output, false);
 		}
 		else
 		{
@@ -3485,9 +3485,9 @@ R_EndFrame_RTX(void)
 
 			if (extents_equal(qvk.extent_render, qvk.extent_unscaled) ||
 				(extents_equal(qvk.extent_render, extent_unscaled_half) && drs_effective_scale == 0)) // don't do nearest filter 2x upscale with DRS enabled
-				vkpt_final_blit_simple(cmd_buf, qvk.images[VKPT_IMG_TAA_OUTPUT], qvk.extent_taa_output);
+				vkpt_final_blit(cmd_buf, VKPT_IMG_TAA_OUTPUT, qvk.extent_taa_output, false);
 			else
-				vkpt_final_blit_filtered(cmd_buf);
+				vkpt_final_blit(cmd_buf, VKPT_IMG_TAA_OUTPUT, qvk.extent_taa_output, true);
 		}
 
 		frame_ready = false;

--- a/src/refresh/vkpt/main.c
+++ b/src/refresh/vkpt/main.c
@@ -3475,7 +3475,7 @@ R_EndFrame_RTX(void)
 		}
 		else if (qvk.effective_aa_mode == AA_MODE_UPSCALE)
 		{
-			vkpt_final_blit(cmd_buf, VKPT_IMG_TAA_OUTPUT, qvk.extent_taa_output, false);
+			vkpt_final_blit(cmd_buf, VKPT_IMG_TAA_OUTPUT, qvk.extent_taa_output, false, false);
 		}
 		else
 		{
@@ -3485,9 +3485,9 @@ R_EndFrame_RTX(void)
 
 			if (extents_equal(qvk.extent_render, qvk.extent_unscaled) ||
 				(extents_equal(qvk.extent_render, extent_unscaled_half) && drs_effective_scale == 0)) // don't do nearest filter 2x upscale with DRS enabled
-				vkpt_final_blit(cmd_buf, VKPT_IMG_TAA_OUTPUT, qvk.extent_taa_output, false);
+				vkpt_final_blit(cmd_buf, VKPT_IMG_TAA_OUTPUT, qvk.extent_taa_output, false, false);
 			else
-				vkpt_final_blit(cmd_buf, VKPT_IMG_TAA_OUTPUT, qvk.extent_taa_output, true);
+				vkpt_final_blit(cmd_buf, VKPT_IMG_TAA_OUTPUT, qvk.extent_taa_output, true, false);
 		}
 
 		frame_ready = false;

--- a/src/refresh/vkpt/shader/final_blit.frag
+++ b/src/refresh/vkpt/shader/final_blit.frag
@@ -27,6 +27,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #extension GL_EXT_nonuniform_qualifier    : enable
 
 layout(constant_id = 0) const uint spec_final_blit_filter_lanczos = 0;
+layout(constant_id = 1) const uint spec_final_blit_water_warp = 0;
 
 #include "utils.glsl"
 
@@ -111,7 +112,10 @@ vec3 filter_lanczos(sampler2D img, vec2 uv)
 void
 main()
 {
-    vec2 uv = tex_coord * push.input_dimensions / vec2(global_ubo.taa_image_width, global_ubo.taa_image_height);
+    vec2 uv = tex_coord;
+    if (spec_final_blit_water_warp != 0)
+        uv += vec2(0.00666) * sin(uv.ts * vec2(M_PI * 10) + global_ubo.time);
+    uv *= push.input_dimensions / vec2(global_ubo.taa_image_width, global_ubo.taa_image_height);
 
     vec3 color;
     if(spec_final_blit_filter_lanczos != 0)

--- a/src/refresh/vkpt/shader/final_blit.frag
+++ b/src/refresh/vkpt/shader/final_blit.frag
@@ -26,13 +26,18 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #extension GL_ARB_separate_shader_objects : enable
 #extension GL_EXT_nonuniform_qualifier    : enable
 
+layout(constant_id = 0) const uint spec_final_blit_filter_lanczos = 0;
+
 #include "utils.glsl"
 
 #define GLOBAL_UBO_DESC_SET_IDX 0
 #include "global_ubo.h"
 
-#define GLOBAL_TEXTURES_DESC_SET_IDX 1
-#include "global_textures.h"
+layout(push_constant, std430) uniform PushConstants {
+    vec2 input_dimensions;
+} push;
+
+layout(set = 1, binding = 0) uniform sampler2D final_blit_input_image;
 
 layout(location = 0) in vec2 tex_coord;
 layout(location = 0) out vec4 outColor;
@@ -106,11 +111,13 @@ vec3 filter_lanczos(sampler2D img, vec2 uv)
 void
 main()
 {
-	vec3 color;
+    vec2 uv = tex_coord * push.input_dimensions / vec2(global_ubo.taa_image_width, global_ubo.taa_image_height);
 
-    vec2 uv = tex_coord * vec2(global_ubo.width, global_ubo.height) / vec2(global_ubo.taa_image_width, global_ubo.taa_image_height);
+    vec3 color;
+    if(spec_final_blit_filter_lanczos != 0)
+        color = filter_lanczos(final_blit_input_image, uv);
+    else
+        color = textureLod(final_blit_input_image, uv, 0).rgb;
 
-	color = filter_lanczos(TEX_TAA_OUTPUT, uv);
-	
-	outColor = vec4(color, 1);
+    outColor = vec4(color, 1);
 }

--- a/src/refresh/vkpt/vkpt.h
+++ b/src/refresh/vkpt/vkpt.h
@@ -677,7 +677,7 @@ bool vkpt_fsr_is_enabled(void);
 bool vkpt_fsr_needs_upscale(void);
 void vkpt_fsr_update_ubo(QVKUniformBuffer_t *ubo);
 VkResult vkpt_fsr_do(VkCommandBuffer cmd_buf);
-VkResult vkpt_fsr_final_blit(VkCommandBuffer cmd_buf);
+VkResult vkpt_fsr_final_blit(VkCommandBuffer cmd_buf, bool warp);
 
 VkResult vkpt_bloom_initialize(void);
 VkResult vkpt_bloom_destroy(void);

--- a/src/refresh/vkpt/vkpt.h
+++ b/src/refresh/vkpt/vkpt.h
@@ -607,7 +607,7 @@ VkResult vkpt_draw_destroy(void);
 VkResult vkpt_draw_destroy_pipelines(void);
 VkResult vkpt_draw_create_pipelines(void);
 VkResult vkpt_draw_submit_stretch_pics(VkCommandBuffer cmd_buf);
-VkResult vkpt_final_blit(VkCommandBuffer cmd_buf, unsigned int image_index, VkExtent2D extent, bool filtered);
+VkResult vkpt_final_blit(VkCommandBuffer cmd_buf, unsigned int image_index, VkExtent2D extent, bool filtered, bool warped);
 VkResult vkpt_draw_clear_stretch_pics(void);
 
 VkResult vkpt_uniform_buffer_create(void);

--- a/src/refresh/vkpt/vkpt.h
+++ b/src/refresh/vkpt/vkpt.h
@@ -71,8 +71,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define LIST_SHADER_MODULES \
 	SHADER_MODULE_DO(QVK_MOD_STRETCH_PIC_VERT)                       \
 	SHADER_MODULE_DO(QVK_MOD_STRETCH_PIC_FRAG)                       \
+	SHADER_MODULE_DO(QVK_MOD_FINAL_BLIT_FRAG)                        \
 	SHADER_MODULE_DO(QVK_MOD_FINAL_BLIT_VERT)                        \
-	SHADER_MODULE_DO(QVK_MOD_FINAL_BLIT_LANCZOS_FRAG)                \
 	SHADER_MODULE_DO(QVK_MOD_INSTANCE_GEOMETRY_COMP)                 \
 	SHADER_MODULE_DO(QVK_MOD_ANIMATE_MATERIALS_COMP)                 \
 	SHADER_MODULE_DO(QVK_MOD_ASVGF_GRADIENT_IMG_COMP)                \
@@ -607,8 +607,7 @@ VkResult vkpt_draw_destroy(void);
 VkResult vkpt_draw_destroy_pipelines(void);
 VkResult vkpt_draw_create_pipelines(void);
 VkResult vkpt_draw_submit_stretch_pics(VkCommandBuffer cmd_buf);
-VkResult vkpt_final_blit_simple(VkCommandBuffer cmd_buf, VkImage image, VkExtent2D extent);
-VkResult vkpt_final_blit_filtered(VkCommandBuffer cmd_buf);
+VkResult vkpt_final_blit(VkCommandBuffer cmd_buf, unsigned int image_index, VkExtent2D extent, bool filtered);
 VkResult vkpt_draw_clear_stretch_pics(void);
 
 VkResult vkpt_uniform_buffer_create(void);


### PR DESCRIPTION
Upstream added a "water warp" effect to the GL renderer. This adds the same effect to the RTX renderer.

The principle is the same; the water warp is applied as the last step after rendering the view.
I opted to do this in the "final blit" step; the "final_blit_lanczos" shader was turned into a more generic "final_blit" shader, with lanczos filtering and warping controllable via specialization constants. (It's now also used for a "simple blit", ie both filtering and warping is turned off.)