### PR TITLE
Sync with Q2PRO: #pragma once

### DIFF
--- a/inc/client/client.h
+++ b/inc/client/client.h
@@ -16,8 +16,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef CLIENT_H
-#define CLIENT_H
+#pragma once
 
 #include "common/cmd.h"
 #include "common/net/net.h"
@@ -139,5 +138,3 @@ float V_CalcFov(float fov_x, float width, float height);
 #define SCR_EndLoadingPlaque()          (void)0
 
 #endif // !USE_CLIENT
-
-#endif // CLIENT_H

--- a/inc/client/input.h
+++ b/inc/client/input.h
@@ -16,8 +16,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef INPUT_H
-#define INPUT_H
+#pragma once
 
 //
 // input.h -- external (non-keyboard) input devices
@@ -26,5 +25,3 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 void IN_Frame(void);
 void IN_Activate(void);
 void IN_WarpMouse(int x, int y);
-
-#endif // INPUT_H

--- a/inc/client/keys.h
+++ b/inc/client/keys.h
@@ -16,8 +16,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef KEYS_H
-#define KEYS_H
+#pragma once
 
 //
 // these are the key numbers that should be passed to Key_Event
@@ -146,5 +145,3 @@ int     Key_EnumBindings(int key, const char *binding);
 void    Key_WriteBindings(qhandle_t f);
 
 void    Key_WaitKey(keywaitcb_t wait, void *arg);
-
-#endif // KEYS_H

--- a/inc/client/sound/dma.h
+++ b/inc/client/sound/dma.h
@@ -16,8 +16,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef DMA_H
-#define DMA_H
+#pragma once
 
 typedef struct dma_s {
     int         channels;
@@ -48,5 +47,3 @@ extern dma_t    dma;
 extern int      s_paintedtime;
 
 extern cvar_t   *s_khz;
-
-#endif // DMA_H

--- a/inc/client/sound/sound.h
+++ b/inc/client/sound/sound.h
@@ -16,8 +16,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef SOUND_H
-#define SOUND_H
+#pragma once
 
 void S_Init(void);
 void S_Shutdown(void);
@@ -69,5 +68,3 @@ extern vec3_t   listener_forward;
 extern vec3_t   listener_right;
 extern vec3_t   listener_up;
 extern int      listener_entnum;
-
-#endif // SOUND_H

--- a/inc/client/ui.h
+++ b/inc/client/ui.h
@@ -16,8 +16,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef UI_H
-#define UI_H
+#pragma once
 
 #include "common/net/net.h"
 #include "client/client.h"
@@ -56,5 +55,3 @@ bool        UI_IsTransparent(void);
 #define     UI_MouseEvent(x, y)     (void)0
 #define     UI_IsTransparent()      true
 #endif
-
-#endif // UI_H

--- a/inc/client/video.h
+++ b/inc/client/video.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef VIDEO_H
-#define VIDEO_H
+#pragma once
 
 typedef enum { GAPI_OPENGL, GAPI_VULKAN } graphics_api_t;
 
@@ -63,5 +62,3 @@ bool VID_GetFullscreen(vrect_t *rc, int *freq_p, int *depth_p);
 bool VID_GetGeometry(vrect_t *rc);
 void VID_SetGeometry(vrect_t *rc);
 void VID_ToggleFullscreen(void);
-
-#endif // VIDEO_H

--- a/inc/common/bsp.h
+++ b/inc/common/bsp.h
@@ -18,8 +18,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef BSP_H
-#define BSP_H
+#pragma once
 
 #include "shared/list.h"
 #include "common/error.h"
@@ -318,5 +317,3 @@ byte* BSP_GetPvs2(bsp_t *bsp, int cluster);
 bool BSP_SavePatchedPVS(bsp_t *bsp);
 
 void BSP_Init(void);
-
-#endif // BSP_H

--- a/inc/common/cmd.h
+++ b/inc/common/cmd.h
@@ -16,8 +16,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef CMD_H
-#define CMD_H
+#pragma once
 
 //
 // cmd.h -- command text buffering and command execution
@@ -206,5 +205,3 @@ int Cmd_ParseOptions(const cmd_option_t *opt);
 void Cmd_PrintHelp(const cmd_option_t *opt);
 void Cmd_PrintUsage(const cmd_option_t *opt, const char *suffix);
 void Cmd_PrintHint(void);
-
-#endif // CMD_H

--- a/inc/common/cmodel.h
+++ b/inc/common/cmodel.h
@@ -16,8 +16,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef CMODEL_H
-#define CMODEL_H
+#pragma once
 
 #include "common/bsp.h"
 
@@ -88,5 +87,3 @@ bool        CM_HeadnodeVisible(mnode_t *headnode, byte *visbits);
 
 void        CM_WritePortalState(cm_t *cm, qhandle_t f);
 void        CM_ReadPortalState(cm_t *cm, qhandle_t f);
-
-#endif // CMODEL_H

--- a/inc/common/common.h
+++ b/inc/common/common.h
@@ -16,8 +16,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef COMMON_H
-#define COMMON_H
+#pragma once
 
 #include "common/cmd.h"
 #include "common/utils.h"
@@ -180,5 +179,3 @@ extern time_t       com_startTime;
 
 void Qcommon_Init(int argc, char **argv);
 void Qcommon_Frame(void);
-
-#endif // COMMON_H

--- a/inc/common/cvar.h
+++ b/inc/common/cvar.h
@@ -16,8 +16,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef CVAR_H
-#define CVAR_H
+#pragma once
 
 #include "common/cmd.h"
 
@@ -124,5 +123,3 @@ const char *Cvar_VariableString(const char *var_name);
     Q_strlcpy(buffer, Cvar_VariableString(name), size)
 
 void Cvar_Set_f(void);
-
-#endif // CVAR_H

--- a/inc/common/error.h
+++ b/inc/common/error.h
@@ -16,8 +16,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef ERROR_H
-#define ERROR_H
+#pragma once
 
 #include <errno.h>
 
@@ -60,5 +59,3 @@ static inline int Q_ErrorNumber(void)
 }
 
 const char *Q_ErrorString(int error);
