### PR TITLE
Always use EXT_debug_marker extension, if available

### DIFF
--- a/src/refresh/vkpt/device_memory_allocator.h
+++ b/src/refresh/vkpt/device_memory_allocator.h
@@ -36,7 +36,7 @@ typedef struct DeviceMemory
 
 typedef struct DeviceMemoryAllocator DeviceMemoryAllocator;
 
-DeviceMemoryAllocator* create_device_memory_allocator(VkDevice device);
+DeviceMemoryAllocator* create_device_memory_allocator(VkDevice device, const char *debug_label);
 DMAResult allocate_device_memory(DeviceMemoryAllocator* allocator, DeviceMemory* device_memory);
 void free_device_memory(DeviceMemoryAllocator* allocator, const DeviceMemory* device_memory);
 void destroy_device_memory_allocator(DeviceMemoryAllocator* allocator);

--- a/src/refresh/vkpt/draw.c
+++ b/src/refresh/vkpt/draw.c
@@ -257,10 +257,12 @@ vkpt_draw_initialize()
 		_VK(buffer_create(buf_stretch_pic_queue + i, sizeof(StretchPic_t) * MAX_STRETCH_PICS, 
 			VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
 			VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT));
+		buffer_attach_name(buf_stretch_pic_queue + i, va("stretch pic queue %d", i));
 
 		_VK(buffer_create(buf_ubo + i, sizeof(StretchPic_UBO_t),
 			VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
 			VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT));
