### PR TITLE
Sync with Q2PRO: Enums & bitmasks changes

### DIFF
--- a/inc/client/client.h
+++ b/inc/client/client.h
@@ -99,19 +99,19 @@ void SCR_UpdateScreen(void);
 #define U32_MAGENTA MakeColor(255,   0, 255, 255)
 #define U32_WHITE   MakeColor(255, 255, 255, 255)
 
-#define UI_LEFT             0x00000001
-#define UI_RIGHT            0x00000002
+#define UI_LEFT             BIT(0)
+#define UI_RIGHT            BIT(1)
 #define UI_CENTER           (UI_LEFT | UI_RIGHT)
-#define UI_BOTTOM           0x00000004
-#define UI_TOP              0x00000008
+#define UI_BOTTOM           BIT(2)
+#define UI_TOP              BIT(3)
 #define UI_MIDDLE           (UI_BOTTOM | UI_TOP)
-#define UI_DROPSHADOW       0x00000010
-#define UI_ALTCOLOR         0x00000020
-#define UI_IGNORECOLOR      0x00000040
-#define UI_XORCOLOR         0x00000080
-#define UI_AUTOWRAP         0x00000100
-#define UI_MULTILINE        0x00000200
-#define UI_DRAWCURSOR       0x00000400
+#define UI_DROPSHADOW       BIT(4)
+#define UI_ALTCOLOR         BIT(5)
+#define UI_IGNORECOLOR      BIT(6)
+#define UI_XORCOLOR         BIT(7)
+#define UI_AUTOWRAP         BIT(8)
+#define UI_MULTILINE        BIT(9)
+#define UI_DRAWCURSOR       BIT(10)
 
 extern const uint32_t   colorTable[8];
 

--- a/inc/client/keys.h
+++ b/inc/client/keys.h
@@ -114,9 +114,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 typedef enum keydest_e {
     KEY_GAME    = 0,
-    KEY_CONSOLE = (1 << 0),
-    KEY_MESSAGE = (1 << 1),
-    KEY_MENU    = (1 << 2)
+    KEY_CONSOLE = BIT(0),
+    KEY_MESSAGE = BIT(1),
+    KEY_MENU    = BIT(2)
 } keydest_t;
 
 typedef bool (*keywaitcb_t)(void *arg, int key);

--- a/inc/common/cvar.h
+++ b/inc/common/cvar.h
@@ -33,17 +33,17 @@ Cvars are restricted from having the same names as commands to keep this
 interface from being ambiguous.
 */
 
-#define CVAR_CHEAT          (1 << 5)  // can't be changed when connected
-#define CVAR_PRIVATE        (1 << 6)  // never macro expanded or saved to config
-#define CVAR_ROM            (1 << 7)  // can't be changed even from cmdline
-#define CVAR_MODIFIED       (1 << 8)  // modified by user
-#define CVAR_CUSTOM         (1 << 9)  // created by user
-#define CVAR_WEAK           (1 << 10) // doesn't have value
-#define CVAR_GAME           (1 << 11) // created by game library
-#define CVAR_NOARCHIVE      (1 << 12) // never saved to config
-#define CVAR_FILES          (1 << 13) // r_reload when changed
-#define CVAR_REFRESH        (1 << 14) // vid_restart when changed
-#define CVAR_SOUND          (1 << 15) // snd_restart when changed
+#define CVAR_CHEAT          BIT(5)      // can't be changed when connected
+#define CVAR_PRIVATE        BIT(6)      // never macro expanded or saved to config
+#define CVAR_ROM            BIT(7)      // can't be changed even from cmdline
+#define CVAR_MODIFIED       BIT(8)      // modified by user
+#define CVAR_CUSTOM         BIT(9)      // created by user
+#define CVAR_WEAK           BIT(10)     // doesn't have value
+#define CVAR_GAME           BIT(11)     // created by game library
+#define CVAR_NOARCHIVE      BIT(12)     // never saved to config
+#define CVAR_FILES          BIT(13)     // r_reload when changed
+#define CVAR_REFRESH        BIT(14)     // vid_restart when changed
+#define CVAR_SOUND          BIT(15)     // snd_restart when changed
 
 #define CVAR_INFOMASK       (CVAR_USERINFO | CVAR_SERVERINFO)
 #define CVAR_MODIFYMASK     (CVAR_INFOMASK | CVAR_FILES | CVAR_REFRESH | CVAR_SOUND)

--- a/inc/common/msg.h
+++ b/inc/common/msg.h
@@ -59,25 +59,25 @@ typedef struct {
 } player_packed_t;
 
 typedef enum {
-    MSG_PS_IGNORE_GUNINDEX      = (1 << 0),     // ignore gunindex
-    MSG_PS_IGNORE_GUNFRAMES     = (1 << 1),     // ignore gunframe/gunoffset/gunangles
-    MSG_PS_IGNORE_BLEND         = (1 << 2),     // ignore blend
-    MSG_PS_IGNORE_VIEWANGLES    = (1 << 3),     // ignore viewangles
-    MSG_PS_IGNORE_DELTAANGLES   = (1 << 4),     // ignore delta_angles
-    MSG_PS_IGNORE_PREDICTION    = (1 << 5),     // mutually exclusive with IGNORE_VIEWANGLES
-    MSG_PS_FORCE                = (1 << 7),     // send even if unchanged (MVD stream only)
-    MSG_PS_REMOVE               = (1 << 8),     // player is removed (MVD stream only)
+    MSG_PS_IGNORE_GUNINDEX      = BIT(0),   // ignore gunindex
+    MSG_PS_IGNORE_GUNFRAMES     = BIT(1),   // ignore gunframe/gunoffset/gunangles
+    MSG_PS_IGNORE_BLEND         = BIT(2),   // ignore blend
+    MSG_PS_IGNORE_VIEWANGLES    = BIT(3),   // ignore viewangles
+    MSG_PS_IGNORE_DELTAANGLES   = BIT(4),   // ignore delta_angles
+    MSG_PS_IGNORE_PREDICTION    = BIT(5),   // mutually exclusive with IGNORE_VIEWANGLES
+    MSG_PS_FORCE                = BIT(7),   // send even if unchanged (MVD stream only)
+    MSG_PS_REMOVE               = BIT(8),   // player is removed (MVD stream only)
 } msgPsFlags_t;
 
 typedef enum {
-    MSG_ES_FORCE        = (1 << 0),     // send even if unchanged
-    MSG_ES_NEWENTITY    = (1 << 1),     // send old_origin
-    MSG_ES_FIRSTPERSON  = (1 << 2),     // ignore origin/angles
-    MSG_ES_LONGSOLID    = (1 << 3),     // higher precision bbox encoding
-    MSG_ES_UMASK        = (1 << 4),     // client has 16-bit mask MSB fix
-    MSG_ES_BEAMORIGIN   = (1 << 5),     // client has RF_BEAM old_origin fix
-    MSG_ES_SHORTANGLES  = (1 << 6),     // higher precision angles encoding
-    MSG_ES_REMOVE       = (1 << 7),     // entity is removed (MVD stream only)
+    MSG_ES_FORCE        = BIT(0),   // send even if unchanged
+    MSG_ES_NEWENTITY    = BIT(1),   // send old_origin
+    MSG_ES_FIRSTPERSON  = BIT(2),   // ignore origin/angles
+    MSG_ES_LONGSOLID    = BIT(3),   // higher precision bbox encoding
+    MSG_ES_UMASK        = BIT(4),   // client has 16-bit mask MSB fix
+    MSG_ES_BEAMORIGIN   = BIT(5),   // client has RF_BEAM old_origin fix
+    MSG_ES_SHORTANGLES  = BIT(6),   // higher precision angles encoding
+    MSG_ES_REMOVE       = BIT(7),   // entity is removed (MVD stream only)
 } msgEsFlags_t;
 
 extern sizebuf_t    msg_write;