-
-#endif // ERROR_H

--- a/inc/common/field.h
+++ b/inc/common/field.h
@@ -16,8 +16,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef FIELD_H
-#define FIELD_H
+#pragma once
 
 //
 // field.h -- line editing
@@ -38,5 +37,3 @@ void        IF_Init(inputField_t *field, size_t visibleChars, size_t maxChars);
 void        IF_Clear(inputField_t *field);
 void        IF_Replace(inputField_t *field, const char *text);
 int         IF_Draw(inputField_t *field, int x, int y, int flags, qhandle_t font);
-
-#endif // FIELD_H

--- a/inc/common/fifo.h
+++ b/inc/common/fifo.h
@@ -16,8 +16,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef FIFO_H
-#define FIFO_H
+#pragma once
 
 typedef struct {
     byte *data;
@@ -119,5 +118,3 @@ static inline bool FIFO_TryWrite(fifo_t *fifo, void *buffer, size_t len)
 }
 
 bool FIFO_ReadMessage(fifo_t *fifo, size_t msglen);
-
-#endif // FIFO_H

--- a/inc/common/files.h
+++ b/inc/common/files.h
@@ -16,8 +16,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef FILES_H
-#define FILES_H
+#pragma once
 
 #include "common/cmd.h"
 #include "common/error.h"
@@ -138,5 +137,3 @@ FILE *Q_fopen(const char *path, const char *mode);
 extern cvar_t   *fs_game;
 
 extern char     fs_gamedir[];
-
-#endif // FILES_H

--- a/inc/common/intreadwrite.h
+++ b/inc/common/intreadwrite.h
@@ -16,8 +16,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef INTREADWRITE_H
-#define INTREADWRITE_H
+#pragma once
 
 #if (defined __GNUC__)
 
@@ -119,5 +118,3 @@ struct unaligned64 { uint64_t u; } __attribute__((packed, may_alias));
         ((uint8_t *)p)[7] = (_v >> 56) & 0xff;  \
     } while (0)
 #endif
-
-#endif  // INTREADWRITE_H

--- a/inc/common/math.h
+++ b/inc/common/math.h
@@ -16,8 +16,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef MATH_H
-#define MATH_H
+#pragma once
 
 #define NUMVERTEXNORMALS    162
 
