### PR TITLE
Fix incorrect sampler override in vkpt_textures_update_descriptor_set()

### DIFF
--- a/src/refresh/vkpt/textures.c
+++ b/src/refresh/vkpt/textures.c
@@ -1953,11 +1953,6 @@ void vkpt_textures_update_descriptor_set()
 			.sampler     = sampler,
 		};
 
-		if (i >= VKPT_IMG_BLOOM_HBLUR &&
-			i <= VKPT_IMG_BLOOM_VBLUR) {
-			img_info.sampler = qvk.tex_sampler_linear_clamp;
-		}
-
 		VkWriteDescriptorSet descriptor_set_write = {
 			.sType           = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
 			.dstSet          = qvk_get_current_desc_set_textures(),


### PR DESCRIPTION
The intention was clearly to choose the "linear_clamp" sampler for bloom images. This happens correctly in vkpt_create_images().

The removed code happened to set clamping on any unlucky skin/wall/etc texture that happened to have the same indices as the values of VKPT_IMG_BLOOM_*.
