### PR TITLE
Port to stb_image_resize2

### DIFF
--- a/src/refresh/stb/stb.c
+++ b/src/refresh/stb/stb.c
@@ -29,6 +29,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define STB_IMAGE_IMPLEMENTATION
 #include "stb_image.h"
 #define STB_IMAGE_RESIZE_IMPLEMENTATION
-#include "stb_image_resize.h"
+#include "stb_image_resize2.h"
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include "stb_image_write.h"

--- a/src/refresh/vkpt/textures.c
+++ b/src/refresh/vkpt/textures.c
@@ -27,7 +27,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "color.h"
 #include "material.h"
 #include "../stb/stb_image.h"
-#include "../stb/stb_image_resize.h"
+#include "../stb/stb_image_resize2.h"
 #include "../stb/stb_image_write.h"
 
 #define MAX_RBUFFERS 16


### PR DESCRIPTION
This is the long-awaited rewrite that is **2-5x faster scalar, 4-12x faster w/SIMD**

Fortunately our code does not use any deprecated functions so porting is quite trivial