### PR TITLE
Mark SBO in stretch_pic VP as readonly, to silence validation error

### DIFF
--- a/src/refresh/vkpt/shader/stretch_pic.vert
+++ b/src/refresh/vkpt/shader/stretch_pic.vert
@@ -43,7 +43,7 @@ struct StretchPic {
 	uint color, tex_handle;
 };
 
-layout(set = 0, binding = 0) buffer SBO {
+layout(set = 0, binding = 0) readonly buffer SBO {
 	StretchPic stretch_pics[];
 };
 


### PR DESCRIPTION
Latest Vulkan SDK complained about it.