### PR TITLE
Vastly reduce LIGHT_COUNT_HISTORY value

### DIFF
--- a/src/refresh/vkpt/shader/vertex_buffer.h
+++ b/src/refresh/vkpt/shader/vertex_buffer.h
@@ -24,7 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #define MAX_LIGHT_LISTS         (1 << 14)
 #define MAX_LIGHT_LIST_NODES    (1 << 19)
-#define LIGHT_COUNT_HISTORY     16
+#define LIGHT_COUNT_HISTORY     3 // one for previous frame rendered, one for current frame rendering, one for upload
 
 #define MAX_IQM_MATRICES        32768
 


### PR DESCRIPTION
That constant, introduced in #234, is a pretty conservative value, but unnecessarily large number.

The smallest number I found to work well is three - which makes sense, if you think about it: ASVGF only needs "history" from the previous frame, so we need: one for previous frame rendered, one for current frame rendering, and one more for upload.