--- a/inc/common/net/net.h
+++ b/inc/common/net/net.h
@@ -65,8 +65,8 @@ typedef enum {
 
 typedef enum {
     NET_NONE    = 0,
-    NET_CLIENT  = (1 << 0),
-    NET_SERVER  = (1 << 1)
+    NET_CLIENT  = BIT(0),
+    NET_SERVER  = BIT(1)
 } netflag_t;
 
 typedef union {

--- a/inc/common/protocol.h
+++ b/inc/common/protocol.h
@@ -76,13 +76,13 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 
 #define SVCMD_BITS              5
-#define SVCMD_MASK              ((1 << SVCMD_BITS) - 1)
+#define SVCMD_MASK              (BIT(SVCMD_BITS) - 1)
 
 #define FRAMENUM_BITS           27
-#define FRAMENUM_MASK           ((1 << FRAMENUM_BITS) - 1)
+#define FRAMENUM_MASK           (BIT(FRAMENUM_BITS) - 1)
 
 #define SUPPRESSCOUNT_BITS      4
-#define SUPPRESSCOUNT_MASK      ((1 << SUPPRESSCOUNT_BITS) - 1)
+#define SUPPRESSCOUNT_MASK      (BIT(SUPPRESSCOUNT_BITS) - 1)
 
 #define MAX_PACKET_ENTITIES     1024
 #define MAX_PARSE_ENTITIES      (MAX_PACKET_ENTITIES * UPDATE_BACKUP)
@@ -169,9 +169,9 @@ typedef enum {
 
 // MVD stream flags (only 3 bits can be used)
 typedef enum {
-    MVF_NOMSGS      = 1,
-    MVF_SINGLEPOV   = 2,
-    MVF_RESERVED2   = 4
+    MVF_NOMSGS      = BIT(0),
+    MVF_SINGLEPOV   = BIT(1),
+    MVF_RESERVED    = BIT(2)
 } mvd_flags_t;
 
 //==============================================
@@ -199,62 +199,62 @@ typedef enum {
 
 // player_state_t communication
 
-#define PS_M_TYPE           (1<<0)
-#define PS_M_ORIGIN         (1<<1)
-#define PS_M_VELOCITY       (1<<2)
-#define PS_M_TIME           (1<<3)
-#define PS_M_FLAGS          (1<<4)
-#define PS_M_GRAVITY        (1<<5)
-#define PS_M_DELTA_ANGLES   (1<<6)
+#define PS_M_TYPE           BIT(0)
+#define PS_M_ORIGIN         BIT(1)
+#define PS_M_VELOCITY       BIT(2)
+#define PS_M_TIME           BIT(3)
+#define PS_M_FLAGS          BIT(4)
+#define PS_M_GRAVITY        BIT(5)
+#define PS_M_DELTA_ANGLES   BIT(6)
 
-#define PS_VIEWOFFSET       (1<<7)
-#define PS_VIEWANGLES       (1<<8)
-#define PS_KICKANGLES       (1<<9)
-#define PS_BLEND            (1<<10)
-#define PS_FOV              (1<<11)
-#define PS_WEAPONINDEX      (1<<12)
-#define PS_WEAPONFRAME      (1<<13)
-#define PS_RDFLAGS          (1<<14)
-#define PS_RESERVED         (1<<15)
+#define PS_VIEWOFFSET       BIT(7)
+#define PS_VIEWANGLES       BIT(8)
+#define PS_KICKANGLES       BIT(9)
+#define PS_BLEND            BIT(10)
+#define PS_FOV              BIT(11)
+#define PS_WEAPONINDEX      BIT(12)
+#define PS_WEAPONFRAME      BIT(13)
+#define PS_RDFLAGS          BIT(14)
+#define PS_RESERVED         BIT(15)
 
 #define PS_BITS             16
-#define PS_MASK             ((1<<PS_BITS)-1)
+#define PS_MASK             (BIT(PS_BITS) - 1)
 
 // r1q2 protocol specific extra flags
-#define EPS_GUNOFFSET       (1<<0)
-#define EPS_GUNANGLES       (1<<1)
-#define EPS_M_VELOCITY2     (1<<2)
-#define EPS_M_ORIGIN2       (1<<3)
-#define EPS_VIEWANGLE2      (1<<4)
-#define EPS_STATS           (1<<5)
+#define EPS_GUNOFFSET       BIT(0)
+#define EPS_GUNANGLES       BIT(1)
+#define EPS_M_VELOCITY2     BIT(2)
+#define EPS_M_ORIGIN2       BIT(3)
+#define EPS_VIEWANGLE2      BIT(4)
+#define EPS_STATS           BIT(5)
 
 // q2pro protocol specific extra flags
-#define EPS_CLIENTNUM       (1<<6)
+#define EPS_CLIENTNUM       BIT(6)
 
 #define EPS_BITS            7
-#define EPS_MASK            ((1<<EPS_BITS)-1)
+#define EPS_MASK            (BIT(EPS_BITS) - 1)
 
 //==============================================
 
 // packetized player_state_t communication (MVD specific)
 
-#define PPS_M_TYPE          (1<<0)
-#define PPS_M_ORIGIN        (1<<1)
-#define PPS_M_ORIGIN2       (1<<2)
+#define PPS_M_TYPE          BIT(0)
+#define PPS_M_ORIGIN        BIT(1)
+#define PPS_M_ORIGIN2       BIT(2)
 
-#define PPS_VIEWOFFSET      (1<<3)
-#define PPS_VIEWANGLES      (1<<4)
-#define PPS_VIEWANGLE2      (1<<5)
-#define PPS_KICKANGLES      (1<<6)
-#define PPS_BLEND           (1<<7)
-#define PPS_FOV             (1<<8)
-#define PPS_WEAPONINDEX     (1<<9)
-#define PPS_WEAPONFRAME     (1<<10)
-#define PPS_GUNOFFSET       (1<<11)
-#define PPS_GUNANGLES       (1<<12)
-#define PPS_RDFLAGS         (1<<13)
-#define PPS_STATS           (1<<14)
-#define PPS_REMOVE          (1<<15)
+#define PPS_VIEWOFFSET      BIT(3)
+#define PPS_VIEWANGLES      BIT(4)
+#define PPS_VIEWANGLE2      BIT(5)
+#define PPS_KICKANGLES      BIT(6)
+#define PPS_BLEND           BIT(7)
+#define PPS_FOV             BIT(8)
+#define PPS_WEAPONINDEX     BIT(9)
+#define PPS_WEAPONFRAME     BIT(10)
+#define PPS_GUNOFFSET       BIT(11)
+#define PPS_GUNANGLES       BIT(12)
+#define PPS_RDFLAGS         BIT(13)
+#define PPS_STATS           BIT(14)
+#define PPS_REMOVE          BIT(15)
 
 // this is just a small hack to store inuse flag
 // in a field left otherwise unused by MVD code
@@ -265,31 +265,31 @@ typedef enum {
 // user_cmd_t communication
 
 // ms and light always sent, the others are optional
-#define CM_ANGLE1   (1<<0)
-#define CM_ANGLE2   (1<<1)
-#define CM_ANGLE3   (1<<2)
-#define CM_FORWARD  (1<<3)
-#define CM_SIDE     (1<<4)
-#define CM_UP       (1<<5)
-#define CM_BUTTONS  (1<<6)
-#define CM_IMPULSE  (1<<7)
+#define CM_ANGLE1       BIT(0)
+#define CM_ANGLE2       BIT(1)
+#define CM_ANGLE3       BIT(2)
+#define CM_FORWARD      BIT(3)
+#define CM_SIDE         BIT(4)
+#define CM_UP           BIT(5)
+#define CM_BUTTONS      BIT(6)
+#define CM_IMPULSE      BIT(7)
 
 // r1q2 button byte hacks
 #define BUTTON_MASK     (BUTTON_ATTACK|BUTTON_USE|BUTTON_ANY)
-#define BUTTON_FORWARD  4
-#define BUTTON_SIDE     8
-#define BUTTON_UP       16
-#define BUTTON_ANGLE1   32
-#define BUTTON_ANGLE2   64
+#define BUTTON_FORWARD  BIT(2)
+#define BUTTON_SIDE     BIT(3)
+#define BUTTON_UP       BIT(4)
+#define BUTTON_ANGLE1   BIT(5)
+#define BUTTON_ANGLE2   BIT(6)
 
 //==============================================
 
 // a sound without an ent or pos will be a local only sound
-#define SND_VOLUME          (1<<0)  // a byte
-#define SND_ATTENUATION     (1<<1)  // a byte
-#define SND_POS             (1<<2)  // three coordinates
-#define SND_ENT             (1<<3)  // a short 0-2: channel, 3-12: entity
-#define SND_OFFSET          (1<<4)  // a byte, msec offset from frame start
+#define SND_VOLUME          BIT(0)  // a byte
+#define SND_ATTENUATION     BIT(1)  // a byte
+#define SND_POS             BIT(2)  // three coordinates
+#define SND_ENT             BIT(3)  // a short 0-2: channel, 3-12: entity
+#define SND_OFFSET          BIT(4)  // a byte, msec offset from frame start
 
 #define DEFAULT_SOUND_PACKET_VOLUME         1.0f
 #define DEFAULT_SOUND_PACKET_ATTENUATION    1.0f
@@ -299,40 +299,40 @@ typedef enum {
 // entity_state_t communication
 
 // try to pack the common update flags into the first byte
-#define U_ORIGIN1   (1<<0)
-#define U_ORIGIN2   (1<<1)
-#define U_ANGLE2    (1<<2)
-#define U_ANGLE3    (1<<3)
-#define U_FRAME8    (1<<4)        // frame is a byte
-#define U_EVENT     (1<<5)
-#define U_REMOVE    (1<<6)        // REMOVE this entity, don't add it
-#define U_MOREBITS1 (1<<7)        // read one additional byte
+#define U_ORIGIN1       BIT(0)
+#define U_ORIGIN2       BIT(1)
+#define U_ANGLE2        BIT(2)
+#define U_ANGLE3        BIT(3)
+#define U_FRAME8        BIT(4)      // frame is a byte
+#define U_EVENT         BIT(5)
+#define U_REMOVE        BIT(6)      // REMOVE this entity, don't add it
+#define U_MOREBITS1     BIT(7)      // read one additional byte
 
 // second byte
-#define U_NUMBER16  (1<<8)        // NUMBER8 is implicit if not set
-#define U_ORIGIN3   (1<<9)
-#define U_ANGLE1    (1<<10)
-#define U_MODEL     (1<<11)
-#define U_RENDERFX8 (1<<12)        // fullbright, etc
-#define U_ANGLE16   (1<<13)
-#define U_EFFECTS8  (1<<14)        // autorotate, trails, etc
-#define U_MOREBITS2 (1<<15)        // read one additional byte
+#define U_NUMBER16      BIT(8)      // NUMBER8 is implicit if not set
+#define U_ORIGIN3       BIT(9)
+#define U_ANGLE1        BIT(10)
+#define U_MODEL         BIT(11)
+#define U_RENDERFX8     BIT(12)     // fullbright, etc
+#define U_ANGLE16       BIT(13)
+#define U_EFFECTS8      BIT(14)     // autorotate, trails, etc
+#define U_MOREBITS2     BIT(15)     // read one additional byte
 
 // third byte
-#define U_SKIN8         (1<<16)
-#define U_FRAME16       (1<<17)     // frame is a short
-#define U_RENDERFX16    (1<<18)     // 8 + 16 = 32
-#define U_EFFECTS16     (1<<19)     // 8 + 16 = 32
-#define U_MODEL2        (1<<20)     // weapons, flags, etc
-#define U_MODEL3        (1<<21)
-#define U_MODEL4        (1<<22)
-#define U_MOREBITS3     (1<<23)     // read one additional byte
+#define U_SKIN8         BIT(16)
+#define U_FRAME16       BIT(17)     // frame is a short
+#define U_RENDERFX16    BIT(18)     // 8 + 16 = 32
+#define U_EFFECTS16     BIT(19)     // 8 + 16 = 32
+#define U_MODEL2        BIT(20)     // weapons, flags, etc
+#define U_MODEL3        BIT(21)
+#define U_MODEL4        BIT(22)
+#define U_MOREBITS3     BIT(23)     // read one additional byte
 
 // fourth byte
-#define U_OLDORIGIN     (1<<24)     // FIXME: get rid of this
-#define U_SKIN16        (1<<25)
-#define U_SOUND         (1<<26)
-#define U_SOLID         (1<<27)
+#define U_OLDORIGIN     BIT(24)     // FIXME: get rid of this
+#define U_SKIN16        BIT(25)
+#define U_SOUND         BIT(26)
+#define U_SOLID         BIT(27)
 
 #define U_SKIN32        (U_SKIN8 | U_SKIN16)        // used for laser colors
 #define U_EFFECTS32     (U_EFFECTS8 | U_EFFECTS16)
@@ -372,7 +372,7 @@ typedef enum {
 
 // q2pro frame flags sent by the server
 // only SUPPRESSCOUNT_BITS can be used
-#define FF_SUPPRESSED   (1<<0)
-#define FF_CLIENTDROP   (1<<1)
-#define FF_CLIENTPRED   (1<<2)
-#define FF_RESERVED     (1<<3)
+#define FF_SUPPRESSED   BIT(0)
+#define FF_CLIENTDROP   BIT(1)
+#define FF_CLIENTPRED   BIT(2)
+#define FF_RESERVED     BIT(3)

--- a/inc/refresh/refresh.h
+++ b/inc/refresh/refresh.h
@@ -215,8 +215,8 @@ typedef struct {
 } r_opengl_config_t;
 
 typedef enum {
-    QVF_FULLSCREEN      = (1 << 0),
-    QVF_GAMMARAMP       = (1 << 1),
+    QVF_FULLSCREEN      = BIT(0),
+    QVF_GAMMARAMP       = BIT(1),
 } vidFlags_t;
 
 typedef struct {
@@ -233,20 +233,20 @@ typedef struct {
 
 typedef enum {
     IF_NONE         = 0,
-    IF_PERMANENT    = (1 << 0),
-    IF_TRANSPARENT  = (1 << 1),
-    IF_PALETTED     = (1 << 2),
-    IF_UPSCALED     = (1 << 3),
-    IF_SCRAP        = (1 << 4),
-    IF_TURBULENT    = (1 << 5),
-    IF_REPEAT       = (1 << 6),
-    IF_NEAREST      = (1 << 7),
-    IF_OPAQUE       = (1 << 8),
-    IF_SRGB         = (1 << 9),
-    IF_FAKE_EMISSIVE= (1 << 10),
-    IF_EXACT        = (1 << 11),
-    IF_NORMAL_MAP   = (1 << 12),
-    IF_BILERP       = (1 << 13), // always lerp, independent of bilerp_pics cvar
+    IF_PERMANENT    = BIT(0),
+    IF_TRANSPARENT  = BIT(1),
+    IF_PALETTED     = BIT(2),
+    IF_UPSCALED     = BIT(3),
+    IF_SCRAP        = BIT(4),
+    IF_TURBULENT    = BIT(5),
+    IF_REPEAT       = BIT(6),
+    IF_NEAREST      = BIT(7),
+    IF_OPAQUE       = BIT(8),
+    IF_SRGB         = BIT(9),
+    IF_FAKE_EMISSIVE= BIT(10),
+    IF_EXACT        = BIT(11),
+    IF_NORMAL_MAP   = BIT(12),
+    IF_BILERP       = BIT(13), // always lerp, independent of bilerp_pics cvar
 
     // Image source indicator/requirement flags
     IF_SRC_BASE     = (0x1 << 16),

--- a/inc/shared/game.h
+++ b/inc/shared/game.h
@@ -28,9 +28,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 // edict->svflags
 
-#define SVF_NOCLIENT            0x00000001  // don't send entity to clients, even if it has effects
-#define SVF_DEADMONSTER         0x00000002  // treat as CONTENTS_DEADMONSTER for collision
-#define SVF_MONSTER             0x00000004  // treat as CONTENTS_MONSTER for collision
+#define SVF_NOCLIENT            BIT(0)      // don't send entity to clients, even if it has effects
+#define SVF_DEADMONSTER         BIT(1)      // treat as CONTENTS_DEADMONSTER for collision
+#define SVF_MONSTER             BIT(2)      // treat as CONTENTS_MONSTER for collision
 
 // edict->solid values
 
@@ -44,26 +44,24 @@ typedef enum {
 // extended features
 
 // R1Q2 and Q2PRO specific
-#define GMF_CLIENTNUM               0x00000001  // game sets clientNum gclient_s field
-#define GMF_PROPERINUSE             0x00000002  // game maintains edict_s inuse field properly
-#define GMF_MVDSPEC                 0x00000004  // game is dummy MVD client aware
-#define GMF_WANT_ALL_DISCONNECTS    0x00000008  // game wants ClientDisconnect() for non-spawned clients
+#define GMF_CLIENTNUM               BIT(0)      // game sets clientNum gclient_s field
+#define GMF_PROPERINUSE             BIT(1)      // game maintains edict_s inuse field properly
+#define GMF_MVDSPEC                 BIT(2)      // game is dummy MVD client aware
+#define GMF_WANT_ALL_DISCONNECTS    BIT(3)      // game wants ClientDisconnect() for non-spawned clients
 
 // Q2PRO specific
-#define GMF_ENHANCED_SAVEGAMES      0x00000400  // game supports safe/portable savegames
-#define GMF_VARIABLE_FPS            0x00000800  // game supports variable server FPS
-#define GMF_EXTRA_USERINFO          0x00001000  // game wants extra userinfo after normal userinfo
-#define GMF_IPV6_ADDRESS_AWARE      0x00002000  // game supports IPv6 addresses
-#define GMF_ALLOW_INDEX_OVERFLOW    0x00004000  // game wants PF_FindIndex() to return 0 on overflow
+#define GMF_ENHANCED_SAVEGAMES      BIT(10)     // game supports safe/portable savegames
+#define GMF_VARIABLE_FPS            BIT(11)     // game supports variable server FPS
+#define GMF_EXTRA_USERINFO          BIT(12)     // game wants extra userinfo after normal userinfo
+#define GMF_IPV6_ADDRESS_AWARE      BIT(13)     // game supports IPv6 addresses
+#define GMF_ALLOW_INDEX_OVERFLOW    BIT(14)     // game wants PF_FindIndex() to return 0 on overflow
 
 //===============================================================
 
 #define MAX_ENT_CLUSTERS    16
 
-
 typedef struct edict_s edict_t;
 typedef struct gclient_s gclient_t;
-
 
 #ifndef GAME_INCLUDE
 
@@ -78,7 +76,6 @@ struct gclient_s {
     // the game dll can add anything it wants after
     // this point in the structure
 };
-
 
 struct edict_s {
     entity_state_t  s;

--- a/inc/shared/shared.h
+++ b/inc/shared/shared.h
@@ -621,12 +621,12 @@ CVARS (console variables)
 #ifndef CVAR
 #define CVAR
 
-#define CVAR_ARCHIVE    1   // set to cause it to be saved to vars.rc
-#define CVAR_USERINFO   2   // added to userinfo  when changed
-#define CVAR_SERVERINFO 4   // added to serverinfo when changed
-#define CVAR_NOSET      8   // don't allow change from console at all,
-                            // but can be set from the command line
-#define CVAR_LATCH      16  // save changes until server restart
+#define CVAR_ARCHIVE    BIT(0)  // set to cause it to be saved to vars.rc
+#define CVAR_USERINFO   BIT(1)  // added to userinfo when changed
+#define CVAR_SERVERINFO BIT(2)  // added to serverinfo when changed
+#define CVAR_NOSET      BIT(3)  // don't allow change from console at all,
+                                // but can be set from the command line
+#define CVAR_LATCH      BIT(4)  // save changes until server restart
 
 struct cvar_s;
 struct genctx_s;
@@ -665,57 +665,55 @@ COLLISION DETECTION
 */
 
 // lower bits are stronger, and will eat weaker brushes completely
-#define CONTENTS_SOLID          1       // an eye is never valid in a solid
-#define CONTENTS_WINDOW         2       // translucent, but not watery
-#define CONTENTS_AUX            4
-#define CONTENTS_LAVA           8
-#define CONTENTS_SLIME          16
-#define CONTENTS_WATER          32
-#define CONTENTS_MIST           64
-#define LAST_VISIBLE_CONTENTS   64
+#define CONTENTS_SOLID          BIT(0)      // an eye is never valid in a solid
+#define CONTENTS_WINDOW         BIT(1)      // translucent, but not watery
+#define CONTENTS_AUX            BIT(2)
+#define CONTENTS_LAVA           BIT(3)
+#define CONTENTS_SLIME          BIT(4)
+#define CONTENTS_WATER          BIT(5)
+#define CONTENTS_MIST           BIT(6)
+#define LAST_VISIBLE_CONTENTS   CONTENTS_MIST
 
 // remaining contents are non-visible, and don't eat brushes
 
-#define CONTENTS_AREAPORTAL     0x8000
+#define CONTENTS_AREAPORTAL     BIT(15)
 
-#define CONTENTS_PLAYERCLIP     0x10000
-#define CONTENTS_MONSTERCLIP    0x20000
+#define CONTENTS_PLAYERCLIP     BIT(16)
+#define CONTENTS_MONSTERCLIP    BIT(17)
 
 // currents can be added to any other contents, and may be mixed
-#define CONTENTS_CURRENT_0      0x40000
-#define CONTENTS_CURRENT_90     0x80000
-#define CONTENTS_CURRENT_180    0x100000
-#define CONTENTS_CURRENT_270    0x200000
-#define CONTENTS_CURRENT_UP     0x400000
-#define CONTENTS_CURRENT_DOWN   0x800000
+#define CONTENTS_CURRENT_0      BIT(18)
+#define CONTENTS_CURRENT_90     BIT(19)
+#define CONTENTS_CURRENT_180    BIT(20)
+#define CONTENTS_CURRENT_270    BIT(21)
+#define CONTENTS_CURRENT_UP     BIT(22)
+#define CONTENTS_CURRENT_DOWN   BIT(23)
 
-#define CONTENTS_ORIGIN         0x1000000   // removed before bsping an entity
+#define CONTENTS_ORIGIN         BIT(24)     // removed before bsping an entity
 
-#define CONTENTS_MONSTER        0x2000000   // should never be on a brush, only in game
-#define CONTENTS_DEADMONSTER    0x4000000
-#define CONTENTS_DETAIL         0x8000000   // brushes to be added after vis leafs
-#define CONTENTS_TRANSLUCENT    0x10000000  // auto set if any surface has trans
-#define CONTENTS_LADDER         0x20000000
+#define CONTENTS_MONSTER        BIT(25)     // should never be on a brush, only in game
+#define CONTENTS_DEADMONSTER    BIT(26)
+#define CONTENTS_DETAIL         BIT(27)     // brushes to be added after vis leafs
+#define CONTENTS_TRANSLUCENT    BIT(28)     // auto set if any surface has trans
+#define CONTENTS_LADDER         BIT(29)
 
 
 
-#define SURF_LIGHT      0x1     // value will hold the light strength
+#define SURF_LIGHT              BIT(0)      // value will hold the light strength
+#define SURF_SLICK              BIT(1)      // effects game physics
+#define SURF_SKY                BIT(2)      // don't draw, but add to skybox
+#define SURF_WARP               BIT(3)      // turbulent water warp
+#define SURF_TRANS33            BIT(4)
+#define SURF_TRANS66            BIT(5)
+#define SURF_FLOWING            BIT(6)      // scroll towards angle
+#define SURF_NODRAW             BIT(7)      // don't bother referencing the texture
 
-#define SURF_SLICK      0x2     // effects game physics
+#define SURF_ALPHATEST          BIT(25)     // used by kmquake2
 
-#define SURF_SKY        0x4     // don't draw, but add to skybox
-#define SURF_WARP       0x8     // turbulent water warp
-#define SURF_TRANS33    0x10
-#define SURF_TRANS66    0x20
-#define SURF_FLOWING    0x40    // scroll towards angle
-#define SURF_NODRAW     0x80    // don't bother referencing the texture
-
-#define SURF_ALPHATEST  0x02000000  // used by kmquake2
-
-#define SURF_N64_UV             (1U << 28)
-#define SURF_N64_SCROLL_X       (1U << 29)
-#define SURF_N64_SCROLL_Y       (1U << 30)
-#define SURF_N64_SCROLL_FLIP    (1U << 31)
+#define SURF_N64_UV             BIT(28)
+#define SURF_N64_SCROLL_X       BIT(29)
+#define SURF_N64_SCROLL_Y       BIT(30)
+#define SURF_N64_SCROLL_FLIP    BIT(31)
 
 
 // content masks
@@ -790,14 +788,14 @@ typedef enum {
 } pmtype_t;
 
 // pmove->pm_flags
-#define PMF_DUCKED          1
-#define PMF_JUMP_HELD       2
-#define PMF_ON_GROUND       4
-#define PMF_TIME_WATERJUMP  8   // pm_time is waterjump
-#define PMF_TIME_LAND       16  // pm_time is time before rejump
-#define PMF_TIME_TELEPORT   32  // pm_time is non-moving time
-#define PMF_NO_PREDICTION   64  // temporarily disables prediction (used for grappling hook)
-#define PMF_TELEPORT_BIT    128 // used by q2pro
+#define PMF_DUCKED          BIT(0)
+#define PMF_JUMP_HELD       BIT(1)
+#define PMF_ON_GROUND       BIT(2)
+#define PMF_TIME_WATERJUMP  BIT(3)      // pm_time is waterjump
+#define PMF_TIME_LAND       BIT(4)      // pm_time is time before rejump
+#define PMF_TIME_TELEPORT   BIT(5)      // pm_time is non-moving time
+#define PMF_NO_PREDICTION   BIT(6)      // temporarily disables prediction (used for grappling hook)
+#define PMF_TELEPORT_BIT    BIT(7)      // used by q2pro
 
 // this structure needs to be communicated bit-accurate
 // from the server to the client to guarantee that
@@ -820,9 +818,9 @@ typedef struct {
 //
 // button bits
 //
-#define BUTTON_ATTACK       1
-#define BUTTON_USE          2
-#define BUTTON_ANY          128         // any key whatsoever
+#define BUTTON_ATTACK   BIT(0)
+#define BUTTON_USE      BIT(1)
+#define BUTTON_ANY      BIT(7)  // any key whatsoever
 
 
 // usercmd_t is sent to the server each client frame
@@ -869,72 +867,73 @@ typedef struct {
 // that happen constantly on the given entity.
 // An entity that has effects will be sent to the client
 // even if it has a zero index model.
-#define EF_ROTATE           0x00000001      // rotate (bonus items)
-#define EF_GIB              0x00000002      // leave a trail
-#define EF_BLASTER          0x00000008      // redlight + trail
-#define EF_ROCKET           0x00000010      // redlight + trail
-#define EF_GRENADE          0x00000020
-#define EF_HYPERBLASTER     0x00000040
-#define EF_BFG              0x00000080
-#define EF_COLOR_SHELL      0x00000100
-#define EF_POWERSCREEN      0x00000200
-#define EF_ANIM01           0x00000400      // automatically cycle between frames 0 and 1 at 2 hz
-#define EF_ANIM23           0x00000800      // automatically cycle between frames 2 and 3 at 2 hz
-#define EF_ANIM_ALL         0x00001000      // automatically cycle through all frames at 2hz
-#define EF_ANIM_ALLFAST     0x00002000      // automatically cycle through all frames at 10hz
-#define EF_FLIES            0x00004000
-#define EF_QUAD             0x00008000
-#define EF_PENT             0x00010000
-#define EF_TELEPORTER       0x00020000      // particle fountain
-#define EF_FLAG1            0x00040000
-#define EF_FLAG2            0x00080000
+#define EF_ROTATE           BIT(0)      // rotate (bonus items)
+#define EF_GIB              BIT(1)      // leave a trail
+#define EF_BLASTER          BIT(3)      // redlight + trail
+#define EF_ROCKET           BIT(4)      // redlight + trail
+#define EF_GRENADE          BIT(5)
+#define EF_HYPERBLASTER     BIT(6)
+#define EF_BFG              BIT(7)
+#define EF_COLOR_SHELL      BIT(8)
+#define EF_POWERSCREEN      BIT(9)
+#define EF_ANIM01           BIT(10)     // automatically cycle between frames 0 and 1 at 2 hz
+#define EF_ANIM23           BIT(11)     // automatically cycle between frames 2 and 3 at 2 hz
+#define EF_ANIM_ALL         BIT(12)     // automatically cycle through all frames at 2hz
+#define EF_ANIM_ALLFAST     BIT(13)     // automatically cycle through all frames at 10hz
+#define EF_FLIES            BIT(14)
+#define EF_QUAD             BIT(15)
+#define EF_PENT             BIT(16)
+#define EF_TELEPORTER       BIT(17)     // particle fountain
+#define EF_FLAG1            BIT(18)
+#define EF_FLAG2            BIT(19)
+
 // RAFAEL
-#define EF_IONRIPPER        0x00100000
-#define EF_GREENGIB         0x00200000
-#define EF_BLUEHYPERBLASTER 0x00400000
-#define EF_SPINNINGLIGHTS   0x00800000
-#define EF_PLASMA           0x01000000
-#define EF_TRAP             0x02000000
+#define EF_IONRIPPER        BIT(20)
+#define EF_GREENGIB         BIT(21)
+#define EF_BLUEHYPERBLASTER BIT(22)
+#define EF_SPINNINGLIGHTS   BIT(23)
+#define EF_PLASMA           BIT(24)
+#define EF_TRAP             BIT(25)
 
 //ROGUE
-#define EF_TRACKER          0x04000000
-#define EF_DOUBLE           0x08000000
-#define EF_SPHERETRANS      0x10000000
-#define EF_TAGTRAIL         0x20000000
-#define EF_HALF_DAMAGE      0x40000000
-#define EF_TRACKERTRAIL     0x80000000
+#define EF_TRACKER          BIT(26)
+#define EF_DOUBLE           BIT(27)
+#define EF_SPHERETRANS      BIT(28)
+#define EF_TAGTRAIL         BIT(29)
+#define EF_HALF_DAMAGE      BIT(30)
+#define EF_TRACKERTRAIL     BIT(31)
 //ROGUE
 
 // entity_state_t->renderfx flags
-#define RF_MINLIGHT         1       // allways have some light (viewmodel)
-#define RF_VIEWERMODEL      2       // don't draw through eyes, only mirrors
-#define RF_WEAPONMODEL      4       // only draw through eyes
-#define RF_FULLBRIGHT       8       // allways draw full intensity
-#define RF_DEPTHHACK        16      // for view weapon Z crunching
-#define RF_TRANSLUCENT      32
-#define RF_FRAMELERP        64
-#define RF_BEAM             128
-#define RF_CUSTOMSKIN       256     // skin is an index in image_precache
-#define RF_GLOW             512     // pulse lighting for bonus items
-#define RF_SHELL_RED        1024
-#define RF_SHELL_GREEN      2048
-#define RF_SHELL_BLUE       4096
-#define RF_NOSHADOW         8192    // used by YQ2
+#define RF_MINLIGHT         BIT(0)      // allways have some light (viewmodel)
+#define RF_VIEWERMODEL      BIT(1)      // don't draw through eyes, only mirrors
+#define RF_WEAPONMODEL      BIT(2)      // only draw through eyes
+#define RF_FULLBRIGHT       BIT(3)      // allways draw full intensity
+#define RF_DEPTHHACK        BIT(4)      // for view weapon Z crunching
+#define RF_TRANSLUCENT      BIT(5)
+#define RF_FRAMELERP        BIT(6)
+#define RF_BEAM             BIT(7)
+#define RF_CUSTOMSKIN       BIT(8)      // skin is an index in image_precache
+#define RF_GLOW             BIT(9)      // pulse lighting for bonus items
+#define RF_SHELL_RED        BIT(10)
+#define RF_SHELL_GREEN      BIT(11)
+#define RF_SHELL_BLUE       BIT(12)
+#define RF_NOSHADOW         BIT(13)     // used by YQ2
 
 //ROGUE
-#define RF_IR_VISIBLE       0x00008000      // 32768
-#define RF_SHELL_DOUBLE     0x00010000      // 65536
-#define RF_SHELL_HALF_DAM   0x00020000
-#define RF_USE_DISGUISE     0x00040000
+#define RF_IR_VISIBLE       BIT(15)
+#define RF_SHELL_DOUBLE     BIT(16)
+#define RF_SHELL_HALF_DAM   BIT(17)
+#define RF_USE_DISGUISE     BIT(18)
 //ROGUE
 
 // player_state_t->refdef flags
-#define RDF_UNDERWATER      1       // warp the screen as apropriate
-#define RDF_NOWORLDMODEL    2       // used for player configuration screen
+#define RDF_UNDERWATER      BIT(0)      // warp the screen as apropriate
+#define RDF_NOWORLDMODEL    BIT(1)      // used for player configuration screen
 
 //ROGUE
-#define RDF_IRGOGGLES       4
-#define RDF_UVGOGGLES       8
+#define RDF_IRGOGGLES       BIT(2)
+#define RDF_UVGOGGLES       BIT(3)
 //ROGUE
 
 //
@@ -979,7 +978,7 @@ enum {
 #define MZ_FLARE            40
 // Q2RTX
 
-    MZ_SILENCED = 128,  // bit flag ORed with one of the above numbers
+    MZ_SILENCED = BIT(7),  // bit flag ORed with one of the above numbers
 };
 
 
@@ -1075,8 +1074,8 @@ enum {
 #define CHAN_ITEM               3
 #define CHAN_BODY               4
 // modifier flags
-#define CHAN_NO_PHS_ADD         8   // send to all clients, not just ones in PHS (ATTN 0 will also do this)
-#define CHAN_RELIABLE           16  // send by reliable message, not datagram
+#define CHAN_NO_PHS_ADD         BIT(3)  // send to all clients, not just ones in PHS (ATTN 0 will also do this)
+#define CHAN_RELIABLE           BIT(4)  // send by reliable message, not datagram
 
 
 // sound attenuation values
@@ -1112,41 +1111,41 @@ enum {
 
 
 // dmflags->value flags
-#define DF_NO_HEALTH        0x00000001  // 1
-#define DF_NO_ITEMS         0x00000002  // 2
-#define DF_WEAPONS_STAY     0x00000004  // 4
-#define DF_NO_FALLING       0x00000008  // 8
-#define DF_INSTANT_ITEMS    0x00000010  // 16
-#define DF_SAME_LEVEL       0x00000020  // 32
-#define DF_SKINTEAMS        0x00000040  // 64
-#define DF_MODELTEAMS       0x00000080  // 128
-#define DF_NO_FRIENDLY_FIRE 0x00000100  // 256
-#define DF_SPAWN_FARTHEST   0x00000200  // 512
-#define DF_FORCE_RESPAWN    0x00000400  // 1024
-#define DF_NO_ARMOR         0x00000800  // 2048
-#define DF_ALLOW_EXIT       0x00001000  // 4096
-#define DF_INFINITE_AMMO    0x00002000  // 8192
-#define DF_QUAD_DROP        0x00004000  // 16384
-#define DF_FIXED_FOV        0x00008000  // 32768
+#define DF_NO_HEALTH        BIT(0)
+#define DF_NO_ITEMS         BIT(1)
+#define DF_WEAPONS_STAY     BIT(2)
+#define DF_NO_FALLING       BIT(3)
+#define DF_INSTANT_ITEMS    BIT(4)
+#define DF_SAME_LEVEL       BIT(5)
+#define DF_SKINTEAMS        BIT(6)
+#define DF_MODELTEAMS       BIT(7)
+#define DF_NO_FRIENDLY_FIRE BIT(8)
+#define DF_SPAWN_FARTHEST   BIT(9)
+#define DF_FORCE_RESPAWN    BIT(10)
+#define DF_NO_ARMOR         BIT(11)
+#define DF_ALLOW_EXIT       BIT(12)
+#define DF_INFINITE_AMMO    BIT(13)
+#define DF_QUAD_DROP        BIT(14)
+#define DF_FIXED_FOV        BIT(15)
 
 // RAFAEL
-#define DF_QUADFIRE_DROP    0x00010000  // 65536
+#define DF_QUADFIRE_DROP    BIT(16)
 
 //ROGUE
-#define DF_NO_MINES         0x00020000
-#define DF_NO_STACK_DOUBLE  0x00040000
-#define DF_NO_NUKES         0x00080000
-#define DF_NO_SPHERES       0x00100000
+#define DF_NO_MINES         BIT(17)
+#define DF_NO_STACK_DOUBLE  BIT(18)
+#define DF_NO_NUKES         BIT(19)
+#define DF_NO_SPHERES       BIT(20)
 //ROGUE
 
 
-#define UF_AUTOSCREENSHOT   1
-#define UF_AUTORECORD       2
-#define UF_LOCALFOV         4
-#define UF_MUTE_PLAYERS     8
-#define UF_MUTE_OBSERVERS   16
-#define UF_MUTE_MISC        32
-#define UF_PLAYERFOV        64
+#define UF_AUTOSCREENSHOT   BIT(0)
+#define UF_AUTORECORD       BIT(1)
+#define UF_LOCALFOV         BIT(2)
+#define UF_MUTE_PLAYERS     BIT(3)
+#define UF_MUTE_OBSERVERS   BIT(4)
+#define UF_MUTE_MISC        BIT(5)
+#define UF_PLAYERFOV        BIT(6)
 
 /*
 ==========================================================

--- a/inc/shared/shared.h
+++ b/inc/shared/shared.h
@@ -774,7 +774,7 @@ typedef struct {
     cplane_t    plane;      // surface normal at impact
     csurface_t  *surface;   // surface hit
     int         contents;   // contents on other side of surface hit
-    struct edict_s  *ent;       // not set by CM_*() functions
+    struct edict_s  *ent;   // not set by CM_*() functions
 } trace_t;
 
 // pmove_state_t is the information necessary for client side movement
@@ -1055,13 +1055,15 @@ typedef enum {
     TE_NUM_ENTITIES
 } temp_event_t;
 
-#define SPLASH_UNKNOWN      0
-#define SPLASH_SPARKS       1
-#define SPLASH_BLUE_WATER   2
-#define SPLASH_BROWN_WATER  3
-#define SPLASH_SLIME        4
-#define SPLASH_LAVA         5
-#define SPLASH_BLOOD        6
+enum {
+    SPLASH_UNKNOWN,
+    SPLASH_SPARKS,
+    SPLASH_BLUE_WATER,
+    SPLASH_BROWN_WATER,
+    SPLASH_SLIME,
+    SPLASH_LAVA,
+    SPLASH_BLOOD,
+};
 
 
 // sound channels
@@ -1085,26 +1087,28 @@ typedef enum {
 
 
 // player_state->stats[] indexes
-#define STAT_HEALTH_ICON        0
-#define STAT_HEALTH             1
-#define STAT_AMMO_ICON          2
-#define STAT_AMMO               3
-#define STAT_ARMOR_ICON         4
-#define STAT_ARMOR              5
-#define STAT_SELECTED_ICON      6
-#define STAT_PICKUP_ICON        7
-#define STAT_PICKUP_STRING      8
-#define STAT_TIMER_ICON         9
-#define STAT_TIMER              10
-#define STAT_HELPICON           11
-#define STAT_SELECTED_ITEM      12
-#define STAT_LAYOUTS            13
-#define STAT_FRAGS              14
-#define STAT_FLASHES            15      // cleared each frame, 1 = health, 2 = armor
-#define STAT_CHASE              16
-#define STAT_SPECTATOR          17
+enum {
+    STAT_HEALTH_ICON,
+    STAT_HEALTH,
+    STAT_AMMO_ICON,
+    STAT_AMMO,
+    STAT_ARMOR_ICON,
+    STAT_ARMOR,
+    STAT_SELECTED_ICON,
+    STAT_PICKUP_ICON,
+    STAT_PICKUP_STRING,
+    STAT_TIMER_ICON,
+    STAT_TIMER,
+    STAT_HELPICON,
+    STAT_SELECTED_ITEM,
+    STAT_LAYOUTS,
+    STAT_FRAGS,
+    STAT_FLASHES,           // cleared each frame, 1 = health, 2 = armor
+    STAT_CHASE,
+    STAT_SPECTATOR,
 
-#define MAX_STATS               32
+    MAX_STATS = 32
+};
 
 
 // dmflags->value flags

--- a/inc/shared/shared.h
+++ b/inc/shared/shared.h
@@ -1068,14 +1068,17 @@ enum {
 // sound channels
 // channel 0 never willingly overrides
 // other channels (1-7) allways override a playing sound on that channel
-#define CHAN_AUTO               0
-#define CHAN_WEAPON             1
-#define CHAN_VOICE              2
-#define CHAN_ITEM               3
-#define CHAN_BODY               4
-// modifier flags
-#define CHAN_NO_PHS_ADD         BIT(3)  // send to all clients, not just ones in PHS (ATTN 0 will also do this)
-#define CHAN_RELIABLE           BIT(4)  // send by reliable message, not datagram
+enum {
+    CHAN_AUTO,
+    CHAN_WEAPON,
+    CHAN_VOICE,
+    CHAN_ITEM,
+    CHAN_BODY,
+
+    // modifier flags
+    CHAN_NO_PHS_ADD     = BIT(3),   // send to all clients, not just ones in PHS (ATTN 0 will also do this)
+    CHAN_RELIABLE       = BIT(4),   // send by reliable message, not datagram
+};
 
 
 // sound attenuation values

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -144,11 +144,11 @@ typedef struct {
 } server_frame_t;
 
 // locally calculated frame flags for debug display
-#define FF_SERVERDROP   (1<<4)
-#define FF_BADFRAME     (1<<5)
-#define FF_OLDFRAME     (1<<6)
-#define FF_OLDENT       (1<<7)
-#define FF_NODELTA      (1<<8)
+#define FF_SERVERDROP   BIT(4)
+#define FF_BADFRAME     BIT(5)
+#define FF_OLDFRAME     BIT(6)
+#define FF_OLDENT       BIT(7)
+#define FF_NODELTA      BIT(8)
 
 // variable server FPS
 #if USE_FPS

--- a/src/client/screen.c
+++ b/src/client/screen.c
@@ -421,8 +421,8 @@ LAGOMETER
 #define LAG_WIDTH   48
 #define LAG_HEIGHT  48
 
-#define LAG_CRIT_BIT    (1U << 31)
-#define LAG_WARN_BIT    (1U << 30)
+#define LAG_WARN_BIT    BIT(30)
+#define LAG_CRIT_BIT    BIT(31)
 
 #define LAG_BASE    0xD5
 #define LAG_WARN    0xDC

--- a/src/client/ui/ui.h
+++ b/src/client/ui/ui.h
@@ -59,13 +59,13 @@ typedef enum {
     MTYPE_LOADGAME
 } menuType_t;
 
-#define QMF_LEFT_JUSTIFY    0x00000001
-#define QMF_GRAYED          0x00000002
-#define QMF_NUMBERSONLY     0x00000004
-#define QMF_HASFOCUS        0x00000008
-#define QMF_HIDDEN          0x00000010
-#define QMF_DISABLED        0x00000020
-#define QMF_CUSTOM_COLOR    0x00000040
+#define QMF_LEFT_JUSTIFY    BIT(0)
+#define QMF_GRAYED          BIT(1)
+#define QMF_NUMBERSONLY     BIT(2)
+#define QMF_HASFOCUS        BIT(3)
+#define QMF_HIDDEN          BIT(4)
+#define QMF_DISABLED        BIT(5)
+#define QMF_CUSTOM_COLOR    BIT(6)
 
 typedef enum {
     QMS_NOTHANDLED,
@@ -191,9 +191,9 @@ typedef struct menuSlider_s {
 #define MLIST_PRESTEP           3
 #define MLIST_PADDING           (MLIST_PRESTEP*2)
 
-#define MLF_HEADER      0x00000001
-#define MLF_SCROLLBAR   0x00000002
-#define MLF_COLOR       0x00000004
+#define MLF_HEADER      BIT(0)
+#define MLF_SCROLLBAR   BIT(1)
+#define MLF_COLOR       BIT(2)
 
 typedef struct menuListColumn_s {
     const char *name;

--- a/src/common/bsp.c
+++ b/src/common/bsp.c
@@ -574,7 +574,7 @@ LOAD(Nodes)
 
         for (j = 0; j < 2; j++) {
             child = BSP_Long();
-            if (child & 0x80000000) {
+            if (child & BIT(31)) {
                 child = ~child;
                 if (child >= bsp->numleafs) {
                     DEBUG("bad leafnum");
@@ -644,7 +644,7 @@ LOAD(SubModels)
             out->origin[j] = BSP_Float();
 
         headnode = BSP_Long();
-        if (headnode & 0x80000000) {
+        if (headnode & BIT(31)) {
             // be careful, some models have no nodes, just a leaf
             headnode = ~headnode;
             if (headnode >= bsp->numleafs) {

--- a/src/common/msg.c
+++ b/src/common/msg.c
@@ -906,11 +906,11 @@ void MSG_WriteDeltaPlayerstate_Default(const player_packed_t *from, const player
     statbits = 0;
     for (i = 0; i < MAX_STATS; i++)
         if (to->stats[i] != from->stats[i])
-            statbits |= 1U << i;
+            statbits |= BIT(i);
 
     MSG_WriteLong(statbits);
     for (i = 0; i < MAX_STATS; i++)
-        if (statbits & (1U << i))
+        if (statbits & BIT(i))
             MSG_WriteShort(to->stats[i]);
 }
 
@@ -1034,7 +1034,7 @@ int MSG_WriteDeltaPlayerstate_Enhanced(const player_packed_t    *from,
     statbits = 0;
     for (i = 0; i < MAX_STATS; i++)
         if (to->stats[i] != from->stats[i])
-            statbits |= 1U << i;
+            statbits |= BIT(i);
 
     if (statbits)
         eflags |= EPS_STATS;
@@ -1139,7 +1139,7 @@ int MSG_WriteDeltaPlayerstate_Enhanced(const player_packed_t    *from,
     if (eflags & EPS_STATS) {
         MSG_WriteLong(statbits);
         for (i = 0; i < MAX_STATS; i++)
-            if (statbits & (1U << i))
+            if (statbits & BIT(i))
                 MSG_WriteShort(to->stats[i]);
     }
 
@@ -1232,7 +1232,7 @@ void MSG_WriteDeltaPlayerstate_Packet(const player_packed_t *from,
     statbits = 0;
     for (i = 0; i < MAX_STATS; i++)
         if (to->stats[i] != from->stats[i])
-            statbits |= 1U << i;
+            statbits |= BIT(i);
 
     if (statbits)
         pflags |= PPS_STATS;
@@ -1321,7 +1321,7 @@ void MSG_WriteDeltaPlayerstate_Packet(const player_packed_t *from,
     if (pflags & PPS_STATS) {
         MSG_WriteLong(statbits);
         for (i = 0; i < MAX_STATS; i++)
-            if (statbits & (1U << i))
+            if (statbits & BIT(i))
                 MSG_WriteShort(to->stats[i]);
     }
 }
@@ -1980,7 +1980,7 @@ void MSG_ParseDeltaPlayerstate_Default(const player_state_t *from,
     statbits = MSG_ReadLong();
     if (statbits) {
         for (i = 0; i < MAX_STATS; i++)
-            if (statbits & (1U << i))
+            if (statbits & BIT(i))
                 to->stats[i] = MSG_ReadShort();
     }
 }
@@ -2108,7 +2108,7 @@ void MSG_ParseDeltaPlayerstate_Enhanced(const player_state_t    *from,
     if (extraflags & EPS_STATS) {
         statbits = MSG_ReadLong();
         for (i = 0; i < MAX_STATS; i++) {
-            if (statbits & (1U << i)) {
+            if (statbits & BIT(i)) {
                 to->stats[i] = MSG_ReadShort();
             }
         }
@@ -2217,7 +2217,7 @@ void MSG_ParseDeltaPlayerstate_Packet(const player_state_t *from,
     if (flags & PPS_STATS) {
         statbits = MSG_ReadLong();
         for (i = 0; i < MAX_STATS; i++) {
-            if (statbits & (1U << i)) {
+            if (statbits & BIT(i)) {
                 to->stats[i] = MSG_ReadShort();
             }
         }

--- a/src/common/net/chan.c
+++ b/src/common/net/chan.c
@@ -395,7 +395,7 @@ static size_t NetchanNew_TransmitNextFragment(netchan_t *chan)
     send_reliable = chan->reliable_length;
 
     // write the packet header
-    w1 = (chan->outgoing_sequence & 0x3FFFFFFF) | (1 << 30);
+    w1 = (chan->outgoing_sequence & 0x3FFFFFFF) | BIT(30);
     if (send_reliable)
         w1 |= 0x80000000;
 

--- a/src/refresh/gl/gl.h
+++ b/src/refresh/gl/gl.h
@@ -127,14 +127,14 @@ typedef struct {
 } glRefdef_t;
 
 enum {
-    QGL_CAP_LEGACY                      = (1 << 0),
-    QGL_CAP_SHADER                      = (1 << 1),
-    QGL_CAP_TEXTURE_BITS                = (1 << 2),
-    QGL_CAP_TEXTURE_CLAMP_TO_EDGE       = (1 << 3),
-    QGL_CAP_TEXTURE_MAX_LEVEL           = (1 << 4),
-    QGL_CAP_TEXTURE_LOD_BIAS            = (1 << 5),
-    QGL_CAP_TEXTURE_NON_POWER_OF_TWO    = (1 << 6),
-    QGL_CAP_TEXTURE_ANISOTROPY          = (1 << 7),
+    QGL_CAP_LEGACY                      = BIT(0),
+    QGL_CAP_SHADER                      = BIT(1),
+    QGL_CAP_TEXTURE_BITS                = BIT(2),
+    QGL_CAP_TEXTURE_CLAMP_TO_EDGE       = BIT(3),
+    QGL_CAP_TEXTURE_MAX_LEVEL           = BIT(4),
+    QGL_CAP_TEXTURE_LOD_BIAS            = BIT(5),
+    QGL_CAP_TEXTURE_NON_POWER_OF_TWO    = BIT(6),
+    QGL_CAP_TEXTURE_ANISOTROPY          = BIT(7),
 };
 
 #define QGL_VER(major, minor)   ((major) * 100 + (minor))
@@ -307,23 +307,23 @@ void GL_LoadWorld(const char *name);
  */
 typedef enum {
     GLS_DEFAULT             = 0,
-    GLS_DEPTHMASK_FALSE     = (1 <<  0),
-    GLS_DEPTHTEST_DISABLE   = (1 <<  1),
-    GLS_CULL_DISABLE        = (1 <<  2),
-    GLS_BLEND_BLEND         = (1 <<  3),
-    GLS_BLEND_ADD           = (1 <<  4),
-    GLS_BLEND_MODULATE      = (1 <<  5),
-    GLS_ALPHATEST_ENABLE    = (1 <<  6),
-    GLS_TEXTURE_REPLACE     = (1 <<  7),
-    GLS_SCROLL_ENABLE       = (1 <<  8),
-    GLS_LIGHTMAP_ENABLE     = (1 <<  9),
-    GLS_WARP_ENABLE         = (1 << 10),
-    GLS_INTENSITY_ENABLE    = (1 << 11),
-    GLS_SHADE_SMOOTH        = (1 << 12),
-    GLS_SCROLL_X            = (1 << 13),
-    GLS_SCROLL_Y            = (1 << 14),
-    GLS_SCROLL_FLIP         = (1 << 15),
-    GLS_SCROLL_SLOW         = (1 << 16),
+    GLS_DEPTHMASK_FALSE     = BIT(0),
+    GLS_DEPTHTEST_DISABLE   = BIT(1),
+    GLS_CULL_DISABLE        = BIT(2),
+    GLS_BLEND_BLEND         = BIT(3),
+    GLS_BLEND_ADD           = BIT(4),
+    GLS_BLEND_MODULATE      = BIT(5),
+    GLS_ALPHATEST_ENABLE    = BIT(6),
+    GLS_TEXTURE_REPLACE     = BIT(7),
+    GLS_SCROLL_ENABLE       = BIT(8),
+    GLS_LIGHTMAP_ENABLE     = BIT(9),
+    GLS_WARP_ENABLE         = BIT(10),
+    GLS_INTENSITY_ENABLE    = BIT(11),
+    GLS_SHADE_SMOOTH        = BIT(12),
+    GLS_SCROLL_X            = BIT(13),
+    GLS_SCROLL_Y            = BIT(14),
+    GLS_SCROLL_FLIP         = BIT(15),
+    GLS_SCROLL_SLOW         = BIT(16),
 
     GLS_BLEND_MASK  = GLS_BLEND_BLEND | GLS_BLEND_ADD | GLS_BLEND_MODULATE,
     GLS_COMMON_MASK = GLS_DEPTHMASK_FALSE | GLS_DEPTHTEST_DISABLE | GLS_CULL_DISABLE | GLS_BLEND_MASK,
@@ -334,10 +334,10 @@ typedef enum {
 
 typedef enum {
     GLA_NONE        = 0,
-    GLA_VERTEX      = (1 << 0),
-    GLA_TC          = (1 << 1),
-    GLA_LMTC        = (1 << 2),
-    GLA_COLOR       = (1 << 3),
+    GLA_VERTEX      = BIT(0),
+    GLA_TC          = BIT(1),
+    GLA_LMTC        = BIT(2),
+    GLA_COLOR       = BIT(3),
 } glArrayBits_t;
 
 typedef struct {

--- a/src/refresh/gl/main.c
+++ b/src/refresh/gl/main.c
@@ -421,7 +421,7 @@ static void GL_DrawEntities(int mask)
         GL_SetEntityAxis();
 
         // inline BSP model
-        if (ent->model & 0x80000000) {
+        if (ent->model & BIT(31)) {
             bsp_t *bsp = gl_static.world.cache;
             int index = ~ent->model;
 

--- a/src/refresh/gl/surf.c
+++ b/src/refresh/gl/surf.c
@@ -141,7 +141,7 @@ static void add_dynamic_lights(mface_t *surf)
     t_scale = surf->lm_scale[1];
 
     for (i = 0; i < glr.fd.num_dlights; i++) {
-        if (!(surf->dlightbits & (1U << i)))
+        if (!(surf->dlightbits & BIT(i)))
             continue;
 
         light = &glr.fd.dlights[i];

--- a/src/refresh/gl/world.c
+++ b/src/refresh/gl/world.c
@@ -188,7 +188,7 @@ static void GL_MarkLights(void)
         if(light->light_type != DLIGHT_SPHERE)
             continue;
         VectorCopy(light->origin, light->transformed);
-        GL_MarkLights_r(gl_static.world.cache->nodes, light, 1U << i);
+        GL_MarkLights_r(gl_static.world.cache->nodes, light, BIT(i));
     }
 }
 
@@ -207,7 +207,7 @@ static void GL_TransformLights(mmodel_t *model)
         light->transformed[0] = DotProduct(temp, glr.entaxis[0]);
         light->transformed[1] = DotProduct(temp, glr.entaxis[1]);
         light->transformed[2] = DotProduct(temp, glr.entaxis[2]);
-        GL_MarkLights_r(model->headnode, light, 1U << i);
+        GL_MarkLights_r(model->headnode, light, BIT(i));
     }
 }
 

--- a/src/refresh/gl/world.c
+++ b/src/refresh/gl/world.c
@@ -95,7 +95,7 @@ static bool _GL_LightPoint(const vec3_t start, vec3_t color)
     for (i = 0; i < glr.fd.num_entities; i++) {
         ent = &glr.fd.entities[i];
         index = ent->model;
-        if (!(index & 0x80000000))
+        if (!(index & BIT(31)))
             break;  // BSP models are at the start of entity array
 
         index = ~index;
@@ -436,7 +436,7 @@ void GL_DrawBspModel(mmodel_t *model)
 }
 
 #define NODE_CLIPPED    0
-#define NODE_UNCLIPPED  15
+#define NODE_UNCLIPPED  (BIT(4) - 1)
 
 static inline bool GL_ClipNode(mnode_t *node, int *clipflags)
 {

--- a/src/server/ac.c
+++ b/src/server/ac.c
@@ -108,10 +108,10 @@ typedef struct {
     char hashlist_name[MAX_QPATH];
 } ac_static_t;
 
-#define ACP_BLOCKPLAY   (1 << 0)
+#define ACP_BLOCKPLAY   BIT(0)
 
-#define ACH_REQUIRED    (1 << 0)
-#define ACH_NEGATIVE    (1 << 1)
+#define ACH_REQUIRED    BIT(0)
+#define ACH_NEGATIVE    BIT(1)
 
 #define AC_PROTOCOL_VERSION     0xAC03
 

--- a/src/server/mvd/game.c
+++ b/src/server/mvd/game.c
@@ -697,7 +697,7 @@ static void MVD_UpdateClient(mvd_client_t *client)
             if (mvd_stats_hack->integer && mvd->dummy) {
                 // copy stats of the dummy MVD observer
                 for (i = 0; i < MAX_STATS; i++) {
-                    if (mvd_stats_hack->integer & (1U << i)) {
+                    if (mvd_stats_hack->integer & BIT(i)) {
                         client->ps.stats[i] = mvd->dummy->ps.stats[i];
                     }
                 }
@@ -1148,7 +1148,7 @@ static bool count_chase_bits(mvd_client_t *client)
     for (i = 0; i < (mvd->maxclients + CHAR_BIT - 1) / CHAR_BIT; i++)
         if (client->chase_bitmap[i])
             for (j = 0; j < 8; j++)
-                if (client->chase_bitmap[i] & (1 << j))
+                if (client->chase_bitmap[i] & BIT(j))
                     count++;
 
     return count;

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -95,9 +95,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 // ugly hack for SV_Shutdown
 #define MVD_SPAWN_DISABLED  0
-#define MVD_SPAWN_ENABLED   0x40000000
-#define MVD_SPAWN_INTERNAL  0x80000000
-#define MVD_SPAWN_MASK      0xc0000000
+#define MVD_SPAWN_ENABLED   BIT(30)
+#define MVD_SPAWN_INTERNAL  BIT(31)
+#define MVD_SPAWN_MASK      (MVD_SPAWN_ENABLED | MVD_SPAWN_INTERNAL)
 
 typedef struct {
     int         number;


### PR DESCRIPTION
Upstream switched to using a macro to specify bitmasks, making them more readable than hex values or `1 << x` style values.
Also using enums instead of macros for some constants.