@@ -66,5 +65,3 @@ static inline vec_t PlaneDiffFast(const vec3_t v, const cplane_t *p)
 }
 
 void SetupRotationMatrix(vec3_t matrix[3], const vec3_t dir, float degrees);
-
-#endif // MATH_H

--- a/inc/common/mdfour.h
+++ b/inc/common/mdfour.h
@@ -16,8 +16,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef MDFOUR_H
-#define MDFOUR_H
+#pragma once
 
 typedef struct mdfour {
     uint32_t A, B, C, D;
@@ -30,5 +29,3 @@ void mdfour_update(struct mdfour *md, const uint8_t *in, size_t n);
 void mdfour_result(struct mdfour *md, uint8_t *out);
 
 uint32_t Com_BlockChecksum(const void *buffer, size_t len);
-
-#endif // MDFOUR_H

--- a/inc/common/msg.h
+++ b/inc/common/msg.h
@@ -16,8 +16,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef MSG_H
-#define MSG_H
+#pragma once
 
 #include "common/protocol.h"
 #include "common/sizebuf.h"
@@ -234,5 +233,3 @@ static inline void MSG_UnpackSolid32(int solid, vec3_t mins, vec3_t maxs)
     mins[2] = -zd;
     maxs[2] = zu;
 }
-
-#endif // MSG_H

--- a/inc/common/net/chan.h
+++ b/inc/common/net/chan.h
@@ -16,8 +16,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef NET_CHAN_H
-#define NET_CHAN_H
+#pragma once
 
 #include "common/msg.h"
 #include "common/net/net.h"
@@ -96,5 +95,3 @@ void Netchan_Close(netchan_t *netchan);
 
 #define OOB_PRINT(sock, addr, data) \
     NET_SendPacket(sock, CONST_STR_LEN("\xff\xff\xff\xff" data), addr)
-
-#endif // NET_CHAN_H

--- a/inc/common/net/net.h
+++ b/inc/common/net/net.h
@@ -16,8 +16,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef NET_H
-#define NET_H
+#pragma once
 
 #include "common/fifo.h"
 
@@ -226,5 +225,3 @@ extern cvar_t       *net_ip;
 extern cvar_t       *net_port;
 
 extern netadr_t     net_from;
-
-#endif // NET_H

