### PR TITLE
Fixes for turnip

### DIFF
--- a/src/refresh/vkpt/main.c
+++ b/src/refresh/vkpt/main.c
@@ -1069,15 +1069,20 @@ init_vulkan(void)
 
 		if (picked_driver_ray_query == VK_DRIVER_ID_NVIDIA_PROPRIETARY)
 		{
-			// Pick KHR_ray_query on NVIDIA drivers, if available.
+			// Prefer KHR_ray_query on NVIDIA drivers, if available.
 			qvk.use_ray_query = true;
 			picked_device = picked_device_with_ray_query;
 		}
 		else if (picked_device_with_ray_pipeline >= 0)
 		{
-			// Pick KHR_ray_tracing_pipeline otherwise
+			// Prefer KHR_ray_tracing_pipeline otherwise
 			qvk.use_ray_query = false;
 			picked_device = picked_device_with_ray_pipeline;
+		}
+		else if (picked_device_with_ray_query >= 0)
+		{
+			qvk.use_ray_query = true;
+			picked_device = picked_device_with_ray_query;
 		}
 	}
 

--- a/src/refresh/vkpt/uniform_buffer.c
+++ b/src/refresh/vkpt/uniform_buffer.c
@@ -29,6 +29,7 @@ static size_t ubo_alignment = 0;
 VkResult
 vkpt_uniform_buffer_create()
 {
+	VkDescriptorPoolSize pool_sizes[2] = { };
 	VkDescriptorSetLayoutBinding ubo_layout_bindings[2] = { 0 };
 
 	ubo_layout_bindings[0].descriptorType  = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
@@ -36,10 +37,16 @@ vkpt_uniform_buffer_create()
 	ubo_layout_bindings[0].binding  = GLOBAL_UBO_BINDING_IDX;
 	ubo_layout_bindings[0].stageFlags  = VK_SHADER_STAGE_ALL;
 
+	pool_sizes[0].type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+	pool_sizes[0].descriptorCount = 1;
+
 	ubo_layout_bindings[1].descriptorType  = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
 	ubo_layout_bindings[1].descriptorCount  = 1;
 	ubo_layout_bindings[1].binding  = GLOBAL_INSTANCE_BUFFER_BINDING_IDX;
 	ubo_layout_bindings[1].stageFlags  = VK_SHADER_STAGE_ALL;
+
+	pool_sizes[1].type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+	pool_sizes[1].descriptorCount = 1;
 
 	VkDescriptorSetLayoutCreateInfo layout_info = {
 		.sType        = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO,
@@ -63,16 +70,11 @@ vkpt_uniform_buffer_create()
 	buffer_create(&device_uniform_buffer, buffer_size, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
 		device_memory_flags);
 
-	VkDescriptorPoolSize pool_size = {
-		.type            = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
-		.descriptorCount = MAX_FRAMES_IN_FLIGHT,
-	};
-
 	VkDescriptorPoolCreateInfo pool_info = {
 		.sType         = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
-		.poolSizeCount = 1,
-		.pPoolSizes    = &pool_size,
-		.maxSets       = MAX_FRAMES_IN_FLIGHT,
+		.poolSizeCount = LENGTH(pool_sizes),
+		.pPoolSizes    = pool_sizes,
+		.maxSets       = 1,
 	};
 
 	_VK(vkCreateDescriptorPool(qvk.device, &pool_info, NULL, &desc_pool_ubo));


### PR DESCRIPTION
I've been working on adding `VK_KHR_ray_query` support to turnip, the open-source Vulkan driver for Qualcomm Adreno GPUs. These are fixes I needed to get Q2RTX running in combination with a [Mesa MR](https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/28447). The performance at the moment isn't that great, however.