### PR TITLE
Bump zlib to 1.3.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,6 @@
 [submodule "extern/zlib"]
     path = extern/zlib
     url = https://github.com/madler/zlib.git
-    ignore = dirty
 [submodule "extern/curl"]
     path = extern/curl
     url = https://github.com/curl/curl.git


### PR DESCRIPTION
As title, the v1.3 is known to have issue with compilation on Fedora 40 (which comes with gcc 14.0.1). The v1.3.1 has addressed all of those issues.