--- a/inc/common/pmove.h
+++ b/inc/common/pmove.h
@@ -16,8 +16,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef PMOVE_H
-#define PMOVE_H
+#pragma once
 
 /*
 ==============================================================
@@ -47,5 +46,3 @@ void Pmove(pmove_t *pmove, pmoveParams_t *params);
 
 void PmoveInit(pmoveParams_t *pmp);
 void PmoveEnableQW(pmoveParams_t *pmp);
-
-#endif // PMOVE_H

--- a/inc/common/prompt.h
+++ b/inc/common/prompt.h
@@ -16,8 +16,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef PROMPT_H
-#define PROMPT_H
+#pragma once
 
 #include "common/field.h"
 #include "common/cmd.h"
@@ -53,5 +52,3 @@ void Prompt_HistoryDown(commandPrompt_t *prompt);
 void Prompt_Clear(commandPrompt_t *prompt);
 void Prompt_SaveHistory(commandPrompt_t *prompt, const char *filename, int lines);
 void Prompt_LoadHistory(commandPrompt_t *prompt, const char *filename);
-
-#endif // PROMPT_H

--- a/inc/common/protocol.h
+++ b/inc/common/protocol.h
@@ -16,8 +16,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef PROTOCOL_H
-#define PROTOCOL_H
+#pragma once
 
 //
 // protocol.h -- communications protocols
@@ -377,5 +376,3 @@ typedef enum {
 #define FF_CLIENTDROP   (1<<1)
 #define FF_CLIENTPRED   (1<<2)
 #define FF_RESERVED     (1<<3)
-
-#endif // PROTOCOL_H

--- a/inc/common/sizebuf.h
+++ b/inc/common/sizebuf.h
@@ -16,8 +16,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef SIZEBUF_H
-#define SIZEBUF_H
+#pragma once
 
 typedef struct {
     bool        allowoverflow;
@@ -50,5 +49,3 @@ void *SZ_ReadData(sizebuf_t *buf, size_t len);
 int SZ_ReadByte(sizebuf_t *sb);
 int SZ_ReadShort(sizebuf_t *sb);
 int SZ_ReadLong(sizebuf_t *sb);
-
-#endif // SIZEBUF_H

--- a/inc/common/tests.h
+++ b/inc/common/tests.h
@@ -16,13 +16,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef TESTS_H
-#define TESTS_H
+#pragma once
 
 #if USE_TESTS
 void TST_Init(void);
 #else
 #define TST_Init() (void)0
 #endif
-
-#endif // TESTS_H

--- a/inc/common/utils.h
+++ b/inc/common/utils.h
@@ -67,4 +67,3 @@ color_index_t Com_ParseColor(const char *s);
 #if USE_DEBUG
 char *Com_MakePrintable(const char *s);
 #endif
-

--- a/inc/common/utils.h
+++ b/inc/common/utils.h
@@ -16,8 +16,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef UTILS_H
-#define UTILS_H
+#pragma once
 
 typedef enum {
     COLOR_BLACK,
@@ -69,4 +68,3 @@ color_index_t Com_ParseColor(const char *s);
 char *Com_MakePrintable(const char *s);
 #endif
 
-#endif // UTILS_H

--- a/inc/common/zone.h
+++ b/inc/common/zone.h
@@ -16,8 +16,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef ZONE_H
-#define ZONE_H
+#pragma once
 
 #define Z_CopyString(string)    Z_TagCopyString(string, TAG_GENERAL)
 #define Z_CopyStruct(ptr)       memcpy(Z_Malloc(sizeof(*ptr)), ptr, sizeof(*ptr))
@@ -58,5 +57,3 @@ void    Z_Stats_f(void);
 
 // may return pointer to static memory
 char    *Z_CvarCopyString(const char *in);
-
-#endif // ZONE_H

--- a/inc/format/bsp.h
+++ b/inc/format/bsp.h
@@ -16,8 +16,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef FORMAT_BSP_H
-#define FORMAT_BSP_H
+#pragma once
 
 /*
 ==============================================================================
@@ -88,5 +87,3 @@ typedef struct {
     uint32_t    fileofs;
     uint32_t    filelen;
 } xlump_t;
-
-#endif // FORMAT_BSP_H

--- a/inc/format/md2.h
+++ b/inc/format/md2.h
@@ -16,8 +16,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef FORMAT_MD2_H
-#define FORMAT_MD2_H
+#pragma once
 
 /*
 ========================================================================
@@ -94,5 +93,3 @@ typedef struct dmd2header_s {
     uint32_t        ofs_glcmds;
     uint32_t        ofs_end;        // end of file
 } dmd2header_t;
-
-#endif // FORMAT_MD2_H

--- a/inc/format/md3.h
+++ b/inc/format/md3.h
@@ -16,8 +16,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef FORMAT_MD3_H
-#define FORMAT_MD3_H
+#pragma once
 
 /*
 =======================================================================
@@ -108,5 +107,3 @@ typedef struct dmd3header_s {
     uint32_t    ofs_meshes;
     uint32_t    ofs_end;
 } dmd3header_t;
-
-#endif // FORMAT_MD3_H

--- a/inc/format/pak.h
+++ b/inc/format/pak.h
@@ -16,8 +16,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef FORMAT_PAK_H
-#define FORMAT_PAK_H
+#pragma once
 
 /*
 ========================================================================
@@ -39,5 +38,3 @@ typedef struct {
     uint32_t    dirofs;
     uint32_t    dirlen;
 } dpackheader_t;
-
-#endif // FORMAT_PAK_H

--- a/inc/format/pcx.h
+++ b/inc/format/pcx.h
@@ -16,8 +16,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef FORMAT_PCX_H
-#define FORMAT_PCX_H
+#pragma once
 
 /*
 ========================================================================
@@ -42,5 +41,3 @@ typedef struct {
     uint8_t     filler[58];
     uint8_t     data[1];            // unbounded
 } dpcx_t;
-
-#endif // FORMAT_PCX_H

--- a/inc/format/sp2.h
+++ b/inc/format/sp2.h
@@ -16,8 +16,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef FORMAT_SP2_H
-#define FORMAT_SP2_H
+#pragma once
 
 /*
 ========================================================================
@@ -45,5 +44,3 @@ typedef struct {
     uint32_t    numframes;
     // dsp2frame_t frames[1];              // variable sized
 } dsp2header_t;
-
-#endif // FORMAT_SP2_H

--- a/inc/format/wal.h
+++ b/inc/format/wal.h
@@ -16,8 +16,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef FORMAT_WAL_H
-#define FORMAT_WAL_H
+#pragma once
 
 /*
 ==============================================================================
@@ -38,5 +37,3 @@ typedef struct {
     uint32_t    contents;
     uint32_t    value;
 } miptex_t;
-
-#endif // FORMAT_WAL_H

--- a/inc/refresh/images.h
+++ b/inc/refresh/images.h
@@ -18,8 +18,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef IMAGES_H
-#define IMAGES_H
+#pragma once
 
 //
 // images.h -- common image manager
@@ -145,7 +144,5 @@ typedef struct screenshot_s {
 
 extern void (*IMG_ReadPixels)(screenshot_t *s);
 extern void (*IMG_ReadPixelsHDR)(screenshot_t *s);
-
-#endif // IMAGES_H
 
 /* vim: set ts=8 sw=4 tw=0 et : */

