### PR TITLE
Update glslang

### DIFF
--- a/cmake/compileShaders.cmake
+++ b/cmake/compileShaders.cmake
@@ -23,9 +23,9 @@ set(SHADER_SOURCE_DEPENDENCIES
     ${CMAKE_SOURCE_DIR}/src/refresh/vkpt/shader/vertex_buffer.h
     ${CMAKE_SOURCE_DIR}/src/refresh/vkpt/shader/water.glsl)
 
-if(TARGET glslangValidator)
-    set(GLSLANG_COMPILER "$<TARGET_FILE:glslangValidator>")
-    message(STATUS "Using glslangValidator built from source")
+if(TARGET glslang-standalone)
+    set(GLSLANG_COMPILER "$<TARGET_FILE:glslang-standalone>")
+    message(STATUS "Using glslang-standalone built from source")
 else()
     find_program(GLSLANG_COMPILER glslangValidator PATHS "$ENV{VULKAN_SDK}/bin/")
 

--- a/cmake/compileShaders.cmake
+++ b/cmake/compileShaders.cmake
@@ -25,16 +25,16 @@ set(SHADER_SOURCE_DEPENDENCIES
 
 if(TARGET glslang-standalone)
     set(GLSLANG_COMPILER "$<TARGET_FILE:glslang-standalone>")
-    message(STATUS "Using glslang-standalone built from source")
+    message(STATUS "Using glslang built from source")
 else()
-    find_program(GLSLANG_COMPILER glslangValidator PATHS "$ENV{VULKAN_SDK}/bin/")
+    find_program(GLSLANG_COMPILER NAMES glslang glslangValidator PATHS "$ENV{VULKAN_SDK}/bin/")
 
     if(NOT GLSLANG_COMPILER)
-        message(FATAL_ERROR "Couldn't find glslangValidator! "
+        message(FATAL_ERROR "Couldn't find glslang! "
             "Please provide a valid path to it using the GLSLANG_COMPILER variable.")
     endif()
     
-    message(STATUS "Using this glslangValidator: ${GLSLANG_COMPILER}")
+    message(STATUS "Using this glslang: ${GLSLANG_COMPILER}")
 endif()
 
 # Collect additional glslangValidator args

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -36,8 +36,7 @@ if(CONFIG_BUILD_GLSLANG)
 
     add_subdirectory(glslang)
 
-    set_target_properties(glslangValidator PROPERTIES FOLDER glslang)
-    set_target_properties(glslang-build-info PROPERTIES FOLDER glslang)
+    set_target_properties(glslang-standalone PROPERTIES FOLDER glslang)
 endif()
 
 #

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -371,8 +371,8 @@ IF(IS_64_BIT)
 
     add_custom_target(shaders DEPENDS ${shader_bytecode})
 
-    if(TARGET glslangValidator)
-        add_dependencies(shaders glslangValidator)
+    if(TARGET glslang-standalone)
+        add_dependencies(shaders glslang-standalone)
     endif()
 ENDIF()
 


### PR DESCRIPTION
I noticed a Windows build failure on my fork (https://github.com/res2k/Q2RTX/actions/runs/14248436691/job/39935161357) caused by a combination of GH apparently shipping a very recent CMake on the Windows agents and the glslang in `extern/glslang` being a few years old. In all likelihood the same issue affects this repo as well.

Take this as an occasion to update `extern/glslang`, to 15.2.0.
