### PR TITLE
FSR: Clamp input coords when fetching TAA output, to avoid issues near borders

### DIFF
--- a/src/refresh/vkpt/shader/fsr_easu.glsl
+++ b/src/refresh/vkpt/shader/fsr_easu.glsl
@@ -51,6 +51,12 @@ fsr_vec4 input_r, input_g, input_b;
 
 fsr_vec4 FsrEasuR(AF2 p)
 {
+	/* Avoid fetching pixels that haven't been rendered this frame.
+	 * Otherwise produces somewhat incorrect borders (which aren't terribly visible...
+	 * unless water warp is enabled.) */
+	vec2 taa_dim_inv = vec2(1) / vec2(global_ubo.taa_image_width, global_ubo.taa_image_height);
+	p = clamp(p, 0.5 * taa_dim_inv, vec2(1) - 1.5 * taa_dim_inv);
+
 	input_r = fsr_vec4(textureGather(TEX_TAA_OUTPUT, p, 0));
 	input_g = fsr_vec4(textureGather(TEX_TAA_OUTPUT, p, 1));
 	input_b = fsr_vec4(textureGather(TEX_TAA_OUTPUT, p, 2));

--- a/src/refresh/vkpt/shader/fsr_rcas.glsl
+++ b/src/refresh/vkpt/shader/fsr_rcas.glsl
@@ -51,6 +51,7 @@ fsr_vec4 FsrRcasLoad(load_coord p)
 	else
 	{
 		// RCAS after TAAU (if EASU was disabled via cvar)
+		p = clamp(p, load_coord(0), load_coord(global_ubo.taa_image_width - 1, global_ubo.taa_image_height - 1));
 		fsr_vec4 color = fsr_vec4(texelFetch(TEX_TAA_OUTPUT, ivec2(p), 0));
 		color.rgb = hdr_input(color.rgb);
 		return color;


### PR DESCRIPTION
When combined with DSR pixels not from this frames might have been fetched, resulting in incorrect output near the borders, which becomes very visible when water warp is enabled.

Found while investigating https://github.com/NVIDIA/Q2RTX/pull/376#issuecomment-1949584336