### PR TITLE
ReSTIR (with tweaks)

### DIFF
--- a/baseq2/q2rtx.menu
+++ b/baseq2/q2rtx.menu
@@ -147,6 +147,7 @@ begin video
         toggle "AMD FSR 1.0" flt_fsr_enable
         range --status "lower is sharper" "AMD FSR 1.0 sharpness" flt_fsr_sharpness 0 2 0.01
         pairs "global illumination" pt_num_bounce_rays low 0.5 medium 1 high 2
+        pairs "direct light sampling" pt_restir "RIS light" 0 "ReSTIR, high quality" 1 "ReSTIR, half" 2 "ReSTIR, quarter" 3
         pairs "reflection/refraction depth" pt_reflect_refract off 0 1 1 2 2 4 4 8 8
 		toggle --status "turn some monitors in the game into security camera views" \
             "security cameras" pt_cameras

--- a/cmake/compileShaders.cmake
+++ b/cmake/compileShaders.cmake
@@ -16,6 +16,7 @@ set(SHADER_SOURCE_DEPENDENCIES
     ${CMAKE_SOURCE_DIR}/src/refresh/vkpt/shader/precomputed_sky.glsl
     ${CMAKE_SOURCE_DIR}/src/refresh/vkpt/shader/precomputed_sky_params.h
     ${CMAKE_SOURCE_DIR}/src/refresh/vkpt/shader/projection.glsl
+    ${CMAKE_SOURCE_DIR}/src/refresh/vkpt/shader/restir.h
     ${CMAKE_SOURCE_DIR}/src/refresh/vkpt/shader/sky.h
     ${CMAKE_SOURCE_DIR}/src/refresh/vkpt/shader/tiny_encryption_algorithm.h
     ${CMAKE_SOURCE_DIR}/src/refresh/vkpt/shader/tone_mapping_utils.glsl

--- a/doc/client.md
+++ b/doc/client.md
@@ -937,6 +937,14 @@ Selects the projection to use for rendering. Default value is 0.
 #### `pt_reflect_refract`
 Number of reflection or refraction bounces to trace. Default value is 2.
 
+#### `pt_restir`
+Switch for experimental direct light sampling algorithms. Default value is 1.
+
+- 0 — RIS light sampling.
+- 1 — ReSTIR, high quality.
+- 2 — ReSTIR El-Cheapo, uses half of the shadow rays.
+- 3 — ReSTIR El-Very-Cheapo, uses one quarter of the shadow rays.
+
 #### `pt_roughness_override`
 Global override for roughness of all materials. Negative values mean there is no
 override. Default value is -1.

--- a/doc/client.md
+++ b/doc/client.md
@@ -939,7 +939,6 @@ Number of reflection or refraction bounces to trace. Default value is 2.
 
 #### `pt_restir`
 Switch for experimental direct light sampling algorithms. Default value is 1.
-
 - 0 — RIS light sampling.
 - 1 — ReSTIR, high quality.
 - 2 — ReSTIR El-Cheapo, uses half of the shadow rays.

--- a/inc/refresh/models.h
+++ b/inc/refresh/models.h
@@ -118,6 +118,7 @@ typedef struct light_poly_s {
 	int cluster;
 	int style;
 	float emissive_factor;
+	int type;
 } light_poly_t;
 
 typedef struct maliasmesh_s maliasmesh_t;

--- a/src/refresh/vkpt/bsp_mesh.c
+++ b/src/refresh/vkpt/bsp_mesh.c
@@ -959,7 +959,7 @@ collect_one_light_poly_entire_texture(bsp_t *bsp, mface_t *surf, mtexinfo_t *tex
 
 		light.material = texinfo->material;
 		light.style = light_style;
-		light.type = DYNLIGHT_POLYGON;
+		light.type = LIGHT_POLYGON;
 
 		if(!get_triangle_off_center(light.positions, light.off_center, NULL, 1.f))
 			continue;
@@ -1114,7 +1114,7 @@ collect_one_light_poly(bsp_t *bsp, mface_t *surf, mtexinfo_t *texinfo, int model
 				light_poly_t* light = append_light_poly(num_lights, allocated_lights, lights);
 				light->material = texinfo->material;
 				light->style = light_style;
-				light->type = DYNLIGHT_POLYGON;
+				light->type = LIGHT_POLYGON;
 				light->emissive_factor = emissive_factor;
 				VectorCopy(instance_positions[0], light->positions + 0);
 				VectorCopy(instance_positions[i1], light->positions + 3);
@@ -1330,7 +1330,7 @@ collect_sky_and_lava_light_polys(bsp_mesh_t *wm, bsp_t* bsp)
 			}
 
 			light.style = 0;
-			light.type = DYNLIGHT_POLYGON;
+			light.type = LIGHT_POLYGON;
 
 			if (!get_triangle_off_center(light.positions, light.off_center, NULL, 1.f))
 				continue;
@@ -1824,7 +1824,7 @@ bsp_mesh_create_custom_sky_prims(uint32_t* prim_ctr, bsp_mesh_t* wm, const bsp_t
 		light->material = 0;
 		light->style = 0;
 		light->cluster = cluster;
-		light->type = DYNLIGHT_POLYGON;
+		light->type = LIGHT_POLYGON;
 
 		++*prim_ctr;
 

--- a/src/refresh/vkpt/bsp_mesh.c
+++ b/src/refresh/vkpt/bsp_mesh.c
@@ -959,6 +959,7 @@ collect_one_light_poly_entire_texture(bsp_t *bsp, mface_t *surf, mtexinfo_t *tex
 
 		light.material = texinfo->material;
 		light.style = light_style;
+		light.type = DYNLIGHT_POLYGON;
 
 		if(!get_triangle_off_center(light.positions, light.off_center, NULL, 1.f))
 			continue;
@@ -1113,6 +1114,7 @@ collect_one_light_poly(bsp_t *bsp, mface_t *surf, mtexinfo_t *texinfo, int model
 				light_poly_t* light = append_light_poly(num_lights, allocated_lights, lights);
 				light->material = texinfo->material;
 				light->style = light_style;
+				light->type = DYNLIGHT_POLYGON;
 				light->emissive_factor = emissive_factor;
 				VectorCopy(instance_positions[0], light->positions + 0);
 				VectorCopy(instance_positions[i1], light->positions + 3);
@@ -1328,6 +1330,7 @@ collect_sky_and_lava_light_polys(bsp_mesh_t *wm, bsp_t* bsp)
 			}
 
 			light.style = 0;
+			light.type = DYNLIGHT_POLYGON;
 
 			if (!get_triangle_off_center(light.positions, light.off_center, NULL, 1.f))
 				continue;
@@ -1821,6 +1824,7 @@ bsp_mesh_create_custom_sky_prims(uint32_t* prim_ctr, bsp_mesh_t* wm, const bsp_t
 		light->material = 0;
 		light->style = 0;
 		light->cluster = cluster;
+		light->type = DYNLIGHT_POLYGON;
 
 		++*prim_ctr;
 

--- a/src/refresh/vkpt/conversion.h
+++ b/src/refresh/vkpt/conversion.h
@@ -90,6 +90,16 @@ static inline float halfToFloat(uint16_t value)
 	return v.f;
 }
 
+static inline float uintBitsToFloat(uint32_t ui)
+{
+	union {
+		float f;
+		uint32_t ui;
+	} bits;
+	bits.ui = ui;
+	return bits.f;
+}
+
 void packHalf4x16(uint32_t* half, float* vec4);
 
 #endif // CONVERSION_H_

--- a/src/refresh/vkpt/main.c
+++ b/src/refresh/vkpt/main.c
@@ -1666,16 +1666,11 @@ destroy_vulkan(void)
 	return 0;
 }
 
-typedef struct entity_hash_s {
-	unsigned int mesh : 8;
-	unsigned int model : 9;
-	unsigned int entity : 14;
-	unsigned int bsp : 1;
-} entity_hash_t;
-
 static int entity_frame_num = 0;
 static uint32_t model_entity_ids[2][MAX_MODEL_INSTANCES];
 static int model_entity_id_count[2];
+static int light_entity_ids[2][MAX_MODEL_LIGHTS];
+static int light_entity_id_count[2];
 static int iqm_matrix_count[2];
 static ModelInstance model_instances_prev[MAX_MODEL_INSTANCES];
 
@@ -1828,7 +1823,7 @@ static void add_dlight_spot(const dlight_t* dlight, light_poly_t* light)
 }
 
 static void
-add_dlights(const dlight_t* dlights, int num_dlights, light_poly_t* light_list, int* num_lights, int max_lights, bsp_t *bsp)
+add_dlights(const dlight_t* dlights, int num_dlights, light_poly_t* light_list, int* num_lights, int max_lights, bsp_t *bsp, int* light_entity_ids)
 {
 	for (int i = 0; i < num_dlights; i++)
 	{
@@ -1839,6 +1834,10 @@ add_dlights(const dlight_t* dlights, int num_dlights, light_poly_t* light_list, 
 		light_poly_t* light = light_list + *num_lights;
 
 		light->cluster = BSP_PointLeaf(bsp->nodes, dlight->origin)->cluster;
+
+		entity_hash_t hash;
+		hash.entity = i + 1; //entity ID
+		hash.mesh = 0xAA;
 
 		if(light->cluster >= 0)
 		{
@@ -1853,14 +1852,17 @@ add_dlights(const dlight_t* dlights, int num_dlights, light_poly_t* light_list, 
 			switch(dlight->light_type) {
 				case DLIGHT_SPHERE:
 					light->type = LIGHT_SPHERE;
+					hash.model = 0xFE;
 					break;
 				case DLIGHT_SPOT:
 					light->type = LIGHT_SPOT;
 					// Copy spot data
 					add_dlight_spot(dlight, light);
+					hash.model = 0xFD;
 					break;
 			}
 
+			light_entity_ids[(*num_lights)] = *(uint32_t*)&hash;
 			(*num_lights)++;
 
 		}
@@ -1875,7 +1877,7 @@ static inline void transform_point(const float* p, const float* matrix, float* r
 	VectorCopy(transformed, result); // vec4 -> vec3
 }
 
-static void instance_model_lights(int num_light_polys, const light_poly_t* light_polys, const float* transform)
+static void instance_model_lights(int num_light_polys, const light_poly_t* light_polys, const float* transform, entity_hash_t hash)
 {
 	for (int nlight = 0; nlight < num_light_polys; nlight++)
 	{
@@ -1906,6 +1908,9 @@ static void instance_model_lights(int num_light_polys, const light_poly_t* light
 		dst_light->material = src_light->material;
 		dst_light->style = src_light->style;
 		dst_light->type = LIGHT_POLYGON;
+
+		hash.mesh = nlight; //More a light index than a mesh
+		light_entity_ids[entity_frame_num][num_model_lights] = *(uint32_t*)&hash;
 
 		num_model_lights++;
 	}
@@ -1990,7 +1995,7 @@ static void process_bsp_entity(const entity_t* entity, int* instance_count)
 	mi->render_buffer_idx = VERTEX_BUFFER_WORLD;
 	mi->render_prim_offset = model->geometry.prim_offsets[0];
 	
-	instance_model_lights(model->num_light_polys, model->light_polys, transform);
+	instance_model_lights(model->num_light_polys, model->light_polys, transform, hash);
 
 	if (model->geometry.accel)
 	{
@@ -2183,7 +2188,13 @@ static void process_regular_entity(
 		mult_matrix_vector(end, transform, offset2);
 		VectorSet(color, 0.25f, 0.5f, 0.07f);
 
-		vkpt_build_cylinder_light(model_lights, &num_model_lights, MAX_MODEL_LIGHTS, bsp_world_model, begin, end, color, 1.5f);
+		entity_hash_t hash;
+		hash.entity = entity->id;
+		hash.model = entity->model;
+		hash.mesh = 0;
+		hash.bsp = 0;
+
+		vkpt_build_cylinder_light(model_lights, &num_model_lights, MAX_MODEL_LIGHTS, bsp_world_model, begin, end, color, 1.5f, hash, light_entity_ids[entity_frame_num]);
 	}
 
 	*instance_count = current_instance_index;
@@ -2258,7 +2269,13 @@ prepare_entities(EntityUploadInfo* upload_info)
 				else
 					create_entity_matrix(transform, (entity_t*)entity);
 
-				instance_model_lights(model->num_light_polys, model->light_polys, transform);
+				entity_hash_t hash;
+				hash.entity = i + 1;
+				hash.model = ~entity->model;
+				hash.mesh = 0;
+				hash.bsp = 0;
+
+				instance_model_lights(model->num_light_polys, model->light_polys, transform, hash);
 			}
 		}
 	}
@@ -2335,6 +2352,7 @@ prepare_entities(EntityUploadInfo* upload_info)
 	
 	memset(instance_buffer->model_current_to_prev, -1, sizeof(instance_buffer->model_current_to_prev));
 	memset(instance_buffer->model_prev_to_current, -1, sizeof(instance_buffer->model_prev_to_current));
+	memset(instance_buffer->mlight_prev_to_current, ~0u, sizeof(instance_buffer->mlight_prev_to_current));
 	
 	model_entity_id_count[entity_frame_num] = model_instance_idx;
 	for(int i = 0; i < model_entity_id_count[entity_frame_num]; i++) {
@@ -2970,6 +2988,22 @@ prepare_ubo(refdef_t *fd, mleaf_t* viewleaf, const reference_mode_t* ref_mode, c
 	ubo->num_cameras = wm->num_cameras;
 }
 
+static void
+update_mlight_prev_to_current(void)
+{
+	light_entity_id_count[entity_frame_num] = num_model_lights;
+	for(int i = 0; i < light_entity_id_count[entity_frame_num]; i++) {
+		entity_hash_t hash = *(entity_hash_t*)&light_entity_ids[entity_frame_num][i];
+		if(hash.entity == 0u) continue;
+		for(int j = 0; j < light_entity_id_count[!entity_frame_num]; j++) {
+			if(light_entity_ids[entity_frame_num][i] == light_entity_ids[!entity_frame_num][j]) {
+				vkpt_refdef.uniform_instance_buffer.mlight_prev_to_current[j] = i;
+				break;
+			}
+		}
+	}
+}
+
 /* renders the map ingame */
 void
 R_RenderFrame_RTX(refdef_t *fd)
@@ -3057,9 +3091,11 @@ R_RenderFrame_RTX(refdef_t *fd)
 		vkpt_pt_instance_model_blas(&vkpt_refdef.bsp_mesh_world.geom_sky,         g_identity_transform, VERTEX_BUFFER_WORLD, -1, 0);
 		vkpt_pt_instance_model_blas(&vkpt_refdef.bsp_mesh_world.geom_custom_sky,  g_identity_transform, VERTEX_BUFFER_WORLD, -1, 0);
 
-		vkpt_build_beam_lights(model_lights, &num_model_lights, MAX_MODEL_LIGHTS, bsp_world_model, fd->entities, fd->num_entities, prev_adapted_luminance);
-		add_dlights(vkpt_refdef.fd->dlights, vkpt_refdef.fd->num_dlights, model_lights, &num_model_lights, MAX_MODEL_LIGHTS, bsp_world_model);
+		vkpt_build_beam_lights(model_lights, &num_model_lights, MAX_MODEL_LIGHTS, bsp_world_model, fd->entities, fd->num_entities, prev_adapted_luminance, light_entity_ids[entity_frame_num], &num_model_lights);
+		add_dlights(vkpt_refdef.fd->dlights, vkpt_refdef.fd->num_dlights, model_lights, &num_model_lights, MAX_MODEL_LIGHTS, bsp_world_model, light_entity_ids[entity_frame_num]);
 	}
+
+	update_mlight_prev_to_current();
 
 	vkpt_vertex_buffer_ensure_primbuf_size(upload_info.num_prims);
 

--- a/src/refresh/vkpt/main.c
+++ b/src/refresh/vkpt/main.c
@@ -1852,10 +1852,10 @@ add_dlights(const dlight_t* dlights, int num_dlights, light_poly_t* light_list, 
 
 			switch(dlight->light_type) {
 				case DLIGHT_SPHERE:
-					light->type = DYNLIGHT_SPHERE;
+					light->type = LIGHT_SPHERE;
 					break;
 				case DLIGHT_SPOT:
-					light->type = DYNLIGHT_SPOT;
+					light->type = LIGHT_SPOT;
 					// Copy spot data
 					add_dlight_spot(dlight, light);
 					break;
@@ -1905,7 +1905,7 @@ static void instance_model_lights(int num_light_polys, const light_poly_t* light
 		VectorCopy(src_light->color, dst_light->color);
 		dst_light->material = src_light->material;
 		dst_light->style = src_light->style;
-		dst_light->type = DYNLIGHT_POLYGON;
+		dst_light->type = LIGHT_POLYGON;
 
 		num_model_lights++;
 	}

--- a/src/refresh/vkpt/path_tracer.c
+++ b/src/refresh/vkpt/path_tracer.c
@@ -104,6 +104,7 @@ cvar_t*                      cvar_pt_enable_sprites = NULL;
 
 extern cvar_t *cvar_pt_caustics;
 extern cvar_t *cvar_pt_reflect_refract;
+extern cvar_t *cvar_pt_restir;
 
 
 typedef struct QvkGeometryInstance_s {
@@ -1138,6 +1139,12 @@ vkpt_pt_trace_lighting(VkCommandBuffer cmd_buf, float num_bounce_rays)
 	BARRIER_COMPUTE(cmd_buf, qvk.images[VKPT_IMG_PT_COLOR_LF_COCG]);
 	BARRIER_COMPUTE(cmd_buf, qvk.images[VKPT_IMG_PT_COLOR_HF]);
 	BARRIER_COMPUTE(cmd_buf, qvk.images[VKPT_IMG_PT_COLOR_SPEC]);
+
+	if(cvar_pt_restir->value != 0) {
+		int frame_idx = qvk.frame_counter & 1;
+		BARRIER_COMPUTE(cmd_buf, qvk.images[VKPT_IMG_PT_RESTIR_A + frame_idx]);
+		BARRIER_COMPUTE(cmd_buf, qvk.images[VKPT_IMG_PT_RESTIR_ID_A + frame_idx]);
+	}
 
 	BUFFER_BARRIER(cmd_buf,
 		.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT,

--- a/src/refresh/vkpt/path_tracer.c
+++ b/src/refresh/vkpt/path_tracer.c
@@ -1143,7 +1143,6 @@ vkpt_pt_trace_lighting(VkCommandBuffer cmd_buf, float num_bounce_rays)
 	if(cvar_pt_restir->value != 0) {
 		int frame_idx = qvk.frame_counter & 1;
 		BARRIER_COMPUTE(cmd_buf, qvk.images[VKPT_IMG_PT_RESTIR_A + frame_idx]);
-		BARRIER_COMPUTE(cmd_buf, qvk.images[VKPT_IMG_PT_RESTIR_ID_A + frame_idx]);
 	}
 
 	BUFFER_BARRIER(cmd_buf,

--- a/src/refresh/vkpt/shader/constants.h
+++ b/src/refresh/vkpt/shader/constants.h
@@ -114,6 +114,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define MAX_TLAS_INSTANCES       (MAX_MODEL_INSTANCES + MAX_RESERVED_INSTANCES)
 #define MAX_LIGHT_SOURCES        32
 #define MAX_LIGHT_STYLES         64
+#define MAX_MODEL_LIGHTS         16384
 
 #define TLAS_INDEX_GEOMETRY      0
 #define TLAS_INDEX_EFFECTS       1
@@ -162,8 +163,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #endif
 
 // Dynamic light types
-#define DYNLIGHT_SPHERE         0
-#define DYNLIGHT_SPOT           1
+#define DYNLIGHT_POLYGON        0
+#define DYNLIGHT_SPHERE         1
+#define DYNLIGHT_SPOT           2
 
 //
 // Spotlight styles (emission profiles)

--- a/src/refresh/vkpt/shader/constants.h
+++ b/src/refresh/vkpt/shader/constants.h
@@ -162,10 +162,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define M_PI 3.1415926535897932384626433832795
 #endif
 
-// Dynamic light types
-#define DYNLIGHT_POLYGON        0
-#define DYNLIGHT_SPHERE         1
-#define DYNLIGHT_SPOT           2
+// Light types
+#define LIGHT_POLYGON        0
+#define LIGHT_SPHERE         1
+#define LIGHT_SPOT           2
 
 //
 // Spotlight styles (emission profiles)

--- a/src/refresh/vkpt/shader/direct_lighting.rgen
+++ b/src/refresh/vkpt/shader/direct_lighting.rgen
@@ -49,7 +49,8 @@ direct_lighting_restir(ivec2 ipos, bool is_odd_checkerboard, out vec3 high_freq,
 	float vis;
 
 	Reservoir r, prev_r, spatial_r;
-	prev_r.W = 0;
+	prev_r.y = RESTIR_INVALID_ID;
+	init_reservoir(r);
 
 	vec4 position_material = texelFetch(TEX_PT_SHADING_POSITION, ipos, 0);
 
@@ -59,9 +60,11 @@ direct_lighting_restir(ivec2 ipos, bool is_odd_checkerboard, out vec3 high_freq,
 	// don't compute lighting for invalid surfaces
 	if(material_id == 0)
 	{
-		imageStore(IMG_PT_RESTIR_ID_A, ipos, uvec4(RESTIR_INVALID_ID));
+		imageStore(IMG_PT_RESTIR_A, ipos, uvec4(pack_reservoir(r)));
 		return;
 	}
+
+	bool is_gradient = get_is_gradient(ipos);
 
 	vec4 view_direction = texelFetch(TEX_PT_VIEW_DIRECTION, ipos, 0);
 	vec3 normal = decode_normal(texelFetch(TEX_PT_NORMAL_A, ipos, 0).x);
@@ -80,18 +83,6 @@ direct_lighting_restir(ivec2 ipos, bool is_odd_checkerboard, out vec3 high_freq,
 	int primary_medium = int((material_id & MATERIAL_LIGHT_STYLE_MASK) >> MATERIAL_LIGHT_STYLE_SHIFT);
 
 	bool use_shadow_rays = true;
-	ivec2 ipos_r = ipos;
-	
-	if(global_ubo.pt_restir == 2)
-	{
-		ipos_r.y >>= 1;
-		use_shadow_rays = (ipos.x & 1) == (ipos.y & 1);
-	}
-	else if(global_ubo.pt_restir == 3)
-	{
-		ipos_r >>= 1;
-		use_shadow_rays = (ipos.x & 1) == 0 && (ipos.y & 1) == 0;
-	}
 
 	int shadow_cull_mask = SHADOW_RAY_CULL_MASK;
 
@@ -122,28 +113,29 @@ direct_lighting_restir(ivec2 ipos, bool is_odd_checkerboard, out vec3 high_freq,
 	}
 
 	//Do temporal
-	ivec2 pos_prev = ivec2(((vec2(ipos) + vec2(0.5)) * vec2(global_ubo.inv_width * 2, global_ubo.inv_height) + motion.xy) * vec2(global_ubo.prev_width * 0.5, global_ubo.prev_height));
-	ivec2 pos_prev_r = pos_prev;
-
-	if(global_ubo.pt_restir == 2)
+	ivec2 pos_prev = ivec2(floor(((vec2(ipos) + vec2(0.5)) * vec2(global_ubo.inv_width * 2, global_ubo.inv_height) + motion.xy) * vec2(global_ubo.prev_width * 0.5, global_ubo.prev_height)));
+	ivec2 pos_prev_or = pos_prev;
+	if(!is_gradient)
 	{
-		pos_prev.x = (pos_prev.x & ~1) + (pos_prev.y & 1);
-		pos_prev_r = pos_prev;
-		pos_prev_r.y >>= 1;
-	}
-	else if(global_ubo.pt_restir == 3)
-	{
-		pos_prev &= ~1;
-		pos_prev_r >>= 1;
+		if(global_ubo.pt_restir == 2)
+		{
+			use_shadow_rays = (ipos.x & 1) == (ipos.y & 1);
+			pos_prev.x = (pos_prev.x & ~1) + (pos_prev.y & 1);
+		}
+		else if(global_ubo.pt_restir == 3)
+		{
+			use_shadow_rays = (ipos.x & 1) == 0 && (ipos.y & 1) == 0;
+			pos_prev &= ~1;
+		}
 	}
 
 	if (!(pos_prev.x < field_left || pos_prev.x >= field_right || pos_prev.y < 0 || pos_prev.y >= global_ubo.height))
 	{
-		uint prev_idx = texelFetch(TEX_PT_RESTIR_ID_B, pos_prev_r, 0).x;
+		uvec4 packed_reservoir = texelFetch(TEX_PT_RESTIR_B, pos_prev, 0);
+		unpack_reservoir(packed_reservoir, prev_r);
+		prev_r.y = get_light_current_idx(prev_r.y);
 
-		prev_idx = get_light_current_idx(prev_idx);
-
-		if(prev_idx != RESTIR_INVALID_ID)
+		if(prev_r.y != RESTIR_INVALID_ID)
 		{
 			float depth_prev = texelFetch(TEX_PT_VIEW_DEPTH_B, pos_prev, 0).x;
 			float dist_depth = abs(depth_prev - view_depth) / abs(view_depth);
@@ -163,10 +155,8 @@ direct_lighting_restir(ivec2 ipos, bool is_odd_checkerboard, out vec3 high_freq,
 				{
 					dot_normals = 1.0f;
 				}
-				if(dot_normals > 0.9)
+				if(dot_normals > 0.5)
 				{
-					uvec4 packed_reservoir = texelFetch(TEX_PT_RESTIR_B, pos_prev_r, 0);
-					unpack_reservoir(packed_reservoir, prev_idx, prev_r);
 					prev_r.p_hat = get_unshadowed_path_contrib(prev_r.y, position, normal, view_direction.xyz, phong_exp, phong_scale, phong_weight, prev_r.y_pos);
 				}
 			}
@@ -174,7 +164,7 @@ direct_lighting_restir(ivec2 ipos, bool is_odd_checkerboard, out vec3 high_freq,
 	}
 
 	//Sample lights
-	if(use_shadow_rays)
+	if(use_shadow_rays && !is_gradient)
 	{
 		get_direct_illumination_restir(
 			position,
@@ -188,15 +178,21 @@ direct_lighting_restir(ivec2 ipos, bool is_odd_checkerboard, out vec3 high_freq,
 			prev_r,
 			r);
 	}
-	else
+	else if(is_gradient)
 	{
 		r = prev_r;
 	}
+	else if(prev_r.y != RESTIR_INVALID_ID)
+	{
+		float rng = 0.0;
+		update_reservoir(prev_r.y, prev_r.p_hat * prev_r.W * prev_r.M, prev_r.y_pos, prev_r.M, prev_r.p_hat, rng, r);
+	}
 
 	//Spatio-temporal
-	if(global_ubo.pt_restir_spatial != 0)
+	if(global_ubo.pt_restir_spatial != 0 && !is_gradient)
 	{
 		float rng = get_rng(RNG_RESTIR_SP_LIGHT_SELECTION(0));
+		float min_p_hat = 0.0;//rng * 0.5;
 		uint processed = 0;
 		ivec2 sample_pos;
 		Reservoir st_r;
@@ -204,7 +200,12 @@ direct_lighting_restir(ivec2 ipos, bool is_odd_checkerboard, out vec3 high_freq,
 
 		vec2 rng_pos = vec2(get_rng(RNG_RESTIR_SPATIAL_X(0)), get_rng(RNG_RESTIR_SPATIAL_Y(0)));
 		int distance = use_shadow_rays ? RESTIR_SPACIAL_DISTANCE : 2;
-		int samples = min(RESTIR_SPACIAL_SAMPLES, int(global_ubo.pt_restir_spatial) * 2);
+		uint sp_samples = uint(global_ubo.pt_restir_spatial);
+
+		//Extra sampling when temporal failed
+		if(prev_r.y == RESTIR_INVALID_ID) sp_samples += 2;
+
+		int samples = min(RESTIR_SPACIAL_SAMPLES, int(sp_samples) * 2);
 		ivec2 pos;
 		#pragma unroll
 		for(int i=0; i < samples ; i++)
@@ -215,26 +216,25 @@ direct_lighting_restir(ivec2 ipos, bool is_odd_checkerboard, out vec3 high_freq,
 
 			rng_pos = rng_pos * 10 - floor(rng_pos * 10);
 
-			sample_pos.x = clamp(pos_prev.x + pos.x, field_left, field_right - 1);
-			sample_pos.y = clamp(pos_prev.y + pos.y, 0, int(global_ubo.height - 1));
+			sample_pos.x = clamp(pos_prev_or.x + pos.x, field_left, field_right - 1);
+			sample_pos.y = clamp(pos_prev_or.y + pos.y, 0, int(global_ubo.height - 1));
 			ivec2 sample_pos_r = sample_pos;
 
 			if(global_ubo.pt_restir == 2)
 			{
 				sample_pos.x = min((sample_pos.x & ~1) + (sample_pos.y & 1), field_right - 1);
 				sample_pos_r = sample_pos;
-				sample_pos_r.y >>= 1;
 			}
 			else if(global_ubo.pt_restir == 3)
 			{
 				sample_pos &= ~1;
-				sample_pos_r >>= 1;
 			}
 
-			uint str_idx = texelFetch(TEX_PT_RESTIR_ID_B, sample_pos_r, 0).x;
-			str_idx = get_light_current_idx(str_idx);
+			uvec4 packed_reservoir = texelFetch(TEX_PT_RESTIR_B, sample_pos, 0);
+			unpack_reservoir(packed_reservoir, st_r);
+			st_r.y = get_light_current_idx(st_r.y);
 
-			if(str_idx == RESTIR_INVALID_ID) continue;
+			if(st_r.y == RESTIR_INVALID_ID || st_r.M == 0) continue;
 
 			float depth_prev = texelFetch(TEX_PT_VIEW_DEPTH_B, sample_pos, 0).x;
 			float dist_depth = abs(depth_prev - view_depth) / abs(view_depth);
@@ -255,49 +255,38 @@ direct_lighting_restir(ivec2 ipos, bool is_odd_checkerboard, out vec3 high_freq,
 					dot_normals = 1.0f;
 				}
 
-				if(dot_normals > 0.9)
+				if(dot_normals > 0.5)
 				{
-					uvec4 packed_reservoir = texelFetch(TEX_PT_RESTIR_B, sample_pos_r, 0);
-					unpack_reservoir(packed_reservoir, str_idx, st_r);
 
 					float p_hat = get_unshadowed_path_contrib(st_r.y, position, normal, view_direction.xyz, phong_exp, phong_scale, phong_weight, st_r.y_pos);
-					if(p_hat <= 0.0) {
+					if(p_hat < min_p_hat) {
 						continue;
 					}
 
 					//Combine reservoirs
-					update_reservoir(st_r.y, p_hat * st_r.W * st_r.M, st_r.y_pos, p_hat, rng, spatial_r);
-					spatial_r.M += st_r.M - 1;
+					update_reservoir(st_r.y, p_hat * st_r.W * st_r.M, st_r.y_pos, st_r.M, p_hat, rng, spatial_r);
 					processed ++;
-					if(global_ubo.pt_restir_spatial == processed) break;
+					if(sp_samples == processed) break;
 				}
 			}
 
 		}
 
-		if(spatial_r.w_sum != 0)
+		if(processed > 0)
 		{
 			//Combine with the other reservoir
-			if(r.W != 0)
-			{
-				update_reservoir(spatial_r.y, spatial_r.w_sum, spatial_r.y_pos, spatial_r.p_hat, rng, r);
-				r.M += spatial_r.M - 1;
-				r.W = r.w_sum / (r.p_hat * r.M);
-			}
-			else
-			{
-				spatial_r.W = (spatial_r.w_sum ) / (spatial_r.p_hat * spatial_r.M);
-				r = spatial_r;
-			}
+			update_reservoir(spatial_r.y, spatial_r.w_sum, spatial_r.y_pos, spatial_r.M, spatial_r.p_hat, rng, r);
+			r.W = r.w_sum / (r.p_hat * r.M);
+			if(isnan(r.W) || isinf(r.W)) r.W = 0.0;
 		}
 	}
 
-	if(r.W != 0.0f)
+	if(r.y != RESTIR_INVALID_ID)
 	{
 		process_selected_light_restir(
 			r.y,
 			r.y_pos,
-			r.W,
+			min(r.W, global_ubo.pt_restir_max_w),
 			position,
 			normal,
 			geo_normal,
@@ -312,17 +301,16 @@ direct_lighting_restir(ivec2 ipos, bool is_odd_checkerboard, out vec3 high_freq,
 			phong_exp,
 			phong_scale,
 			phong_weight,
-			use_shadow_rays,
+			use_shadow_rays && r.W > 0.0,
 			cluster_idx,
 			direct_diffuse,
 			direct_specular,
 			vis);
 
-
 		high_freq += direct_diffuse;
 		o_specular += direct_specular;
-		if(vis == 0.0f) r.W = 0.0f;
 
+		if(vis == 0.0f) r.W = 0.0f;
 	}
 
 	//Normalize reservoir
@@ -334,11 +322,8 @@ direct_lighting_restir(ivec2 ipos, bool is_odd_checkerboard, out vec3 high_freq,
 	high_freq = clamp_output(high_freq);
 	o_specular = clamp_output(o_specular);
 
-	if(use_shadow_rays)
-	{
-		imageStore(IMG_PT_RESTIR_ID_A, ipos_r, uvec4(r.W == 0.0f ? RESTIR_INVALID_ID : r.y));
-		imageStore(IMG_PT_RESTIR_A, ipos_r, uvec4(pack_reservoir(r)));
-	}
+	imageStore(IMG_PT_RESTIR_A, ipos, uvec4(pack_reservoir(r)));
+
 }
 
 

--- a/src/refresh/vkpt/shader/direct_lighting.rgen
+++ b/src/refresh/vkpt/shader/direct_lighting.rgen
@@ -131,31 +131,22 @@ direct_lighting_restir(ivec2 ipos, bool is_odd_checkerboard, out vec3 high_freq,
 
 	if (!(pos_prev.x < field_left || pos_prev.x >= field_right || pos_prev.y < 0 || pos_prev.y >= global_ubo.height))
 	{
-		uvec4 packed_reservoir = texelFetch(TEX_PT_RESTIR_B, pos_prev, 0);
-		unpack_reservoir(packed_reservoir, prev_r);
-		prev_r.y = get_light_current_idx(prev_r.y);
+		float depth_prev = texelFetch(TEX_PT_VIEW_DEPTH_B, pos_prev, 0).x;
+		float dist_depth = abs(depth_prev - view_depth) / abs(view_depth);
 
-		if(prev_r.y != RESTIR_INVALID_ID)
+		if(dist_depth < 0.1)
 		{
-			float depth_prev = texelFetch(TEX_PT_VIEW_DEPTH_B, pos_prev, 0).x;
-			float dist_depth = abs(depth_prev - view_depth) / abs(view_depth);
+			vec3 normal_prev;
+			float dot_normals;
+			normal_prev = decode_normal(texelFetch(TEX_PT_NORMAL_B, pos_prev, 0).x);
+			dot_normals = dot(normal_prev, normal);
 
-			if(dist_depth < 0.1)
+			if(dot_normals > 0.5)
 			{
-
-				vec3 normal_prev;
-				float dot_normals;
-
-				if(use_shadow_rays)
-				{
-					normal_prev = decode_normal(texelFetch(TEX_PT_NORMAL_B, pos_prev, 0).x);
-					dot_normals = dot(normal_prev, normal);
-				}
-				else
-				{
-					dot_normals = 1.0f;
-				}
-				if(dot_normals > 0.5)
+				uvec4 packed_reservoir = texelFetch(TEX_PT_RESTIR_B, pos_prev, 0);
+				unpack_reservoir(packed_reservoir, prev_r);
+				prev_r.y = get_light_current_idx(prev_r.y);
+				if(prev_r.y != RESTIR_INVALID_ID && use_shadow_rays)
 				{
 					prev_r.p_hat = get_unshadowed_path_contrib(prev_r.y, position, normal, view_direction.xyz, phong_exp, phong_scale, phong_weight, prev_r.y_pos);
 				}

--- a/src/refresh/vkpt/shader/direct_lighting.rgen
+++ b/src/refresh/vkpt/shader/direct_lighting.rgen
@@ -1,6 +1,7 @@
 /*
 Copyright (C) 2018 Christoph Schied
 Copyright (C) 2019, NVIDIA CORPORATION. All rights reserved.
+Copyright (C) 2022 Jorge Gustavo Martinez
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -30,10 +31,316 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #pragma optionNV(unroll all)
 
 #define ENABLE_SHADOW_CAUSTICS
-#include "path_tracer_rgen.h"
+#include "restir.h"
 #include "projection.glsl"
 
 layout(constant_id = 0) const uint spec_enable_caustics = 0;
+
+
+void
+direct_lighting_restir(ivec2 ipos, bool is_odd_checkerboard, out vec3 high_freq, out vec3 o_specular)
+{
+	high_freq = vec3(0);
+	o_specular = vec3(0);
+
+	rng_seed = texelFetch(TEX_ASVGF_RNG_SEED_A, ipos, 0).r;
+
+	vec3 direct_diffuse, direct_specular;
+	float vis;
+
+	Reservoir r, prev_r, spatial_r;
+	prev_r.W = 0;
+
+	vec4 position_material = texelFetch(TEX_PT_SHADING_POSITION, ipos, 0);
+
+	vec3 position   = position_material.xyz;
+	uint material_id = floatBitsToUint(position_material.w);
+
+	// don't compute lighting for invalid surfaces
+	if(material_id == 0)
+	{
+		imageStore(IMG_PT_RESTIR_ID_A, ipos, uvec4(RESTIR_INVALID_ID));
+		return;
+	}
+
+	vec4 view_direction = texelFetch(TEX_PT_VIEW_DIRECTION, ipos, 0);
+	vec3 normal = decode_normal(texelFetch(TEX_PT_NORMAL_A, ipos, 0).x);
+	vec3 geo_normal = decode_normal(texelFetch(TEX_PT_GEO_NORMAL_A, ipos, 0).x);
+	vec4 primary_base_color = texelFetch(TEX_PT_BASE_COLOR_A, ipos, 0);
+	float primary_specular_factor = primary_base_color.a;
+	vec2 metal_rough = texelFetch(TEX_PT_METALLIC_A, ipos, 0).xy;
+	float primary_metallic = metal_rough.x;
+	float primary_roughness = metal_rough.y;
+	uint cluster_idx = texelFetch(TEX_PT_CLUSTER_A, ipos, 0).x;
+	if(cluster_idx == 0xffff) cluster_idx = ~0u; // because the image is uint16
+	float view_depth =  texelFetch(TEX_PT_VIEW_DEPTH_A, ipos, 0).x;
+	vec4 motion = texelFetch(TEX_PT_MOTION, ipos, 0);
+
+	bool primary_is_weapon = (material_id & MATERIAL_FLAG_WEAPON) != 0;
+	int primary_medium = int((material_id & MATERIAL_LIGHT_STYLE_MASK) >> MATERIAL_LIGHT_STYLE_SHIFT);
+
+	bool use_shadow_rays = true;
+	ivec2 ipos_r = ipos;
+	
+	if(global_ubo.pt_restir == 2)
+	{
+		ipos_r.y >>= 1;
+		use_shadow_rays = (ipos.x & 1) == (ipos.y & 1);
+	}
+	else if(global_ubo.pt_restir == 3)
+	{
+		ipos_r >>= 1;
+		use_shadow_rays = (ipos.x & 1) == 0 && (ipos.y & 1) == 0;
+	}
+
+	int shadow_cull_mask = SHADOW_RAY_CULL_MASK;
+
+	if(global_ubo.first_person_model != 0 && !primary_is_weapon)
+		shadow_cull_mask |= AS_FLAG_VIEWER_MODELS;
+	else
+		shadow_cull_mask |= AS_FLAG_VIEWER_WEAPON;
+
+	float direct_specular_weight = smoothstep(
+		global_ubo.pt_direct_roughness_threshold - 0.02,
+		global_ubo.pt_direct_roughness_threshold + 0.02,
+		primary_roughness);
+
+	vec3 primary_albedo, primary_base_reflectivity;
+	get_reflectivity(primary_base_color.rgb, primary_metallic, primary_albedo, primary_base_reflectivity);
+
+	float alpha = square(primary_roughness);
+	float phong_exp = RoughnessSquareToSpecPower(alpha);
+	float phong_scale = min(100, 1 / (M_PI * square(alpha)));
+	float phong_weight = clamp(primary_specular_factor * luminance(primary_base_reflectivity) / (luminance(primary_base_reflectivity) + luminance(primary_albedo)), 0, 0.9);
+
+	int field_left = 0;
+	int field_right = global_ubo.prev_width / 2;
+	if(ipos.x >= global_ubo.width / 2)
+	{
+		field_left = field_right;
+		field_right = global_ubo.prev_width;
+	}
+
+	//Do temporal
+	ivec2 pos_prev = ivec2(((vec2(ipos) + vec2(0.5)) * vec2(global_ubo.inv_width * 2, global_ubo.inv_height) + motion.xy) * vec2(global_ubo.prev_width * 0.5, global_ubo.prev_height));
+	ivec2 pos_prev_r = pos_prev;
+
+	if(global_ubo.pt_restir == 2)
+	{
+		pos_prev.x = (pos_prev.x & ~1) + (pos_prev.y & 1);
+		pos_prev_r = pos_prev;
+		pos_prev_r.y >>= 1;
+	}
+	else if(global_ubo.pt_restir == 3)
+	{
+		pos_prev &= ~1;
+		pos_prev_r >>= 1;
+	}
+
+	if (!(pos_prev.x < field_left || pos_prev.x >= field_right || pos_prev.y < 0 || pos_prev.y >= global_ubo.height))
+	{
+		uint prev_idx = texelFetch(TEX_PT_RESTIR_ID_B, pos_prev_r, 0).x;
+
+		prev_idx = get_light_current_idx(prev_idx);
+
+		if(prev_idx != RESTIR_INVALID_ID)
+		{
+			float depth_prev = texelFetch(TEX_PT_VIEW_DEPTH_B, pos_prev, 0).x;
+			float dist_depth = abs(depth_prev - view_depth) / abs(view_depth);
+
+			if(dist_depth < 0.1)
+			{
+
+				vec3 normal_prev;
+				float dot_normals;
+
+				if(use_shadow_rays)
+				{
+					normal_prev = decode_normal(texelFetch(TEX_PT_NORMAL_B, pos_prev, 0).x);
+					dot_normals = dot(normal_prev, normal);
+				}
+				else
+				{
+					dot_normals = 1.0f;
+				}
+				if(dot_normals > 0.9)
+				{
+					uvec4 packed_reservoir = texelFetch(TEX_PT_RESTIR_B, pos_prev_r, 0);
+					unpack_reservoir(packed_reservoir, prev_idx, prev_r);
+					prev_r.p_hat = get_unshadowed_path_contrib(prev_r.y, position, normal, view_direction.xyz, phong_exp, phong_scale, phong_weight, prev_r.y_pos);
+				}
+			}
+		}
+	}
+
+	//Sample lights
+	if(use_shadow_rays)
+	{
+		get_direct_illumination_restir(
+			position,
+			normal,
+			cluster_idx,
+			view_direction.xyz,
+			phong_exp,
+			phong_scale,
+			phong_weight,
+			0,
+			prev_r,
+			r);
+	}
+	else
+	{
+		r = prev_r;
+	}
+
+	//Spatio-temporal
+	if(global_ubo.pt_restir_spatial != 0)
+	{
+		float rng = get_rng(RNG_RESTIR_SP_LIGHT_SELECTION(0));
+		uint processed = 0;
+		ivec2 sample_pos;
+		Reservoir st_r;
+		init_reservoir(spatial_r);
+
+		vec2 rng_pos = vec2(get_rng(RNG_RESTIR_SPATIAL_X(0)), get_rng(RNG_RESTIR_SPATIAL_Y(0)));
+		int distance = use_shadow_rays ? RESTIR_SPACIAL_DISTANCE : 2;
+		int samples = min(RESTIR_SPACIAL_SAMPLES, int(global_ubo.pt_restir_spatial) * 2);
+		ivec2 pos;
+		#pragma unroll
+		for(int i=0; i < samples ; i++)
+		{
+			pos = ivec2(ceil(sample_disk(rng_pos) * distance));
+
+			if(i == 4) distance *= 2;
+
+			rng_pos = rng_pos * 10 - floor(rng_pos * 10);
+
+			sample_pos.x = clamp(pos_prev.x + pos.x, field_left, field_right - 1);
+			sample_pos.y = clamp(pos_prev.y + pos.y, 0, int(global_ubo.height - 1));
+			ivec2 sample_pos_r = sample_pos;
+
+			if(global_ubo.pt_restir == 2)
+			{
+				sample_pos.x = min((sample_pos.x & ~1) + (sample_pos.y & 1), field_right - 1);
+				sample_pos_r = sample_pos;
+				sample_pos_r.y >>= 1;
+			}
+			else if(global_ubo.pt_restir == 3)
+			{
+				sample_pos &= ~1;
+				sample_pos_r >>= 1;
+			}
+
+			uint str_idx = texelFetch(TEX_PT_RESTIR_ID_B, sample_pos_r, 0).x;
+			str_idx = get_light_current_idx(str_idx);
+
+			if(str_idx == RESTIR_INVALID_ID) continue;
+
+			float depth_prev = texelFetch(TEX_PT_VIEW_DEPTH_B, sample_pos, 0).x;
+			float dist_depth = abs(depth_prev - view_depth) / abs(view_depth);
+
+			if(dist_depth < 0.1)
+			{
+
+				vec3 normal_prev;
+				float dot_normals;
+
+				if(use_shadow_rays)
+				{
+					normal_prev = decode_normal(texelFetch(TEX_PT_NORMAL_B, sample_pos, 0).x);
+					dot_normals = dot(normal_prev, normal);
+				}
+				else
+				{
+					dot_normals = 1.0f;
+				}
+
+				if(dot_normals > 0.9)
+				{
+					uvec4 packed_reservoir = texelFetch(TEX_PT_RESTIR_B, sample_pos_r, 0);
+					unpack_reservoir(packed_reservoir, str_idx, st_r);
+
+					float p_hat = get_unshadowed_path_contrib(st_r.y, position, normal, view_direction.xyz, phong_exp, phong_scale, phong_weight, st_r.y_pos);
+					if(p_hat <= 0.0) {
+						continue;
+					}
+
+					//Combine reservoirs
+					update_reservoir(st_r.y, p_hat * st_r.W * st_r.M, st_r.y_pos, p_hat, rng, spatial_r);
+					spatial_r.M += st_r.M - 1;
+					processed ++;
+					if(global_ubo.pt_restir_spatial == processed) break;
+				}
+			}
+
+		}
+
+		if(spatial_r.w_sum != 0)
+		{
+			//Combine with the other reservoir
+			if(r.W != 0)
+			{
+				update_reservoir(spatial_r.y, spatial_r.w_sum, spatial_r.y_pos, spatial_r.p_hat, rng, r);
+				r.M += spatial_r.M - 1;
+				r.W = r.w_sum / (r.p_hat * r.M);
+			}
+			else
+			{
+				spatial_r.W = (spatial_r.w_sum ) / (spatial_r.p_hat * spatial_r.M);
+				r = spatial_r;
+			}
+		}
+	}
+
+	if(r.W != 0.0f)
+	{
+		process_selected_light_restir(
+			r.y,
+			r.y_pos,
+			r.W,
+			position,
+			normal,
+			geo_normal,
+			shadow_cull_mask,
+			view_direction.xyz,
+			primary_base_reflectivity,
+			primary_specular_factor,
+			primary_roughness,
+			primary_medium,
+			spec_enable_caustics != 0,
+			direct_specular_weight,
+			phong_exp,
+			phong_scale,
+			phong_weight,
+			use_shadow_rays,
+			cluster_idx,
+			direct_diffuse,
+			direct_specular,
+			vis);
+
+
+		high_freq += direct_diffuse;
+		o_specular += direct_specular;
+		if(vis == 0.0f) r.W = 0.0f;
+
+	}
+
+	//Normalize reservoir
+	float m_clamp = global_ubo.pt_restir != 3 ? float(RESTIR_M_CLAMP) : float(RESTIR_M_VC_CLAMP);
+	r.w_sum = (m_clamp * r.w_sum) / r.M;
+
+	o_specular = demodulate_specular(primary_base_reflectivity, o_specular);
+
+	high_freq = clamp_output(high_freq);
+	o_specular = clamp_output(o_specular);
+
+	if(use_shadow_rays)
+	{
+		imageStore(IMG_PT_RESTIR_ID_A, ipos_r, uvec4(r.W == 0.0f ? RESTIR_INVALID_ID : r.y));
+		imageStore(IMG_PT_RESTIR_A, ipos_r, uvec4(pack_reservoir(r)));
+	}
+}
+
 
 void
 direct_lighting(ivec2 ipos, bool is_odd_checkerboard, out vec3 high_freq, out vec3 o_specular)
@@ -45,7 +352,7 @@ direct_lighting(ivec2 ipos, bool is_odd_checkerboard, out vec3 high_freq, out ve
 
 
 	vec4 position_material = texelFetch(TEX_PT_SHADING_POSITION, ipos, 0);
-	
+
 	vec3 position   = position_material.xyz;
 	uint material_id = floatBitsToUint(position_material.w);
 
@@ -55,11 +362,11 @@ direct_lighting(ivec2 ipos, bool is_odd_checkerboard, out vec3 high_freq, out ve
 
 	vec4 view_direction = texelFetch(TEX_PT_VIEW_DIRECTION, ipos, 0);
 	vec3 normal = decode_normal(texelFetch(TEX_PT_NORMAL_A, ipos, 0).x);
-    vec3 geo_normal = decode_normal(texelFetch(TEX_PT_GEO_NORMAL_A, ipos, 0).x);
-    vec4 primary_base_color = texelFetch(TEX_PT_BASE_COLOR_A, ipos, 0);
-    float primary_specular_factor = primary_base_color.a;
-    vec2 metal_rough = texelFetch(TEX_PT_METALLIC_A, ipos, 0).xy;
-    float primary_metallic = metal_rough.x;
+	vec3 geo_normal = decode_normal(texelFetch(TEX_PT_GEO_NORMAL_A, ipos, 0).x);
+	vec4 primary_base_color = texelFetch(TEX_PT_BASE_COLOR_A, ipos, 0);
+	float primary_specular_factor = primary_base_color.a;
+	vec2 metal_rough = texelFetch(TEX_PT_METALLIC_A, ipos, 0).xy;
+	float primary_metallic = metal_rough.x;
 	float primary_roughness = metal_rough.y;
 	uint cluster_idx = texelFetch(TEX_PT_CLUSTER_A, ipos, 0).x;
 	if(cluster_idx == 0xffff) cluster_idx = ~0u; // because the image is uint16
@@ -81,35 +388,35 @@ direct_lighting(ivec2 ipos, bool is_odd_checkerboard, out vec3 high_freq, out ve
 
 	bool is_gradient = get_is_gradient(ipos);
 
-    vec3 primary_albedo, primary_base_reflectivity;
-    get_reflectivity(primary_base_color.rgb, primary_metallic, primary_albedo, primary_base_reflectivity);
+	vec3 primary_albedo, primary_base_reflectivity;
+	get_reflectivity(primary_base_color.rgb, primary_metallic, primary_albedo, primary_base_reflectivity);
 
 	vec3 direct_diffuse, direct_specular;
-    get_direct_illumination(
-    	position, 
-    	normal, 
-    	geo_normal, 
-    	cluster_idx, 
-    	material_id, 
-    	shadow_cull_mask, 
-    	view_direction.xyz, 
-    	primary_albedo,
-    	primary_base_reflectivity,
-    	primary_specular_factor,
-    	primary_roughness, 
-    	primary_medium, 
-    	spec_enable_caustics != 0, 
-    	direct_specular_weight, 
-    	global_ubo.pt_direct_polygon_lights > 0,
-    	global_ubo.pt_direct_dyn_lights > 0,
-    	is_gradient,
-    	0,
-    	direct_diffuse,
-    	direct_specular);
+	get_direct_illumination(
+		position,
+		normal,
+		geo_normal,
+		cluster_idx,
+		material_id,
+		shadow_cull_mask,
+		view_direction.xyz,
+		primary_albedo,
+		primary_base_reflectivity,
+		primary_specular_factor,
+		primary_roughness,
+		primary_medium,
+		spec_enable_caustics != 0,
+		direct_specular_weight,
+		global_ubo.pt_direct_polygon_lights > 0,
+		global_ubo.pt_direct_dyn_lights > 0,
+		is_gradient,
+		0,
+		direct_diffuse,
+		direct_specular);
 
-    high_freq += direct_diffuse;
-    o_specular += direct_specular;
-	
+	high_freq += direct_diffuse;
+	o_specular += direct_specular;
+
 	if(global_ubo.pt_direct_sun_light != 0)
 	{
 		vec3 direct_sun_diffuse, direct_sun_specular;
@@ -149,7 +456,10 @@ main()
 	bool is_odd_checkerboard = (rt_LaunchID.z != 0) || (push_constants.gpu_index == 1);
 
 	vec3 high_freq, specular;
-	direct_lighting(ipos, is_odd_checkerboard, high_freq, specular);
+	if(global_ubo.pt_restir > 0)
+		direct_lighting_restir(ipos, is_odd_checkerboard, high_freq, specular);
+	else
+		direct_lighting(ipos, is_odd_checkerboard, high_freq, specular);
 
 	high_freq *= STORAGE_SCALE_HF;
 	specular *= STORAGE_SCALE_SPEC;

--- a/src/refresh/vkpt/shader/global_textures.h
+++ b/src/refresh/vkpt/shader/global_textures.h
@@ -109,6 +109,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	IMG_DO(ASVGF_HIST_COLOR_LF_COCG_B,NUM_IMAGES_BASE + 27, R16G16_SFLOAT,       rg16f,   IMG_WIDTH_MGPU,      IMG_HEIGHT     ) \
 	IMG_DO(ASVGF_GRAD_SMPL_POS_A,     NUM_IMAGES_BASE + 28, R32_UINT,            r32ui,   IMG_WIDTH_GRAD_MGPU, IMG_HEIGHT_GRAD) \
 	IMG_DO(ASVGF_GRAD_SMPL_POS_B,     NUM_IMAGES_BASE + 29, R32_UINT,            r32ui,   IMG_WIDTH_GRAD_MGPU, IMG_HEIGHT_GRAD) \
+	IMG_DO(PT_RESTIR_ID_A,            NUM_IMAGES_BASE + 30, R16_UINT,            r16ui,   IMG_WIDTH_MGPU,      IMG_HEIGHT     ) \
+	IMG_DO(PT_RESTIR_ID_B,            NUM_IMAGES_BASE + 31, R16_UINT,            r16ui,   IMG_WIDTH_MGPU,      IMG_HEIGHT     ) \
+	IMG_DO(PT_RESTIR_A,               NUM_IMAGES_BASE + 32, R32G32_UINT,         rg32ui,  IMG_WIDTH_MGPU,      IMG_HEIGHT     ) \
+	IMG_DO(PT_RESTIR_B,               NUM_IMAGES_BASE + 33, R32G32_UINT,         rg32ui,  IMG_WIDTH_MGPU,      IMG_HEIGHT     ) \
 
 #define LIST_IMAGES_B_A \
 	IMG_DO(PT_VISBUF_PRIM_B,          NUM_IMAGES_BASE + 0,  R32G32_UINT,         rg32ui,  IMG_WIDTH_MGPU,      IMG_HEIGHT     ) \
@@ -141,8 +145,12 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	IMG_DO(ASVGF_HIST_COLOR_LF_COCG_A,NUM_IMAGES_BASE + 27, R16G16_SFLOAT,       rg16f,   IMG_WIDTH_MGPU,      IMG_HEIGHT     ) \
 	IMG_DO(ASVGF_GRAD_SMPL_POS_B,     NUM_IMAGES_BASE + 28, R32_UINT,            r32ui,   IMG_WIDTH_GRAD_MGPU, IMG_HEIGHT_GRAD) \
 	IMG_DO(ASVGF_GRAD_SMPL_POS_A,     NUM_IMAGES_BASE + 29, R32_UINT,            r32ui,   IMG_WIDTH_GRAD_MGPU, IMG_HEIGHT_GRAD) \
+	IMG_DO(PT_RESTIR_ID_B,            NUM_IMAGES_BASE + 30, R16_UINT,            r16ui,   IMG_WIDTH_MGPU,      IMG_HEIGHT     ) \
+	IMG_DO(PT_RESTIR_ID_A,            NUM_IMAGES_BASE + 31, R16_UINT,            r16ui,   IMG_WIDTH_MGPU,      IMG_HEIGHT     ) \
+	IMG_DO(PT_RESTIR_B,               NUM_IMAGES_BASE + 32, R32G32_UINT,         rg32ui,  IMG_WIDTH_MGPU,      IMG_HEIGHT     ) \
+	IMG_DO(PT_RESTIR_A,               NUM_IMAGES_BASE + 33, R32G32_UINT,         rg32ui,  IMG_WIDTH_MGPU,      IMG_HEIGHT     ) \
 
-#define NUM_IMAGES (NUM_IMAGES_BASE + 30) /* this really sucks but I don't know how to fix it
+#define NUM_IMAGES (NUM_IMAGES_BASE + 34) /* this really sucks but I don't know how to fix it
                                              counting with enum does not work in GLSL */
 
 // todo: make naming consistent!

--- a/src/refresh/vkpt/shader/global_textures.h
+++ b/src/refresh/vkpt/shader/global_textures.h
@@ -109,10 +109,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	IMG_DO(ASVGF_HIST_COLOR_LF_COCG_B,NUM_IMAGES_BASE + 27, R16G16_SFLOAT,       rg16f,   IMG_WIDTH_MGPU,      IMG_HEIGHT     ) \
 	IMG_DO(ASVGF_GRAD_SMPL_POS_A,     NUM_IMAGES_BASE + 28, R32_UINT,            r32ui,   IMG_WIDTH_GRAD_MGPU, IMG_HEIGHT_GRAD) \
 	IMG_DO(ASVGF_GRAD_SMPL_POS_B,     NUM_IMAGES_BASE + 29, R32_UINT,            r32ui,   IMG_WIDTH_GRAD_MGPU, IMG_HEIGHT_GRAD) \
-	IMG_DO(PT_RESTIR_ID_A,            NUM_IMAGES_BASE + 30, R16_UINT,            r16ui,   IMG_WIDTH_MGPU,      IMG_HEIGHT     ) \
-	IMG_DO(PT_RESTIR_ID_B,            NUM_IMAGES_BASE + 31, R16_UINT,            r16ui,   IMG_WIDTH_MGPU,      IMG_HEIGHT     ) \
-	IMG_DO(PT_RESTIR_A,               NUM_IMAGES_BASE + 32, R32G32_UINT,         rg32ui,  IMG_WIDTH_MGPU,      IMG_HEIGHT     ) \
-	IMG_DO(PT_RESTIR_B,               NUM_IMAGES_BASE + 33, R32G32_UINT,         rg32ui,  IMG_WIDTH_MGPU,      IMG_HEIGHT     ) \
+	IMG_DO(PT_RESTIR_A,               NUM_IMAGES_BASE + 30, R32G32_UINT,         rg32ui,  IMG_WIDTH_MGPU,      IMG_HEIGHT     ) \
+	IMG_DO(PT_RESTIR_B,               NUM_IMAGES_BASE + 31, R32G32_UINT,         rg32ui,  IMG_WIDTH_MGPU,      IMG_HEIGHT     ) \
 
 #define LIST_IMAGES_B_A \
 	IMG_DO(PT_VISBUF_PRIM_B,          NUM_IMAGES_BASE + 0,  R32G32_UINT,         rg32ui,  IMG_WIDTH_MGPU,      IMG_HEIGHT     ) \
@@ -145,12 +143,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	IMG_DO(ASVGF_HIST_COLOR_LF_COCG_A,NUM_IMAGES_BASE + 27, R16G16_SFLOAT,       rg16f,   IMG_WIDTH_MGPU,      IMG_HEIGHT     ) \
 	IMG_DO(ASVGF_GRAD_SMPL_POS_B,     NUM_IMAGES_BASE + 28, R32_UINT,            r32ui,   IMG_WIDTH_GRAD_MGPU, IMG_HEIGHT_GRAD) \
 	IMG_DO(ASVGF_GRAD_SMPL_POS_A,     NUM_IMAGES_BASE + 29, R32_UINT,            r32ui,   IMG_WIDTH_GRAD_MGPU, IMG_HEIGHT_GRAD) \
-	IMG_DO(PT_RESTIR_ID_B,            NUM_IMAGES_BASE + 30, R16_UINT,            r16ui,   IMG_WIDTH_MGPU,      IMG_HEIGHT     ) \
-	IMG_DO(PT_RESTIR_ID_A,            NUM_IMAGES_BASE + 31, R16_UINT,            r16ui,   IMG_WIDTH_MGPU,      IMG_HEIGHT     ) \
-	IMG_DO(PT_RESTIR_B,               NUM_IMAGES_BASE + 32, R32G32_UINT,         rg32ui,  IMG_WIDTH_MGPU,      IMG_HEIGHT     ) \
-	IMG_DO(PT_RESTIR_A,               NUM_IMAGES_BASE + 33, R32G32_UINT,         rg32ui,  IMG_WIDTH_MGPU,      IMG_HEIGHT     ) \
+	IMG_DO(PT_RESTIR_B,               NUM_IMAGES_BASE + 30, R32G32_UINT,         rg32ui,  IMG_WIDTH_MGPU,      IMG_HEIGHT     ) \
+	IMG_DO(PT_RESTIR_A,               NUM_IMAGES_BASE + 31, R32G32_UINT,         rg32ui,  IMG_WIDTH_MGPU,      IMG_HEIGHT     ) \
 
-#define NUM_IMAGES (NUM_IMAGES_BASE + 34) /* this really sucks but I don't know how to fix it
+#define NUM_IMAGES (NUM_IMAGES_BASE + 32) /* this really sucks but I don't know how to fix it
                                              counting with enum does not work in GLSL */
 
 // todo: make naming consistent!

--- a/src/refresh/vkpt/shader/global_ubo.h
+++ b/src/refresh/vkpt/shader/global_ubo.h
@@ -162,7 +162,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	GLOBAL_UBO_VAR_LIST_DO(int,             planet_albedo_map) \
 	GLOBAL_UBO_VAR_LIST_DO(int,             planet_normal_map) \
 	\
-	GLOBAL_UBO_VAR_LIST_DO(int,             num_dyn_lights) \
+	GLOBAL_UBO_VAR_LIST_DO(int,             padding1) \
 	GLOBAL_UBO_VAR_LIST_DO(int ,            num_static_lights) \
 	GLOBAL_UBO_VAR_LIST_DO(uint,            num_static_primitives) \
 	GLOBAL_UBO_VAR_LIST_DO(int,             cluster_debug_index) \

--- a/src/refresh/vkpt/shader/global_ubo.h
+++ b/src/refresh/vkpt/shader/global_ubo.h
@@ -219,7 +219,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	GLOBAL_UBO_VAR_LIST_DO(vec4,            world_size) \
 	GLOBAL_UBO_VAR_LIST_DO(vec4,            world_half_size_inv) \
 	\
-	GLOBAL_UBO_VAR_LIST_DO(DynLightData,    dyn_light_data[MAX_LIGHT_SOURCES]) \
 	GLOBAL_UBO_VAR_LIST_DO(vec4,            cam_pos) \
 	GLOBAL_UBO_VAR_LIST_DO(mat4,            V) \
 	GLOBAL_UBO_VAR_LIST_DO(mat4,            invV) \
@@ -237,21 +236,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	GLOBAL_UBO_VAR_LIST_DO(float,           ui_color_scale) \
 	\
 	UBO_CVAR_LIST // WARNING: Do not put any other members into global_ubo after this: the CVAR list is not vec4-aligned
-
-BEGIN_SHADER_STRUCT( DynLightData )
-{
-	vec3 center;
-	float radius;
-	vec3 color;
-	uint type; // Combines type (sphere vs spot) and "style" of light (eg spotlight emission profile)
-	vec3 spot_direction;
-	/* spot_data depends on spotlight emssion profile:
-	 * DYNLIGHT_SPOT_EMISSION_PROFILE_FALLOFF -> contains packed2x16 with cosTotalWidth, cosFalloffStart
-	 * DYNLIGHT_SPOT_EMISSION_PROFILE_AXIS_ANGLE_TEXTURE -> contains a half with cosTotalWidth and the texture index
-	 */
-	uint spot_data;
-}
-END_SHADER_STRUCT( DynLightData )
 
 BEGIN_SHADER_STRUCT( ModelInstance )
 {

--- a/src/refresh/vkpt/shader/global_ubo.h
+++ b/src/refresh/vkpt/shader/global_ubo.h
@@ -284,6 +284,7 @@ BEGIN_SHADER_STRUCT( InstanceBuffer )
 	uint            model_current_to_prev    [MAX_MODEL_INSTANCES];
 	uint            model_prev_to_current    [MAX_MODEL_INSTANCES];
 	ModelInstance   model_instances          [MAX_MODEL_INSTANCES];
+	uint            mlight_prev_to_current   [MAX_MODEL_LIGHTS];
 	uint            tlas_instance_prim_offsets[MAX_TLAS_INSTANCES];
 	int             tlas_instance_model_indices[MAX_TLAS_INSTANCES];
 }

--- a/src/refresh/vkpt/shader/global_ubo.h
+++ b/src/refresh/vkpt/shader/global_ubo.h
@@ -92,6 +92,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	UBO_CVAR_DO(pt_particle_softness, 0.7) /* particle softness */ \
 	UBO_CVAR_DO(pt_particle_brightness, 100) /* particle brightness */ \
 	UBO_CVAR_DO(pt_reflect_refract, 2) /* number of reflection or refraction bounces: 0, 1 or 2 */ \
+	UBO_CVAR_DO(pt_restir, 1) /* switch for using RIS or ReSTIR, 0 or 1 */ \
+	UBO_CVAR_DO(pt_restir_spatial, 1) /* ReSTIR spatial samples */ \
+	UBO_CVAR_DO(pt_restir_max_w, 12.0) /* ReSTIR max weight clamp */ \
 	UBO_CVAR_DO(pt_roughness_override, -1) /* overrides roughness of all materials if non-negative, [0..1] */ \
 	UBO_CVAR_DO(pt_specular_anti_flicker, 2) /* fade factor for rough reflections of surfaces far away, [0..inf) */ \
 	UBO_CVAR_DO(pt_specular_mis, 1) /* enables the use of MIS between specular direct lighting and BRDF specular rays */ \

--- a/src/refresh/vkpt/shader/light_lists.h
+++ b/src/refresh/vkpt/shader/light_lists.h
@@ -37,7 +37,7 @@ project_triangle(mat3 positions, vec3 p)
 }
 
 float
-spherical_tri_area(mat3 positions, vec3 p, vec3 n, vec3 V, float phong_exp, float phong_scale, float phong_weight)
+projected_tri_area(mat3 positions, vec3 p, vec3 n, vec3 V, float phong_exp, float phong_scale, float phong_weight)
 {
 	positions[0] = positions[0] - p;
 	positions[1] = positions[1] - p;
@@ -62,6 +62,88 @@ spherical_tri_area(mat3 positions, vec3 p, vec3 n, vec3 V, float phong_exp, floa
 	float area = 2 * atan(abs(dot(A, cross(B, C))), 1 + dot(A, B) + dot(B, C) + dot(A, C));
 	float pa = max(area - 1e-5, 0.);
 	return pa * brdf;
+}
+
+float
+projected_sphere_area(mat3 positions, vec3 p, vec3 n, vec3 V, float phong_exp, float phong_scale, float phong_weight)
+{
+	vec3 position = positions[0] - p;
+	float sphere_radius = positions[1].x;
+	float dist = length(position);
+	float rdist = 1.0 / dist;
+	vec3 L = position * rdist;
+
+	if (dot(n, L) <= 0)
+		return 0.0;
+
+	float specular = phong(n, L, V, phong_exp) * phong_scale;
+	float brdf = mix(1.0, specular, phong_weight);
+
+	float irradiance = 2 * (1 - sqrt(max(0, 1 - square(sphere_radius * rdist))));
+	irradiance = min(irradiance,  2 * M_PI); //max solid angle
+
+	return irradiance * brdf;
+}
+
+float
+spot_falloff(in mat3 positions, in float cosTheta)
+{
+	float falloff;
+	const uint spot_style = floatBitsToUint(positions[1].y);
+	const uint spot_data = floatBitsToUint(positions[1].z);
+
+	if(spot_style == DYNLIGHT_SPOT_EMISSION_PROFILE_FALLOFF) {
+		const vec2 spot_falloff = unpackHalf2x16(spot_data);
+		const float cosTotalWidth = spot_falloff.x;
+		const float cosFalloffStart = spot_falloff.y;
+
+		if(cosTheta < cosTotalWidth)
+			falloff = 0;
+		else if (cosTheta > cosFalloffStart)
+			falloff = 1;
+		else {
+			float delta = (cosTheta - cosTotalWidth) / (cosFalloffStart - cosTotalWidth);
+			falloff = (delta * delta) * (delta * delta);
+		}
+	} else if(spot_style == DYNLIGHT_SPOT_EMISSION_PROFILE_AXIS_ANGLE_TEXTURE) {
+		const float theta = acos(cosTheta);
+		const float totalWidth = unpackHalf2x16(spot_data).x;
+		const uint texture_num = spot_data >> 16;
+
+		if (cosTheta >= 0) {
+			// Use the angle directly as texture coordinate for better angular resolution next to the center of the beam
+			float tc = clamp(theta / totalWidth, 0, 1);
+			falloff = global_texture(texture_num, vec2(tc, 0)).r;
+		} else
+			falloff = 0;
+	}
+
+	return falloff;
+}
+
+float
+projected_spotlight_area(mat3 positions, vec3 p, vec3 n, vec3 V, float phong_exp, float phong_scale, float phong_weight)
+{
+	vec3 position = positions[0] - p;
+
+	float dist = length(position);
+	float rdist = 1.0 / dist;
+	vec3 L = position * rdist;
+
+	if (dot(n, L) <= 0)
+		return 0.0;
+
+	float specular = phong(n, L, V, phong_exp) * phong_scale;
+	float brdf = mix(1.0, specular, phong_weight);
+
+	float cosTheta = dot(-L, positions[2]); // cosine of angle to spot direction
+	float falloff = spot_falloff(positions, cosTheta);
+
+	float irradiance = 2 * falloff * square(rdist);
+
+	irradiance = min(irradiance,  2 * M_PI); //max solid angle
+
+	return irradiance * brdf;
 }
 
 float get_spherical_triangle_pdfw(mat3 positions)
@@ -153,6 +235,62 @@ sample_projected_triangle(vec3 pt, mat3 positions, vec2 rnd, out vec3 light_norm
 	return pt + lo;
 }
 
+vec3
+sample_projected_sphere(vec3 p, mat3 positions, vec2 rnd, out vec3 light_normal, out float pdfw)
+{
+	vec3 light_center = positions[0];
+	vec3 position = light_center - p;
+	float sphere_radius = positions[1].x;
+	float dist = length(position);
+	float rdist = 1.0 / dist;
+	vec3 L = position * rdist;
+
+	float projected_area = 2 * (1 - sqrt(max(0, 1 - square(sphere_radius * rdist))));
+	projected_area = min(projected_area,  2 * M_PI); //max solid angle
+	pdfw = 1.0 / projected_area;
+
+	mat3 onb = construct_ONB_frisvad(L);
+	vec3 diskpt;
+	diskpt.xy = sample_disk(rnd);
+	diskpt.z = sqrt(max(0, 1 - diskpt.x * diskpt.x - diskpt.y * diskpt.y));
+
+	vec3 position_light = light_center + (onb[0] * diskpt.x + onb[2] * diskpt.y - L * diskpt.z) * sphere_radius;
+
+	light_normal = normalize(position_light - light_center);
+
+	return position_light;
+}
+
+vec3
+sample_projected_spotlight(vec3 p, mat3 positions, vec2 rnd, out vec3 light_normal, out float pdfw)
+{
+	vec3 light_center = positions[0];
+	float emitter_radius = positions[1].x;
+
+	mat3 onb = construct_ONB_frisvad(positions[2]);
+	// Emit light from a small disk around the origin
+	vec2 diskpt = sample_disk(rnd);
+	vec3 position_light = light_center + (onb[0] * diskpt.x + onb[2] * diskpt.y) * emitter_radius;
+
+	vec3 c = position_light - p;
+	float dist = length(c);
+	float rdist = 1.0 / dist;
+	vec3 L = c * rdist;
+
+	// Direction from emission point to surface, in a basis where +Y is the spot direction
+	vec3 L_l = -L * onb;
+	float cosTheta = L_l.y; // cosine of angle to spot direction
+	float falloff = spot_falloff(positions, cosTheta);
+
+	float projected_area = 2 * falloff * square(rdist);
+	projected_area = min(projected_area,  2 * M_PI); //max solid angle
+	pdfw = 1.0 / projected_area;
+
+	light_normal = normalize(positions[2]);
+
+	return position_light;
+}
+
 uint get_light_stats_addr(uint cluster, uint light, uint side)
 {
 	uint addr = cluster;
@@ -163,7 +301,7 @@ uint get_light_stats_addr(uint cluster, uint light, uint side)
 }
 
 void
-sample_polygonal_lights(
+sample_lights(
 		uint list_idx,
 		vec3 p,
 		vec3 n,
@@ -232,7 +370,18 @@ sample_polygonal_lights(
 
 		LightPolygon light = get_light_polygon(current_idx);
 
-		float m = spherical_tri_area(light.positions, p, n, V, phong_exp, phong_scale, phong_weight);
+		float m = 0.0f;
+		switch(uint(light.type)){
+			case DYNLIGHT_POLYGON:
+				m = projected_tri_area(light.positions, p, n, V, phong_exp, phong_scale, phong_weight);
+				break;
+			case DYNLIGHT_SPHERE:
+				m = projected_sphere_area(light.positions, p, n, V, phong_exp, phong_scale, phong_weight);
+				break;
+			case DYNLIGHT_SPOT:
+				m = projected_spotlight_area(light.positions, p, n, V, phong_exp, phong_scale, phong_weight);
+				break;
+		}
 
 		float light_lum = luminance(light.color);
 
@@ -315,7 +464,18 @@ sample_polygonal_lights(
 		LightPolygon light = get_light_polygon(current_idx);
 
 		vec3 light_normal;
-		position_light = sample_projected_triangle(p, light.positions, rng.yz, light_normal, pdfw);
+
+		switch(uint(light.type)){
+			case DYNLIGHT_POLYGON:
+				position_light = sample_projected_triangle(p, light.positions, rng.yz, light_normal, pdfw);
+				break;
+			case DYNLIGHT_SPHERE:
+				position_light = sample_projected_sphere(p, light.positions, rng.yz, light_normal, pdfw);
+				break;
+			case DYNLIGHT_SPOT:
+				position_light = sample_projected_spotlight(p, light.positions, rng.yz, light_normal, pdfw);
+				break;
+		}
 
 		vec3 L = normalize(position_light - p);
 
@@ -343,119 +503,6 @@ sample_polygonal_lights(
 	}
 
 	light_color /= pdf;
-}
-
-float
-compute_dynlight_sphere(uint light_idx, vec3 light_center, vec3 p, out vec3 position_light, vec3 rng)
-{
-	vec3 c = light_center - p;
-	float dist = length(c);
-	float rdist = 1.0 / dist;
-	vec3 L = c * rdist;
-
-	float sphere_radius = global_ubo.dyn_light_data[light_idx].radius;
-	float irradiance = 2 * (1 - sqrt(max(0, 1 - square(sphere_radius * rdist))));
-
-	mat3 onb = construct_ONB_frisvad(L);
-	vec3 diskpt;
-	diskpt.xy = sample_disk(rng.yz);
-	diskpt.z = sqrt(max(0, 1 - diskpt.x * diskpt.x - diskpt.y * diskpt.y));
-
-	position_light = light_center + (onb[0] * diskpt.x + onb[2] * diskpt.y - L * diskpt.z) * sphere_radius;
-
-	return irradiance;
-}
-
-float
-compute_dynlight_spot(uint light_idx, uint spot_style, vec3 light_center, vec3 p, out vec3 position_light, vec3 rng)
-{
-	mat3 onb = construct_ONB_frisvad(global_ubo.dyn_light_data[light_idx].spot_direction);
-	// Emit light from a small disk around the origin
-	float emitter_radius = global_ubo.dyn_light_data[light_idx].radius;
-	vec2 diskpt = sample_disk(rng.yz);
-	position_light = light_center + (onb[0] * diskpt.x + onb[2] * diskpt.y) * emitter_radius;
-
-	vec3 c = position_light - p;
-	float dist = length(c);
-	float rdist = 1.0 / dist;
-	vec3 L = c * rdist;
-
-	// Direction from emission point to surface, in a basis where +Y is the spot direction
-	vec3 L_l = -L * onb;
-	float cosTheta = L_l.y; // cosine of angle to spot direction
-	float falloff;
-
-	if(spot_style == DYNLIGHT_SPOT_EMISSION_PROFILE_FALLOFF) {
-		const vec2 spot_falloff = unpackHalf2x16(global_ubo.dyn_light_data[light_idx].spot_data);
-		const float cosTotalWidth = spot_falloff.x;
-		const float cosFalloffStart = spot_falloff.y;
-
-		if(cosTheta < cosTotalWidth)
-			falloff = 0;
-		else if (cosTheta > cosFalloffStart)
-			falloff = 1;
-		else {
-			float delta = (cosTheta - cosTotalWidth) / (cosFalloffStart - cosTotalWidth);
-			falloff = (delta * delta) * (delta * delta);
-		}
-	} else if(spot_style == DYNLIGHT_SPOT_EMISSION_PROFILE_AXIS_ANGLE_TEXTURE) {
-		const uint spot_data = global_ubo.dyn_light_data[light_idx].spot_data;
-		const float theta = acos(cosTheta);
-		const float totalWidth = unpackHalf2x16(spot_data).x;
-		const uint texture_num = spot_data >> 16;
-
-		if (cosTheta >= 0) {
-			// Use the angle directly as texture coordinate for better angular resolution next to the center of the beam
-			float tc = clamp(theta / totalWidth, 0, 1);
-			falloff = global_texture(texture_num, vec2(tc, 0)).r;
-		} else
-			falloff = 0;
-	}
-
-	float irradiance = 2 * falloff * square(rdist);
-
-	return irradiance;
-}
-
-void
-sample_dynamic_lights(
-		vec3 p,
-		vec3 n,
-		vec3 gn,
-		float max_solid_angle,
-		out vec3 position_light,
-		out vec3 light_color,
-		vec3 rng)
-{
-	position_light = vec3(0);
-	light_color = vec3(0);
-
-	if(global_ubo.num_dyn_lights == 0)
-		return;
-
-	float random_light = rng.x * global_ubo.num_dyn_lights;
-	uint light_idx = min(global_ubo.num_dyn_lights - 1, uint(random_light));
-
-	vec3 light_center = global_ubo.dyn_light_data[light_idx].center;
-
-	light_color = global_ubo.dyn_light_data[light_idx].color;
-
-	uint light_type = global_ubo.dyn_light_data[light_idx].type & 0xffff;
-	uint light_style = global_ubo.dyn_light_data[light_idx].type >> 16;
-
-	float irradiance;
-	if(light_type == DYNLIGHT_SPHERE) {
-		irradiance = compute_dynlight_sphere(light_idx, light_center, p, position_light, rng);
-	} else {
-		irradiance = compute_dynlight_spot(light_idx, light_style, light_center, p, position_light, rng);
-	}
-	irradiance = min(irradiance, max_solid_angle);
-	irradiance *= float(global_ubo.num_dyn_lights); // 1 / pdf
-
-	light_color *= irradiance;
-
-	if(dot(position_light - p, gn) <= 0)
-		light_color = vec3(0);
 }
 
 #endif /*_LIGHT_LISTS_*/

--- a/src/refresh/vkpt/shader/light_lists.h
+++ b/src/refresh/vkpt/shader/light_lists.h
@@ -372,13 +372,13 @@ sample_lights(
 
 		float m = 0.0f;
 		switch(uint(light.type)){
-			case DYNLIGHT_POLYGON:
+			case LIGHT_POLYGON:
 				m = projected_tri_area(light.positions, p, n, V, phong_exp, phong_scale, phong_weight);
 				break;
-			case DYNLIGHT_SPHERE:
+			case LIGHT_SPHERE:
 				m = projected_sphere_area(light.positions, p, n, V, phong_exp, phong_scale, phong_weight);
 				break;
-			case DYNLIGHT_SPOT:
+			case LIGHT_SPOT:
 				m = projected_spotlight_area(light.positions, p, n, V, phong_exp, phong_scale, phong_weight);
 				break;
 		}
@@ -466,13 +466,13 @@ sample_lights(
 		vec3 light_normal;
 
 		switch(uint(light.type)){
-			case DYNLIGHT_POLYGON:
+			case LIGHT_POLYGON:
 				position_light = sample_projected_triangle(p, light.positions, rng.yz, light_normal, pdfw);
 				break;
-			case DYNLIGHT_SPHERE:
+			case LIGHT_SPHERE:
 				position_light = sample_projected_sphere(p, light.positions, rng.yz, light_normal, pdfw);
 				break;
-			case DYNLIGHT_SPOT:
+			case LIGHT_SPOT:
 				position_light = sample_projected_spotlight(p, light.positions, rng.yz, light_normal, pdfw);
 				break;
 		}

--- a/src/refresh/vkpt/shader/path_tracer_rgen.h
+++ b/src/refresh/vkpt/shader/path_tracer_rgen.h
@@ -725,6 +725,7 @@ get_direct_illumination(
 		get_rng(RNG_NEE_TRI_X(bounce)),
 		get_rng(RNG_NEE_TRI_Y(bounce)));
 
+	/* polygonal light illumination */
 	if(enable_polygonal || enable_dynamic)
 	{
 		sample_lights(

--- a/src/refresh/vkpt/shader/path_tracer_rgen.h
+++ b/src/refresh/vkpt/shader/path_tracer_rgen.h
@@ -682,19 +682,17 @@ get_direct_illumination(
 	diffuse = vec3(0);
 	specular = vec3(0);
 
-	vec3 pos_on_light_polygonal;
-	vec3 pos_on_light_dynamic;
+	vec3 pos_on_light;
 
-	vec3 contrib_polygonal = vec3(0);
-	vec3 contrib_dynamic = vec3(0);
+	vec3 contrib = vec3(0);
 
 	float alpha = square(roughness);
 	float phong_exp = RoughnessSquareToSpecPower(alpha);
 	float phong_scale = min(100, 1 / (M_PI * square(alpha)));
 	float phong_weight = clamp(specular_factor * luminance(base_reflectivity) / (luminance(base_reflectivity) + luminance(albedo)), 0, 0.9);
 
-	int polygonal_light_index = -1;
-	float polygonal_light_pdfw = 0;
+	int light_index = -1;
+	float light_pdfw = 0;
 	bool polygonal_light_is_sky = false;
 
 	vec3 rng = vec3(
@@ -702,10 +700,9 @@ get_direct_illumination(
 		get_rng(RNG_NEE_TRI_X(bounce)),
 		get_rng(RNG_NEE_TRI_Y(bounce)));
 
-	/* polygonal light illumination */
-	if(enable_polygonal) 
+	if(enable_polygonal || enable_dynamic)
 	{
-		sample_polygonal_lights(
+		sample_lights(
 			cluster_idx,
 			position, 
 			normal, 
@@ -715,51 +712,24 @@ get_direct_illumination(
 			phong_scale,
 			phong_weight, 
 			is_gradient, 
-			pos_on_light_polygonal, 
-			contrib_polygonal,
-			polygonal_light_index,
-			polygonal_light_pdfw,
+			pos_on_light,
+			contrib,
+			light_index,
+			light_pdfw,
 			polygonal_light_is_sky,
 			rng);
 	}
 
 	bool is_polygonal = true;
-	float vis = 1;
+	float vis = 1.0;
 
-	/* dynamic light illumination */
-	if(enable_dynamic)
-	{
-		// Limit the solid angle of sphere lights for indirect lighting 
-		// in order to kill some fireflies in locations with many sphere lights.
-		// Example: green wall-lamp corridor in the "train" map.
-		float max_solid_angle = (bounce == 0) ? 2 * M_PI : 0.02;
-	
-		sample_dynamic_lights(
-			position,
-			normal,
-			geo_normal,
-			max_solid_angle,
-			pos_on_light_dynamic,
-			contrib_dynamic,
-			rng);
-	}
+	float spec_polygonal = phong(normal, normalize(pos_on_light - position), view_direction, phong_exp) * phong_scale;
 
-	float spec_polygonal = phong(normal, normalize(pos_on_light_polygonal - position), view_direction, phong_exp) * phong_scale;
-	float spec_dynamic = phong(normal, normalize(pos_on_light_dynamic - position), view_direction, phong_exp) * phong_scale;
+	float l_polygonal  = luminance(abs(contrib)) * mix(1, spec_polygonal, phong_weight);
 
-	float l_polygonal  = luminance(abs(contrib_polygonal)) * mix(1, spec_polygonal, phong_weight);
-	float l_dynamic = luminance(abs(contrib_dynamic)) * mix(1, spec_dynamic, phong_weight);
-	float l_sum = l_polygonal + l_dynamic;
+	bool null_light = (l_polygonal == 0);
 
-	bool null_light = (l_sum == 0);
-
-	float w = null_light ? 0.5 : l_polygonal / (l_polygonal + l_dynamic);
-
-	float rng2 = get_rng(RNG_NEE_LIGHT_TYPE(bounce));
-	is_polygonal = (rng2 < w);
-	vis = is_polygonal ? (1 / w) : (1 / (1 - w));
-	vec3 pos_on_light = null_light ? position : (is_polygonal ? pos_on_light_polygonal : pos_on_light_dynamic);
-	vec3 contrib = is_polygonal ? contrib_polygonal : contrib_dynamic;
+	pos_on_light = null_light ? position : pos_on_light;
 
 	Ray shadow_ray = get_shadow_ray(position - view_direction * 0.01, pos_on_light, 0);
 	
@@ -788,12 +758,11 @@ get_direct_illumination(
 		between frames.
 	*/
 	if(global_ubo.pt_light_stats != 0 
-		&& is_polygonal 
 		&& !null_light
-		&& polygonal_light_index >= 0 
-		&& polygonal_light_index < global_ubo.num_static_lights)
+		&& light_index >= 0
+		&& light_index < global_ubo.num_static_lights)
 	{
-		uint addr = get_light_stats_addr(cluster_idx, polygonal_light_index, get_primary_direction(normal));
+		uint addr = get_light_stats_addr(cluster_idx, light_index, get_primary_direction(normal));
 
 		// Offset 0 is unshadowed rays,
 		// Offset 1 is shadowed rays
@@ -811,7 +780,7 @@ get_direct_illumination(
 	vec3 L = pos_on_light - position;
 	L = normalize(L);
 
-	if(is_polygonal && direct_specular_weight > 0 && polygonal_light_is_sky && global_ubo.pt_specular_mis != 0)
+	if(direct_specular_weight > 0 && polygonal_light_is_sky && global_ubo.pt_specular_mis != 0)
 	{
 		// MIS with direct specular and indirect specular.
 		// Only applied to sky lights, for two reasons:
@@ -819,7 +788,7 @@ get_direct_illumination(
 		//  2) Non-sky lights are usually away from walls, so the direct sampling issue is not as pronounced.
 
 		direct_specular_weight *= get_specular_sampled_lighting_weight(roughness,
-			normal, -view_direction, L, polygonal_light_pdfw);
+			normal, -view_direction, L, light_pdfw);
 	}
 
 	vec3 F = vec3(0);

--- a/src/refresh/vkpt/shader/restir.h
+++ b/src/refresh/vkpt/shader/restir.h
@@ -1,0 +1,394 @@
+/*
+Copyright (C) 2018 Christoph Schied
+Copyright (C) 2018 Tobias Zirr
+Copyright (C) 2019, NVIDIA CORPORATION. All rights reserved.
+Copyright (C) 2022 Jorge Gustavo Martinez
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+// ========================================================================== //
+// This rgen shader computes direct lighting for the first opaque surface.
+// The parameters of that surface are loaded from the G-buffer, stored there
+// previously by the `primary_rays.rgen` and `reflect_refract.rgen` shaders.
+//
+// See `path_tracer.h` for an overview of the path tracer.
+// ========================================================================== //
+
+#ifndef  _RESTIR_H_
+#define  _RESTIR_H_
+
+#include "path_tracer_rgen.h"
+
+#define RESTIR_INVALID_ID       0xFFFF
+#define RESTIR_ENV_ID           0xFFFE
+
+#define RESTIR_SPACIAL_DISTANCE 32
+#define RESTIR_SPACIAL_SAMPLES  8
+
+#define RESTIR_SAMPLING_M       4
+#define RESTIR_M_CLAMP          32
+#define RESTIR_M_VC_CLAMP       16
+
+struct Reservoir
+{
+    uint y;
+    uint M;
+    float w_sum;
+    float W;
+    float p_hat;
+    vec2 y_pos;
+    vec3 normal;
+};
+
+void
+init_reservoir(inout Reservoir r)
+{
+	r.y = RESTIR_INVALID_ID;
+	r.M = 0;
+	r.w_sum = 0.0;
+	r.W = 0.0;
+	r.p_hat = 0.0;
+	r.y_pos = vec2(0.0);
+}
+
+bool
+update_reservoir(uint xi, float wi, vec2 xi_pos, float p_hat, inout float rng, inout Reservoir r)
+{
+	r.w_sum += wi;
+	r.M++;
+	float p_s = (wi/r.w_sum);
+	if(rng < p_s)
+	{
+		r.y = xi;
+		r.y_pos = xi_pos;
+		r.p_hat = p_hat;
+		rng /= p_s;
+		return true;
+	}
+	else
+	{
+		rng = (rng - p_s) / (1.0f - p_s);
+		return false;
+	}
+}
+
+uvec4
+pack_reservoir(Reservoir r)
+{
+	uvec4 vec;
+	r.W = r.y == RESTIR_INVALID_ID ? 0.0 : r.W;
+	vec.x = packHalf2x16(vec2(r.W, r.w_sum));
+	vec.y = packHalf2x16(r.y_pos);
+	return vec;
+}
+
+void
+unpack_reservoir(uvec4 packed, uint light_idx, out Reservoir r)
+{
+	r.y = light_idx;
+	r.M = light_idx == RESTIR_INVALID_ID ? 0 : (global_ubo.pt_restir != 3 ? RESTIR_M_CLAMP : RESTIR_M_VC_CLAMP);
+	vec2 val = unpackHalf2x16(packed.x);
+	r.W = val.x;
+	if(isnan(r.W) || isinf(r.W) || r.y == RESTIR_INVALID_ID) r.W = 0.0;
+	r.w_sum = val.y;
+	r.y_pos = unpackHalf2x16(packed.y);
+	r.p_hat = 0.0;
+}
+
+// Functions
+
+uint
+get_light_current_idx(uint index)
+{
+	if (index < global_ubo.num_static_lights || index == RESTIR_INVALID_ID || index == RESTIR_ENV_ID)
+	{
+		return index;
+	}
+	else
+	{
+		uint light_id_curr = instance_buffer.mlight_prev_to_current[index - global_ubo.num_static_lights];
+		if(light_id_curr != ~0u) return light_id_curr + global_ubo.num_static_lights;
+		else
+		{
+			return RESTIR_INVALID_ID;
+		}
+	}
+}
+
+
+float
+get_unshadowed_path_contrib(
+		uint light_idx,
+		vec3 position,
+		vec3 normal,
+		vec3 view_direction,
+		float phong_exp,
+		float phong_scale,
+		float phong_weight,
+		vec2 rng)
+{
+	if(light_idx == RESTIR_ENV_ID) return get_unshadowed_env_path_contrib(normal,view_direction, phong_exp, phong_scale, phong_weight, rng);
+	LightPolygon light = get_light_polygon(light_idx);
+
+	float m = 0.0f;
+	switch(uint(light.type))
+	{
+		case LIGHT_POLYGON:
+			m = projected_tri_area(light.positions, position, normal, view_direction, phong_exp, phong_scale, phong_weight);
+			break;
+		case LIGHT_SPHERE:
+			m = projected_sphere_area(light.positions, position, normal, view_direction, phong_exp, phong_scale, phong_weight);
+			break;
+		case LIGHT_SPOT:
+			m = projected_spotlight_area(light.positions, position, normal, view_direction, phong_exp, phong_scale, phong_weight);
+			break;
+	}
+
+	float light_lum = luminance(light.color);
+
+	// Apply light style scaling.
+	light_lum *= light.light_style_scale;
+
+	if(light_lum < 0 && global_ubo.environment_type == ENVIRONMENT_DYNAMIC)
+	{
+		// Set limits on sky luminance to avoid oversampling the sky in shadowed areas, or undersampling at dusk and dawn.
+		// Note: the log -> linear conversion of the cvars happens on the CPU, in main.c
+		m *= clamp(sun_color_ubo.sky_luminance, global_ubo.pt_min_log_sky_luminance, global_ubo.pt_max_log_sky_luminance);
+	}
+	else
+		m *= abs(light_lum); // abs because sky lights have negative color
+
+	return m;
+}
+
+
+void
+process_selected_light_restir(
+		uint light_idx,
+		vec2 light_position,
+		float weight,
+		vec3 position,
+		vec3 normal,
+		vec3 geo_normal,
+		int shadow_cull_mask,
+		vec3 view_direction,
+		vec3 base_reflectivity,
+		float specular_factor,
+		float roughness,
+		int surface_medium,
+		bool enable_caustics,
+		float direct_specular_weight,
+		float phong_exp,
+		float phong_scale,
+		float phong_weight,
+		bool check_vis,
+		uint cluster_idx,
+		out vec3 diffuse,
+		out vec3 specular,
+		out float vis)
+{
+	float polygonal_light_pdfw = 0;
+	vec3 contrib_polygonal = vec3(0);
+	vec3 L, pos_on_light_polygonal;
+	bool polygonal_light_is_sky = false;
+	diffuse = vec3(0);
+	specular = vec3(0);
+	vis = 1.0;
+
+	if(light_idx != RESTIR_ENV_ID)
+	{
+		LightPolygon light = get_light_polygon(light_idx);
+
+		vec3 light_normal;
+
+		switch(uint(light.type))
+		{
+			case LIGHT_POLYGON:
+				pos_on_light_polygonal = sample_projected_triangle(position, light.positions, light_position , light_normal, polygonal_light_pdfw);
+				break;
+			case LIGHT_SPHERE:
+				pos_on_light_polygonal = sample_projected_sphere(position, light.positions, light_position , light_normal, polygonal_light_pdfw);
+				break;
+			case LIGHT_SPOT:
+				pos_on_light_polygonal = sample_projected_spotlight(position, light.positions, light_position , light_normal, polygonal_light_pdfw);
+				break;
+		}
+
+		L = normalize(pos_on_light_polygonal - position);
+
+		if(dot(L, geo_normal) <= 0)
+			polygonal_light_pdfw = 0;
+
+		if(polygonal_light_pdfw > 0){
+			float LdotNL = max(0, -dot(light_normal, L));
+			float spotlight = sqrt(LdotNL);
+			float inv_pdfw = 1.0 / polygonal_light_pdfw;
+
+			if(light.color.r >= 0)
+			{
+				contrib_polygonal = light.color * (inv_pdfw * spotlight * light.light_style_scale);
+			}
+			else
+			{
+				contrib_polygonal = env_map(L, true) * inv_pdfw * global_ubo.pt_env_scale;
+				polygonal_light_is_sky = true;
+			}
+		}
+
+	}
+	else
+	{
+		vec2 disk = sample_disk(light_position);
+		disk.xy *= global_ubo.sun_tan_half_angle;
+		L = normalize(global_ubo.sun_direction + global_ubo.sun_tangent * disk.x + global_ubo.sun_bitangent * disk.y);
+		polygonal_light_pdfw = global_ubo.sun_solid_angle;
+		pos_on_light_polygonal = position + L * 10000;
+		contrib_polygonal = env_map(L, false) * polygonal_light_pdfw * global_ubo.pt_env_scale;
+	}
+
+	contrib_polygonal *= min(weight, global_ubo.pt_restir_max_w);
+
+	float spec_polygonal = phong(normal, L, view_direction, phong_exp) * phong_scale;
+
+	float l_polygonal  = luminance(abs(contrib_polygonal)) * mix(1, spec_polygonal, phong_weight);
+
+	bool null_light = (l_polygonal == 0);
+
+	Ray shadow_ray = get_shadow_ray(position - view_direction * 0.01, pos_on_light_polygonal, 0);
+
+	if(check_vis) vis *= trace_shadow_ray(shadow_ray, null_light ? 0 : shadow_cull_mask);
+
+	#ifdef ENABLE_SHADOW_CAUSTICS
+		if(enable_caustics)
+		{
+			contrib_polygonal *= trace_caustic_ray(shadow_ray, surface_medium);
+		}
+	#endif
+
+	if(null_light)
+	{
+		vis = 0.0f;
+		return;
+	}
+
+	vec3 radiance = vis * contrib_polygonal;
+
+	if(direct_specular_weight > 0 && polygonal_light_is_sky && global_ubo.pt_specular_mis != 0)
+	{
+		// MIS with direct specular and indirect specular.
+		// Only applied to sky lights, for two reasons:
+		//  1) Non-sky lights are trimmed to match the light texture, and indirect rays don't see that;
+		//  2) Non-sky lights are usually away from walls, so the direct sampling issue is not as pronounced.
+
+		direct_specular_weight *= get_specular_sampled_lighting_weight(roughness,
+			normal, -view_direction, L, polygonal_light_pdfw);
+	}
+
+	vec3 F = vec3(0);
+
+	if(vis > 0 && direct_specular_weight > 0)
+	{
+		vec3 specular_brdf = GGX_times_NdotL(view_direction, L,
+			normal, roughness, base_reflectivity, 0.0, specular_factor, F);
+		specular = radiance * specular_brdf * direct_specular_weight;
+	}
+
+	float NdotL = max(0, dot(normal, L));
+
+	float diffuse_brdf = NdotL / M_PI;
+	diffuse = radiance * diffuse_brdf * (vec3(1.0) - F);
+}
+
+
+void
+get_direct_illumination_restir(
+	vec3 position,
+	vec3 normal,
+	uint cluster_idx,
+	vec3 view_direction,
+	float phong_exp,
+	float phong_scale,
+	float phong_weight,
+	int bounce,
+	Reservoir prev_r,
+	out Reservoir reservoir)
+{
+	init_reservoir(reservoir);
+
+	if(cluster_idx == ~0u)
+		return;
+
+	vec3 contrib_polygonal = vec3(0);
+
+	float rng, p_hat;
+
+	uint list_start = light_buffer.light_list_offsets[cluster_idx];
+	uint list_end   = light_buffer.light_list_offsets[cluster_idx + 1];
+
+	rng = get_rng(RNG_NEE_LIGHT_SELECTION(bounce));
+
+
+	uint add_sun = (global_ubo.sun_visible != 0) && ((cluster_idx == ~0u) || (light_buffer.sky_visibility[cluster_idx >> 5] & (1 << (cluster_idx & 31))) != 0) ? 1 : 0;
+
+	uint sun_idx = add_sun > 0 ? list_end : -1;
+	list_end += add_sun;
+	float list_size = float(list_end - list_start);
+	float partitions = ceil(list_size / float(RESTIR_SAMPLING_M));
+	float inv_pdf = list_size;
+	float rng_part = rng * partitions;
+	float fpart = min(floor(rng_part), partitions-1);
+
+	list_start += int(fpart);
+	int stride = int(partitions);
+	rng = rng_part - floor(rng_part);
+
+	uint current_idx, current_light_idx;
+
+	vec2 rng2 = vec2(
+		get_rng(RNG_NEE_TRI_X(bounce)),
+		get_rng(RNG_NEE_TRI_Y(bounce)));
+
+	float samples = 1.;
+
+	#pragma unroll
+	for(uint i = 0, n_idx = list_start; i < RESTIR_SAMPLING_M; i++, n_idx += stride)
+	{
+		if (n_idx >= list_end)
+			break;
+
+		current_light_idx = n_idx != sun_idx ? light_buffer.light_list_lights[n_idx] : RESTIR_ENV_ID;
+
+		if(current_light_idx == ~0u) continue;
+
+		p_hat = get_unshadowed_path_contrib(current_light_idx, position, normal, view_direction, phong_exp, phong_scale, phong_weight, rng2);
+		if(p_hat > 0)update_reservoir(current_light_idx, p_hat * inv_pdf, rng2, p_hat, rng, reservoir);
+	}
+
+	reservoir.M = RESTIR_SAMPLING_M;
+
+	//Combine with temporal
+	if(prev_r.W > 0.0 && prev_r.y != RESTIR_INVALID_ID && prev_r.p_hat > 0)
+	{
+		update_reservoir(prev_r.y, prev_r.p_hat * prev_r.W * prev_r.M ,prev_r.y_pos, prev_r.p_hat, rng, reservoir);
+		reservoir.M += prev_r.M - 1;
+	}
+
+	reservoir.W = reservoir.w_sum / (reservoir.p_hat * reservoir.M);
+	if(isnan(reservoir.W) || isinf(reservoir.W)) reservoir.W = 0.0;
+}
+
+
+#endif  /*_RESTIR_H_*/

--- a/src/refresh/vkpt/shader/restir.h
+++ b/src/refresh/vkpt/shader/restir.h
@@ -50,7 +50,6 @@ struct Reservoir
     float W;
     float p_hat;
     vec2 y_pos;
-    vec3 normal;
 };
 
 void

--- a/src/refresh/vkpt/shader/restir.h
+++ b/src/refresh/vkpt/shader/restir.h
@@ -341,7 +341,6 @@ get_direct_illumination_restir(
 
 	rng = get_rng(RNG_NEE_LIGHT_SELECTION(bounce));
 
-
 	uint add_sun = (global_ubo.sun_visible != 0) && ((cluster_idx == ~0u) || (light_buffer.sky_visibility[cluster_idx >> 5] & (1 << (cluster_idx & 31))) != 0) ? 1 : 0;
 
 	uint sun_idx = add_sun > 0 ? list_end : -1;

--- a/src/refresh/vkpt/shader/vertex_buffer.h
+++ b/src/refresh/vkpt/shader/vertex_buffer.h
@@ -183,6 +183,7 @@ struct LightPolygon
 	vec3 color;
 	float light_style_scale;
 	float prev_style_scale;
+	float type;
 };
 
 // The buffers with primitive data, currently two of them: world and instanced.
@@ -478,6 +479,7 @@ get_light_polygon(uint index)
 	light.color = vec3(p0.w, p1.w, p2.w);
 	light.light_style_scale = p3.x;
 	light.prev_style_scale = p3.y;
+	light.type = p3.z;
 	return light;
 }
 

--- a/src/refresh/vkpt/shader/vertex_buffer.h
+++ b/src/refresh/vkpt/shader/vertex_buffer.h
@@ -179,6 +179,19 @@ struct MaterialInfo
 
 struct LightPolygon
 {
+	/* Meaning of positions depends on light type:
+	 * - static/poly/triangle light: actual positions of vertices
+	 * - dynamic light:
+	 *   - all types:
+	 *       positions[0]: light origin
+	 *       positions[1].x: radius
+	 *   - spot light:
+	 *       positions[1].y: emission profile (uint reinterepreted as float)
+	 *       positions[1].z: spot light data, meaning depending on emission profile:
+	 *         DYNLIGHT_SPOT_EMISSION_PROFILE_FALLOFF -> contains packed2x16 with cosTotalWidth, cosFalloffStart
+	 *         DYNLIGHT_SPOT_EMISSION_PROFILE_AXIS_ANGLE_TEXTURE -> contains a half with cosTotalWidth and the texture index
+	 *       positions[2]: direction
+	 */
 	mat3 positions;
 	vec3 color;
 	float light_style_scale;

--- a/src/refresh/vkpt/transparency.c
+++ b/src/refresh/vkpt/transparency.c
@@ -540,7 +540,7 @@ bool vkpt_build_cylinder_light(light_poly_t* light_list, int* num_lights, int ma
 		light->cluster = BSP_PointLeaf(bsp->nodes, light->off_center)->cluster;
 		light->material = NULL;
 		light->style = 0;
-		light->type = DYNLIGHT_POLYGON;
+		light->type = LIGHT_POLYGON;
 
 		VectorCopy(color, light->color);
 

--- a/src/refresh/vkpt/transparency.c
+++ b/src/refresh/vkpt/transparency.c
@@ -540,6 +540,7 @@ bool vkpt_build_cylinder_light(light_poly_t* light_list, int* num_lights, int ma
 		light->cluster = BSP_PointLeaf(bsp->nodes, light->off_center)->cluster;
 		light->material = NULL;
 		light->style = 0;
+		light->type = DYNLIGHT_POLYGON;
 
 		VectorCopy(color, light->color);
 

--- a/src/refresh/vkpt/transparency.c
+++ b/src/refresh/vkpt/transparency.c
@@ -468,7 +468,7 @@ static int compare_beams(const void* _a, const void* _b)
 	return 0;
 }
 
-bool vkpt_build_cylinder_light(light_poly_t* light_list, int* num_lights, int max_lights, bsp_t *bsp, vec3_t begin, vec3_t end, vec3_t color, float radius)
+bool vkpt_build_cylinder_light(light_poly_t* light_list, int* num_lights, int max_lights, bsp_t *bsp, vec3_t begin, vec3_t end, vec3_t color, float radius, entity_hash_t hash, int* light_entity_ids)
 {
 	vec3_t dir, norm_dir;
 	VectorSubtract(end, begin, dir);
@@ -546,6 +546,8 @@ bool vkpt_build_cylinder_light(light_poly_t* light_list, int* num_lights, int ma
 
 		if (light->cluster >= 0)
 		{
+			hash.mesh = tri;
+			light_entity_ids[(*num_lights)] = *(uint32_t*)&hash;
 			(*num_lights)++;
 		}
 	}
@@ -553,7 +555,7 @@ bool vkpt_build_cylinder_light(light_poly_t* light_list, int* num_lights, int ma
 	return true;
 }
 
-void vkpt_build_beam_lights(light_poly_t* light_list, int* num_lights, int max_lights, bsp_t *bsp, entity_t* entities, int num_entites, float adapted_luminance)
+void vkpt_build_beam_lights(light_poly_t* light_list, int* num_lights, int max_lights, bsp_t *bsp, entity_t* entities, int num_entites, float adapted_luminance, int* light_entity_ids, int* num_light_entities)
 {
 	const float hdr_factor = cvar_pt_beam_lights->value * adapted_luminance * 20.f;
 
@@ -585,6 +587,10 @@ void vkpt_build_beam_lights(light_poly_t* light_list, int* num_lights, int max_l
 		
 		const entity_t* beam = beams[i];
 
+		entity_hash_t hash;
+		hash.entity = (beams[i] - entities) + 1; //entity ID
+		hash.model = RF_BEAM;
+
 		// Adjust beam width. Default "narrow" beams have a width of 4, "fat" beams have 16.
 		if (beam->frame == 0)
 			continue;
@@ -607,7 +613,7 @@ void vkpt_build_beam_lights(light_poly_t* light_list, int* num_lights, int max_l
 		vec3_t color;
 		cast_u32_to_f32_color(beam->skinnum, &beam->rgba, color, hdr_factor);
 
-		vkpt_build_cylinder_light(light_list, num_lights, max_lights, bsp, begin, end, color, beam_radius);
+		vkpt_build_cylinder_light(light_list, num_lights, max_lights, bsp, begin, end, color, beam_radius, hash, light_entity_ids);
 	}
 }
 

--- a/src/refresh/vkpt/vertex_buffer.c
+++ b/src/refresh/vkpt/vertex_buffer.c
@@ -635,7 +635,7 @@ copy_light(const light_poly_t* light, float* vblight, const float* sky_radiance)
 
 	vblight[12] = style_scale;
 	vblight[13] = prev_style;
-	vblight[14] = 0.f;
+	vblight[14] = light->type;
 	vblight[15] = 0.f;
 }
 

--- a/src/refresh/vkpt/vkpt.h
+++ b/src/refresh/vkpt/vkpt.h
@@ -460,6 +460,13 @@ typedef struct sun_light_s {
 	bool visible;
 } sun_light_t;
 
+typedef struct entity_hash_s {
+	unsigned int mesh : 8;
+	unsigned int model : 9;
+	unsigned int entity : 14;
+	unsigned int bsp : 1;
+} entity_hash_t;
+
 void mult_matrix_matrix(mat4_t p, const mat4_t a, const mat4_t b);
 void mult_matrix_vector(vec4_t v, const mat4_t a, const vec4_t b);
 void create_entity_matrix(mat4_t matrix, entity_t *e);
@@ -765,8 +772,8 @@ VkBufferView get_transparency_beam_color_buffer_view(void);
 VkBufferView get_transparency_sprite_info_buffer_view(void);
 VkBufferView get_transparency_beam_intersect_buffer_view(void);
 void get_transparency_counts(int* particle_num, int* beam_num, int* sprite_num);
-void vkpt_build_beam_lights(light_poly_t* light_list, int* num_lights, int max_lights, bsp_t *bsp, entity_t* entities, int num_entites, float adapted_luminance);
-bool vkpt_build_cylinder_light(light_poly_t* light_list, int* num_lights, int max_lights, bsp_t *bsp, vec3_t begin, vec3_t end, vec3_t color, float radius);
+void vkpt_build_beam_lights(light_poly_t* light_list, int* num_lights, int max_lights, bsp_t *bsp, entity_t* entities, int num_entites, float adapted_luminance, int* light_entity_ids, int* num_light_entities);
+bool vkpt_build_cylinder_light(light_poly_t* light_list, int* num_lights, int max_lights, bsp_t *bsp, vec3_t begin, vec3_t end, vec3_t color, float radius, entity_hash_t hash, int* light_entity_ids);
 bool get_triangle_off_center(const float* positions, float* center, float* anti_center, float offset);
 
 VkResult vkpt_initialize_god_rays(void);


### PR DESCRIPTION
This adds ReSTIR light sampling, based on https://github.com/zyanidelab/Q2RTX.

It's essentially #475 but some additional flourishes:
* Addressed the omissions in https://github.com/NVIDIA/Q2RTX/pull/475#issuecomment-2937189856 (although, in the meantime, use of spherical triangles has been added to #475 as well)
* Split up the original monolithic commit a bit, mainly to ease updating, but also to clearer illustrate the contained changes.

I also tried if having separate shaders for ReSTIR vs RIS makes any difference - but it didn't seem to significantly impact performance, so I kept things as they were originally.

Visuals:
* In places with noisy direct lighting, ReSTIR visible reduces the noise. (`q2dm5`, `(-605.3, -310.2, 430.2) (0.999, -0.041, -0.026)` is one such spot.)
* However, with ReSTIR enabled I observed visible dark "smears" when previously occluded pixels are revealed. This can be seen when looking at "revealed" wall pixels when the view weapon is moved, or when turning the camera. (Perhaps some unfortunate interaction with the denoiser?) Does not occur with RIS.
* Also notably, 232c47c64f07622db9ad4517bf256147aa9765b5 combines static and dynamic lights into a single list. This has the potential to degrade visuals in certain circumstances - but practically I didn't notice any issues.

Performance:
I measured frametimes using the timedemos `crusher`, `demo1`, `demo2` on a 5070 TI at 3800x2000 and a 3070 Laptop at 2560x1600. `pt_num_bounces` was set to `0`.

5070 TI:
| demo | `master` branch frametime | restir branch, `pt_restir 1` | percentage of `master` | restir branch, `pt_restir 0` | percentage of `master` |
| ----- | ----- | ----- | ----- | ----- | ----- |
| crusher | 9.551 ms | 9.593 ms | 100.4% | 9.331 ms | 97.7% |
| demo1 | 8.926 ms | 9.065 ms | 101.5% | 8.954 ms | 100.3% |
| demo2 | 9.844 ms | 9.393 ms | 95.4% | 9.328 ms | 94.8% |

3070 Laptop:
| demo | `master` branch frametime | restir branch, `pt_restir 1` | percentage of `master` | restir branch, `pt_restir 0` | percentage of `master` |
| ----- | ----- | ----- | ----- | ----- | ----- |
| crusher | 14.942 ms | 15.179 ms | 101.6% | 14.830 ms | 99.3% |
| demo1 | 14.174 ms | 14.167 ms | 99.9% | 14.179 ms | 100.0% |
| demo2 | 14.966 ms | 15.043 ms | 100.5% | 15.049 ms | 100.6% |

Since we're dealing with frametimes, lower is better.

My thoughts:
Performance-wise, there's no issue (not much of a change compared to the current light sampling), and visually, it really helps in some previously noisy areas - so it would be a clear win _if_ there wasn't the increase of "dark smearing" being observed. (Personally, I find the smearing more distracting than the noise issues, mainly because the smearing occurs constantly, while the current light sampling is decently tuned for the Q2 content and noise is not visible that often.) So it's a bit of a "so-so" right now.
But hopefully the smearing can be addressed, though I didn't look into that yet.