--- a/inc/refresh/refresh.h
+++ b/inc/refresh/refresh.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef REFRESH_H
-#define REFRESH_H
+#pragma once
 
 #include "common/cvar.h"
 #include "common/error.h"
@@ -354,5 +353,3 @@ void R_RegisterFunctionsRTX(void);
 #endif
 
 r_opengl_config_t *R_GetGLConfig(void);
-
-#endif // REFRESH_H

--- a/inc/server/mvd/client.h
+++ b/inc/server/mvd/client.h
@@ -16,6 +16,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
+#pragma once
+
 extern game_export_t    mvd_ge;
 
 extern list_t mvd_gtv_list;

--- a/inc/server/mvd/protocol.h
+++ b/inc/server/mvd/protocol.h
@@ -16,6 +16,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
+#pragma once
+
 #define GTV_PROTOCOL_VERSION 0xED04
 
 #define MAX_GTS_MSGLEN  MAX_MSGLEN  // maximum GTV server message length

--- a/inc/server/server.h
+++ b/inc/server/server.h
@@ -16,8 +16,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef SERVER_H
-#define SERVER_H
+#pragma once
 
 #include "common/net/net.h"
 
@@ -54,5 +53,3 @@ char *SV_GetSaveInfo(const char *dir);
 #else
 #define SV_GetSaveInfo(dir) NULL
 #endif
-
-#endif // SERVER_H

--- a/inc/shared/game.h
+++ b/inc/shared/game.h
@@ -16,8 +16,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef GAME_H
-#define GAME_H
+#pragma once
 
 #include "shared/list.h"
 
@@ -292,5 +291,3 @@ typedef struct {
 } game_export_ex_t;
 
 typedef const game_export_ex_t *(*game_entry_ex_t)(const game_import_ex_t *);
-
-#endif // GAME_H

--- a/inc/shared/list.h
+++ b/inc/shared/list.h
@@ -16,8 +16,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef LIST_H
-#define LIST_H
+#pragma once
 
 //
 // list.h
@@ -159,5 +158,3 @@ static inline void *List_Index(list_t *list, size_t offset, int index)
 
 #define LIST_INDEX(type, index, list, member) \
     ((type *)List_Index(list, q_offsetof(type, member), index))
-
-#endif // LIST_H

--- a/inc/shared/platform.h
+++ b/inc/shared/platform.h
@@ -20,6 +20,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 // platform.h -- platform-specific definitions
 //
 
+#pragma once
+
 #include <sys/types.h>
 #include <sys/stat.h>
 

--- a/inc/shared/shared.h
+++ b/inc/shared/shared.h
@@ -16,8 +16,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef SHARED_H
-#define SHARED_H
+#pragma once
 
 //
 // shared.h -- included first by ALL program modules
@@ -1273,5 +1272,3 @@ typedef struct {
 
     short       stats[MAX_STATS];       // fast status bar updates
 } player_state_t;
