### PR TITLE
Update steamrt to v3 (sniper)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
 
   build-linux-x86_64:
     runs-on: ubuntu-latest
-    container: registry.gitlab.steamos.cloud/steamrt/soldier/sdk:latest
+    container: registry.gitlab.steamos.cloud/steamrt/sniper/sdk:latest
 
     steps:
     - name: Setup variables


### PR DESCRIPTION
The runtime is based on Debian 11 of which libraries and compiler are 2 years newer than that of v2. Steam has officially accepted games that runs on v3.

The main motivation behind this change is to gain access to more up-to-date libs and compilers. That means we do not have to introduce backward compatibility patches in libraries should the upstream maintainers decides to cut support for old compilers.