### PR TITLE
Simplify MSVC runtime selection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.9)
+cmake_minimum_required (VERSION 3.15)
 cmake_policy(SET CMP0069 NEW)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
@@ -79,28 +79,11 @@ if (CMAKE_SIZEOF_VOID_P EQUAL 8)
     set( IS_64_BIT 1 )
 endif ()
 
-IF(MSVC)
-    macro(replace_msvcrt var value)
-        # Remove the existing /MD-type flags, if any
-        string(REGEX REPLACE "/M[TD]d?\\s*" "" ${var} ${${var}})
-        # Append the new flag
-        set(${var} "${${var}} ${value}")
-    endmacro(replace_msvcrt)
-    
-    replace_msvcrt(CMAKE_C_FLAGS_DEBUG "/MTd")
-    replace_msvcrt(CMAKE_C_FLAGS_MINSIZEREL "/MT")
-    replace_msvcrt(CMAKE_C_FLAGS_RELEASE "/MT")
-    replace_msvcrt(CMAKE_C_FLAGS_RELWITHDEBINFO "/MT")
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
+IF(MSVC)
     # Enable multi-processor compilation when using MSBuild
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /MP")
-
-    # Also adjust C++ flags, needed for 3rd party code
-    replace_msvcrt(CMAKE_CXX_FLAGS_DEBUG "/MTd")
-    replace_msvcrt(CMAKE_CXX_FLAGS_MINSIZEREL "/MT")
-    replace_msvcrt(CMAKE_CXX_FLAGS_RELEASE "/MT")
-    replace_msvcrt(CMAKE_CXX_FLAGS_RELWITHDEBINFO "/MT")
-
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
 
 ELSEIF(CMAKE_SYSTEM_PROCESSOR STREQUAL "ppc64le")


### PR DESCRIPTION
CMake >= 3.15 provides a pretty convenient way, use that.