### PR TITLE
Re-apply sv_max_packet_entities change, with fix

### DIFF
--- a/doc/server.md
+++ b/doc/server.md
@@ -132,10 +132,8 @@ If set to 0, server will skip cinematics even if they exist. Default value
 is 1.
 
 #### `sv_max_packet_entities`
-Maximum number of entities in client frame. 0 means unlimited. Default
-value is 128. Some non-standard maps with large open areas may need this
-value increased. Consider however that default Quake 2 client can only
-render 128 entities maximum. Other clients may support more.
+Maximum number of entities in client frame. Default value is 0, which picks
+optimal value automatically.
 
 #### `sv_reserved_slots`
 Number of client slots reserved for clients who know `sv_reserved_password`

--- a/inc/common/protocol.h
+++ b/inc/common/protocol.h
@@ -93,7 +93,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define SUPPRESSCOUNT_BITS      4
 #define SUPPRESSCOUNT_MASK      (BIT(SUPPRESSCOUNT_BITS) - 1)
 
-#define MAX_PACKET_ENTITIES_OLD 128
+/* Note: both this and MAX_PACKET_ENTITIES are larger than their upstream Q2PRO
+ * counterparts. This is because Q2RTX may end up sending, comparatively, quite
+ * a few more entities due to it's use of the PVS2 for entity culling */
+#define MAX_PACKET_ENTITIES_OLD 1024
 
 #define MAX_PACKET_ENTITIES     1024
 #define MAX_PARSE_ENTITIES      (MAX_PACKET_ENTITIES * UPDATE_BACKUP)

--- a/src/server/entities.c
+++ b/src/server/entities.c
@@ -399,6 +399,7 @@ void SV_BuildClientFrame(client_t *client)
     bool    ent_visible;
     int cull_nonvisible_entities = Cvar_Get("sv_cull_nonvisible_entities", "1", CVAR_CHEAT)->integer;
     bool        need_clientnum_fix;
+    int         max_packet_entities;
 
     clent = client->edict;
     if (!clent->client)
@@ -447,6 +448,11 @@ void SV_BuildClientFrame(client_t *client)
         && client->version < PROTOCOL_VERSION_Q2PRO_CLIENTNUM_SHORT
         && frame->clientNum >= CLIENTNUM_NONE;
 
+    // limit maximum number of entities in client frame
+    max_packet_entities =
+        sv_max_packet_entities->integer > 0 ? sv_max_packet_entities->integer :
+        client->csr->extended ? MAX_PACKET_ENTITIES : MAX_PACKET_ENTITIES_OLD;
+
 	if (clientcluster >= 0)
 	{
 		CM_FatPVS(client->cm, clientpvs, org, DVIS_PVS2);
@@ -456,7 +462,6 @@ void SV_BuildClientFrame(client_t *client)
 	{
 		BSP_ClusterVis(client->cm->cache, clientpvs, client->last_valid_cluster, DVIS_PVS2);
 	}
-
     BSP_ClusterVis(client->cm->cache, clientphs, clientcluster, DVIS_PHS);
 
     // build up the list of visible entities
@@ -587,7 +592,7 @@ void SV_BuildClientFrame(client_t *client)
 
         svs.next_entity++;
 
-        if (++frame->num_entities == sv_max_packet_entities->integer) {
+        if (++frame->num_entities == max_packet_entities) {
             break;
         }
     }

--- a/src/server/main.c
+++ b/src/server/main.c
@@ -2227,7 +2227,7 @@ void SV_Init(void)
     sv_calcpings_method = Cvar_Get("sv_calcpings_method", "2", 0);
     sv_changemapcmd = Cvar_Get("sv_changemapcmd", "", 0);
     sv_max_download_size = Cvar_Get("sv_max_download_size", "8388608", 0);
-    sv_max_packet_entities = Cvar_Get("sv_max_packet_entities", STRINGIFY(MAX_PACKET_ENTITIES), 0);
+    sv_max_packet_entities = Cvar_Get("sv_max_packet_entities", "0", 0);
 
     sv_strafejump_hack = Cvar_Get("sv_strafejump_hack", "1", CVAR_LATCH);
     sv_waterjump_hack = Cvar_Get("sv_waterjump_hack", "1", CVAR_LATCH);


### PR DESCRIPTION
...to be a bit closer to the upstream source again while dealing with #462.

My thinking behind keeping `MAX_PACKET_ENTITIES_OLD`:
Q2PRO introduced a larger `MAX_PACKET_ENTITIES` to accommodate remaster content, presumably because it was found it'll exceed the old limit.
In the same vein, should any further support for remastered content make it into Q2RTX, this may require an even larger `MAX_PACKET_ENTITIES` value due to use of PVS2. Keeping both constants may make adjustments easier.