-
-#endif // SHARED_H

--- a/inc/system/hunk.h
+++ b/inc/system/hunk.h
@@ -16,8 +16,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef HUNK_H
-#define HUNK_H
+#pragma once
 
 typedef struct {
     void    *base;
@@ -32,5 +31,3 @@ void    *Hunk_TryAlloc(memhunk_t *hunk, size_t size);
 void    *Hunk_Alloc(memhunk_t *hunk, size_t size);
 void    Hunk_End(memhunk_t *hunk);
 void    Hunk_Free(memhunk_t *hunk);
-
-#endif // HUNK_H

--- a/inc/system/system.h
+++ b/inc/system/system.h
@@ -16,8 +16,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef SYSTEM_H
-#define SYSTEM_H
+#pragma once
 
 #include "common/utils.h"
 
@@ -77,5 +76,3 @@ extern cvar_t   *sys_basedir;
 extern cvar_t   *sys_libdir;
 extern cvar_t   *sys_homedir;
 extern cvar_t   *sys_forcegamelib;
-
-#endif // SYSTEM_H

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -18,6 +18,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 // client.h -- primary header for client
 
+#pragma once
+
 #include "shared/shared.h"
 #include "shared/list.h"
 

--- a/src/client/sound/sound.h
+++ b/src/client/sound/sound.h
@@ -18,6 +18,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 // sound.h -- private sound functions
 
+#pragma once
+
 #include "../client.h"
 #include "shared/list.h"
 

--- a/src/client/ui/ui.h
+++ b/src/client/ui/ui.h
@@ -17,6 +17,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
+#pragma once
+
 #include "shared/shared.h"
 #include "shared/list.h"
 #include "common/cmd.h"

--- a/src/refresh/gl/gl.h
+++ b/src/refresh/gl/gl.h
@@ -16,6 +16,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
+#pragma once
+
 #include "shared/shared.h"
 #include "common/bsp.h"
 #include "common/cmd.h"

--- a/src/refresh/gl/qgl.h
+++ b/src/refresh/gl/qgl.h
@@ -16,8 +16,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef QGL_H
-#define QGL_H
+#pragma once
 
 #if USE_SDL
  #include <SDL2/SDL_opengl.h>
@@ -166,5 +165,3 @@ QGLAPI void (APIENTRYP qglUnlockArraysEXT)(void);
 
 bool QGL_Init(void);
 void QGL_Shutdown(void);
-
-#endif  // QGL_H

--- a/src/server/mvd/client.h
+++ b/src/server/mvd/client.h
@@ -16,6 +16,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
+#pragma once
+
 #include "../server.h"
 #include <setjmp.h>
 

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -17,6 +17,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 // server.h
 
+#pragma once
+
 #include "shared/shared.h"
 #include "shared/list.h"
 #include "shared/game.h"

--- a/src/unix/tty.h
+++ b/src/unix/tty.h
@@ -16,8 +16,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef TTY_H
-#define TTY_H
+#pragma once
 
 #if USE_SYSCON
 void        tty_init_input(void);
@@ -26,5 +25,3 @@ void        tty_shutdown_input(void);
 #define     tty_init_input()        (void)0
 #define     tty_shutdown_input()    (void)0
 #endif
-
-#endif // TTY_H

--- a/src/unix/video/keytables/keytables.h
+++ b/src/unix/video/keytables/keytables.h
@@ -17,8 +17,7 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 */
 
-#ifndef KEYTABLES_H
-#define KEYTABLES_H
+#pragma once
 
 typedef struct {
     const uint8_t *keys;
@@ -26,5 +25,3 @@ typedef struct {
 } keytable_t;
 
 extern const keytable_t keytable_evdev;
-
-#endif

--- a/src/windows/client.h
+++ b/src/windows/client.h
@@ -20,6 +20,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 // client.h -- Win32 client stuff
 //
 
+#pragma once
+
 #include "shared/shared.h"
 #include "common/common.h"
 #include "common/files.h"


### PR DESCRIPTION
Upstream replaced "classic" include guards with `#pragma once`.

Though I'm more of a fan of the "old way" myself, picking these changes will likely make porting future upstream changes easier.