+		buffer_attach_name(buf_stretch_pic_queue + i, va("stretch pic ubo %d", i));
 	}
 
 	VkDescriptorSetLayoutBinding layout_bindings[] = {

--- a/src/refresh/vkpt/main.c
+++ b/src/refresh/vkpt/main.c
@@ -447,10 +447,6 @@ const char* vk_requested_device_extensions_ray_query[] = {
 	VK_KHR_DEFERRED_HOST_OPERATIONS_EXTENSION_NAME
 };
 
-const char *vk_requested_device_extensions_debug[] = {
-	VK_EXT_DEBUG_MARKER_EXTENSION_NAME,
-};
-
 #define OPTIONAL_INSTANCE_EXTENSIONS		\
 	VK_OPT_EXT_DO(VK_EXT_SWAPCHAIN_COLOR_SPACE)
 
@@ -468,8 +464,9 @@ static const char *optional_instance_extension_name[NUM_OPTIONAL_INSTANCE_EXTENS
 #undef VK_OPT_EXT_DO
 };
 
-#define OPTIONAL_DEVICE_EXTENSIONS	\
-	VK_OPT_EXT_DO(VK_KHR_LINE_RASTERIZATION)
+#define OPTIONAL_DEVICE_EXTENSIONS				\
+	VK_OPT_EXT_DO(VK_KHR_LINE_RASTERIZATION)	\
+	VK_OPT_EXT_DO(VK_EXT_DEBUG_MARKER)
 
 enum optional_device_extension_id
 {
@@ -1426,7 +1423,6 @@ init_vulkan(void)
 
 	uint32_t max_extension_count = LENGTH(vk_requested_device_extensions_common);
 	max_extension_count += max(LENGTH(vk_requested_device_extensions_ray_pipeline), LENGTH(vk_requested_device_extensions_ray_query));
-	max_extension_count += LENGTH(vk_requested_device_extensions_debug);
 	max_extension_count += NUM_OPTIONAL_DEVICE_EXTENSIONS;
 
 	const char** device_extensions = alloca(sizeof(char*) * max_extension_count);
@@ -1450,12 +1446,6 @@ init_vulkan(void)
 		device_features_vk12.pNext = &physical_device_rt_pipeline_features;
 	}
 	
-	if (qvk.enable_validation)
-	{
-		append_string_list(device_extensions, &device_extension_count, max_extension_count,
-			vk_requested_device_extensions_debug, LENGTH(vk_requested_device_extensions_debug));
-	}
-
 	// Add detected optional device extensions
 	for (int i = 0; i < NUM_OPTIONAL_DEVICE_EXTENSIONS; i++) {
 		if (available_optional_device_extensions[i])
@@ -1497,7 +1487,7 @@ init_vulkan(void)
 		LIST_EXTENSIONS_RAY_PIPELINE
 	}
 
-	if(qvk.enable_validation)
+	if(available_optional_device_extensions[OPT_EXT_VK_EXT_DEBUG_MARKER])
 	{
 		LIST_EXTENSIONS_DEBUG
 	}

--- a/src/refresh/vkpt/precomputed_sky.c
+++ b/src/refresh/vkpt/precomputed_sky.c
@@ -384,7 +384,7 @@ vkpt_uniform_precomputed_buffer_create(void)
 			VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
 			VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
 
-		ATTACH_LABEL_VARIABLE_NAME(atmosphere_params_buffer.buffer, BUFFER, "AtmosphereParameters");
+		buffer_attach_name(&atmosphere_params_buffer, "AtmosphereParameters");
 	}
 
 	VkDescriptorPoolSize pool_size = {
@@ -766,12 +766,12 @@ struct ShadowmapGeometry FillVertexAndIndexBuffers(const char* FileName, unsigne
 	buffer_create(&result.Vertexes, VertexBufferSize,
 		VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT,
 		VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
-	ATTACH_LABEL_VARIABLE_NAME(result.Vertexes.buffer, BUFFER, "Shadowmap Vertex Buffer");
+	buffer_attach_name(&result.Vertexes, "Shadowmap Vertex Buffer");
 
 	buffer_create(&result.Indexes, IndexBufferSize,
 		VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_INDEX_BUFFER_BIT,
 		VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
-	ATTACH_LABEL_VARIABLE_NAME(result.Indexes.buffer, BUFFER, "Shadowmap Index Buffer");
+	buffer_attach_name(&result.Indexes, "Shadowmap Index Buffer");
 
 	VkCommandBuffer cmd_buf = vkpt_begin_command_buffer(&qvk.cmd_buffers_graphics);
 

--- a/src/refresh/vkpt/textures.c
+++ b/src/refresh/vkpt/textures.c
@@ -2220,7 +2220,8 @@ LIST_IMAGES_A_B
 
 	/* attach labels to images */
 #define IMG_DO(_name, _binding, ...) \
-	ATTACH_LABEL_VARIABLE_NAME(qvk.images[VKPT_IMG_##_name], IMAGE, #_name);
+	ATTACH_LABEL_VARIABLE_NAME(qvk.images[VKPT_IMG_##_name], IMAGE, #_name);	\
+	ATTACH_LABEL_VARIABLE_NAME(mem_images[VKPT_IMG_##_name], DEVICE_MEMORY, "mem:" #_name);
 	LIST_IMAGES
 	LIST_IMAGES_A_B
 #undef IMG_DO

--- a/src/refresh/vkpt/textures.c
+++ b/src/refresh/vkpt/textures.c
@@ -1249,7 +1249,7 @@ vkpt_textures_initialize()
 	vkpt_invalidate_texture_descriptors();
 	memset(&texture_system, 0, sizeof(texture_system));
 
-	tex_device_memory_allocator = create_device_memory_allocator(qvk.device);
+	tex_device_memory_allocator = create_device_memory_allocator(qvk.device, "texture device memory");
 
 	create_invalid_texture();
 

--- a/src/refresh/vkpt/transparency.c
+++ b/src/refresh/vkpt/transparency.c
@@ -807,42 +807,49 @@ static void create_buffers(void)
 		TR_VERTEX_MAX_NUM * sizeof(vec3_t),
 		VK_BUFFER_USAGE_VERTEX_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT,
 		VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+	buffer_attach_name(&transparency.vertex_buffer, "transparency vertex buffer");
 
 	buffer_create(
 		&transparency.beam_aabb_buffer,
 		TR_BEAM_MAX_NUM * sizeof(VkAabbPositionsKHR),
 		VK_BUFFER_USAGE_VERTEX_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT, 
 		VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+	buffer_attach_name(&transparency.vertex_buffer, "transparency beam aabb buffer");
 
 	buffer_create(
 		&transparency.index_buffer,
 		TR_INDEX_MAX_NUM * sizeof(uint16_t),
 		VK_BUFFER_USAGE_INDEX_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT,
 		VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+	buffer_attach_name(&transparency.vertex_buffer, "transparency index buffer");
 
 	buffer_create(
 		&transparency.particle_color_buffer,
 		TR_PARTICLE_MAX_NUM * TR_COLOR_SIZE,
 		VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
 		VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+	buffer_attach_name(&transparency.vertex_buffer, "transparency particle color buffer");
 
 	buffer_create(
 		&transparency.beam_color_buffer,
 		TR_BEAM_MAX_NUM * TR_COLOR_SIZE,
 		VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
 		VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+	buffer_attach_name(&transparency.vertex_buffer, "transparency beam color buffer");
 
 	buffer_create(
 		&transparency.sprite_info_buffer,
 		TR_SPRITE_MAX_NUM * TR_SPRITE_INFO_SIZE,
 		VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
 		VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+	buffer_attach_name(&transparency.vertex_buffer, "transparency sprite info buffer");
 
 	buffer_create(
 		&transparency.beam_intersect_buffer,
 		TR_BEAM_MAX_NUM * TR_BEAM_INTERSECT_SIZE,
 		VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
 		VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+	buffer_attach_name(&transparency.vertex_buffer, "transparency beam intersect buffer");
 }
 
 static bool allocate_and_bind_memory_to_buffers(void)

--- a/src/refresh/vkpt/uniform_buffer.c
+++ b/src/refresh/vkpt/uniform_buffer.c
@@ -64,11 +64,14 @@ vkpt_uniform_buffer_create()
 	ubo_alignment = properties.limits.minUniformBufferOffsetAlignment;
 
 	const size_t buffer_size = align(sizeof(QVKUniformBuffer_t), ubo_alignment) + sizeof(InstanceBuffer);
-	for(int i = 0; i < MAX_FRAMES_IN_FLIGHT; i++)
+	for(int i = 0; i < MAX_FRAMES_IN_FLIGHT; i++) {
 		buffer_create(host_uniform_buffers + i, buffer_size, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, host_memory_flags);
+		buffer_attach_name(host_uniform_buffers + i, va("host uniform buffer %d", i));
+	}
 
 	buffer_create(&device_uniform_buffer, buffer_size, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
 		device_memory_flags);
+	buffer_attach_name(&device_uniform_buffer, "device uniform buffer");
 
 	VkDescriptorPoolCreateInfo pool_info = {
 		.sType         = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,

--- a/src/refresh/vkpt/vertex_buffer.c
+++ b/src/refresh/vkpt/vertex_buffer.c
@@ -282,8 +282,7 @@ vkpt_vertex_buffer_upload_bsp_mesh(bsp_mesh_t* bsp_mesh)
 	
 	if (res != VK_SUCCESS) return res;
 
-	ATTACH_LABEL_VARIABLE(qvk.buf_world.buffer, BUFFER);
-	ATTACH_LABEL_VARIABLE(qvk.buf_world.memory, DEVICE_MEMORY);
+	buffer_attach_name(&qvk.buf_world, "qvk.buf_world");
 
 	BufferResource_t staging_buffer;
 
@@ -1066,8 +1065,7 @@ vkpt_vertex_buffer_upload_models()
 			VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
 			VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
 
-		ATTACH_LABEL_VARIABLE_NAME(vbo->buffer.buffer, BUFFER, model->name);
-		ATTACH_LABEL_VARIABLE_NAME(vbo->buffer.memory, DEVICE_MEMORY, model->name);
+		buffer_attach_name(&vbo->buffer, model->name);
 
 		if (model_is_static)
 		{

--- a/src/refresh/vkpt/vertex_buffer.c
+++ b/src/refresh/vkpt/vertex_buffer.c
@@ -1174,10 +1174,12 @@ void create_primbuf(void)
 	buffer_create(&qvk.buf_primitive_instanced, sizeof(VboPrimitive) * primbuf_size,
 		VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT | VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT,
 		VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+	buffer_attach_name(&qvk.buf_primitive_instanced, "instanced primitive");
 
 	buffer_create(&qvk.buf_positions_instanced, sizeof(prim_positions_t) * primbuf_size,
 		VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT | VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT,
 		VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+	buffer_attach_name(&qvk.buf_positions_instanced, "instanced position");
 
 	VkDescriptorBufferInfo buf_info = { 0 };
 
@@ -1308,27 +1310,32 @@ vkpt_vertex_buffer_create()
 	buffer_create(&qvk.buf_light, sizeof(LightBuffer),
 		VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
 		VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+	buffer_attach_name(&qvk.buf_light, "light");
 
 	for (int frame = 0; frame < MAX_FRAMES_IN_FLIGHT; frame++)
 	{
 		buffer_create(qvk.buf_light_staging + frame, sizeof(LightBuffer),
 			VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
 			VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+		buffer_attach_name(qvk.buf_light_staging + frame, va("light staging %d", frame));
 	}
 
 	buffer_create(&qvk.buf_readback, sizeof(ReadbackBuffer),
 		VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
 		VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+	buffer_attach_name(&qvk.buf_readback, "readback");
 
 	buffer_create(&qvk.buf_iqm_matrices, sizeof(IqmMatrixBuffer),
 		VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
 		VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+	buffer_attach_name(&qvk.buf_iqm_matrices, "iqm matrices");
 
 	for (int frame = 0; frame < MAX_FRAMES_IN_FLIGHT; frame++)
 	{
 		buffer_create(qvk.buf_iqm_matrices_staging + frame, sizeof(IqmMatrixBuffer),
 			VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
 			VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+		buffer_attach_name(qvk.buf_iqm_matrices_staging + frame, va("iqm matrices staging %d", frame));
 	}
 
 	qvk.iqm_matrices_shadow = Z_Mallocz(sizeof(IqmMatrixBuffer));
@@ -1337,19 +1344,23 @@ vkpt_vertex_buffer_create()
 	buffer_create(&qvk.buf_tonemap, sizeof(ToneMappingBuffer),
 		VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
 		VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+	buffer_attach_name(&qvk.buf_tonemap, "tonemap");
 
 	buffer_create(&qvk.buf_sun_color, sizeof(SunColorBuffer),
 		VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
 		VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+	buffer_attach_name(&qvk.buf_sun_color, "sun color");
 
 	for (int frame = 0; frame < MAX_FRAMES_IN_FLIGHT; frame++)
 	{
 		buffer_create(qvk.buf_readback_staging + frame, sizeof(ReadbackBuffer),
 			VK_BUFFER_USAGE_TRANSFER_DST_BIT,
 			VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+		buffer_attach_name(qvk.buf_readback_staging + frame, va("readback staging %d", frame));
 	}
 
 	buffer_create(&null_buffer, 4, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+	buffer_attach_name(&null_buffer, "null");
 
 	VkDescriptorPoolSize pool_size = {
 		.type            = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
@@ -1505,6 +1516,7 @@ VkResult vkpt_light_buffers_create(bsp_mesh_t *bsp_mesh)
 		buffer_create(qvk.buf_light_stats + frame, sizeof(uint32_t) * num_stats,
 			VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
 			VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+		buffer_attach_name(qvk.buf_light_stats + frame, va("light stats %d", frame));
 	}
 
 	assert(NUM_LIGHT_STATS_BUFFERS == 3);
@@ -1542,6 +1554,7 @@ VkResult vkpt_light_buffers_create(bsp_mesh_t *bsp_mesh)
 		buffer_create(qvk.buf_light_counts_history + h, sizeof(uint32_t) * bsp_mesh->num_clusters,
 			VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
 			VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+		buffer_attach_name(qvk.buf_light_counts_history + h, va("light counts history %d", h));
 
 		light_counts_buf_info[h].buffer = qvk.buf_light_counts_history[h].buffer;
 		light_counts_buf_info[h].offset = 0;

--- a/src/refresh/vkpt/vk_util.c
+++ b/src/refresh/vkpt/vk_util.c
@@ -179,6 +179,12 @@ buffer_unmap(BufferResource_t *buf)
 	vkUnmapMemory(qvk.device, buf->memory);
 }
 
+void buffer_attach_name(const BufferResource_t *buf, const char *name)
+{
+	ATTACH_LABEL_VARIABLE_NAME(buf->buffer, BUFFER, name);
+	ATTACH_LABEL_VARIABLE_NAME(buf->memory, DEVICE_MEMORY, name);
+}
+
 VkDeviceAddress
 get_buffer_device_address(VkBuffer buffer)
 {

--- a/src/refresh/vkpt/vk_util.h
+++ b/src/refresh/vkpt/vk_util.h
@@ -44,13 +44,13 @@ buffer_create(
 		VkDeviceSize size, 
 		VkBufferUsageFlags usage,
 		VkMemoryPropertyFlags mem_properties);
-
 VkResult buffer_destroy(BufferResource_t *buf);
 void buffer_unmap(BufferResource_t *buf);
 void *buffer_map(BufferResource_t *buf);
 void buffer_unmap(BufferResource_t *buf);
 
 VkDeviceAddress get_buffer_device_address(VkBuffer buffer);
+void buffer_attach_name(const BufferResource_t *buf, const char *name);
 
 uint32_t get_memory_type(uint32_t mem_req_type_bits, VkMemoryPropertyFlags mem_prop);
 


### PR DESCRIPTION
Given it is mainly provided by debugging tools, always enabling it will conveniently provide object names when using such tools, without impacting the general case.
While we're at it, add debug labels to more objects.