### PR TITLE
Fix view weapon clipping to near place in GL mode

### DIFF
--- a/src/refresh/gl/gl.h
+++ b/src/refresh/gl/gl.h
@@ -452,7 +452,7 @@ void GL_CommonStateBits(GLbitfield bits);
 void GL_ScrollSpeed(vec2_t scroll, GLbitfield bits);
 void GL_DrawOutlines(GLsizei count, QGL_INDEX_TYPE *indices);
 void GL_Ortho(GLfloat xmin, GLfloat xmax, GLfloat ymin, GLfloat ymax, GLfloat znear, GLfloat zfar);
-void GL_Frustum(GLfloat fov_x, GLfloat fov_y, GLfloat reflect_x);
+void GL_Frustum(GLfloat fov_x, GLfloat fov_y, GLfloat reflect_x, GLfloat near_scale);
 void GL_Setup2D(void);
 void GL_Setup3D(bool waterwarp);
 void GL_ClearState(void);

--- a/src/refresh/gl/mesh.c
+++ b/src/refresh/gl/mesh.c
@@ -630,7 +630,7 @@ static void setup_weaponmodel(void)
         qglFrontFace(GL_CCW);
     }
 
-    GL_Frustum(fov_x, fov_y, reflect_x);
+    GL_Frustum(fov_x, fov_y, reflect_x, min(glr.ent->scale, 1.0f));
 }
 
 void GL_DrawAliasModel(const model_t *model)
@@ -704,7 +704,7 @@ void GL_DrawAliasModel(const model_t *model)
         GL_DepthRange(0, 1);
 
     if (ent->flags & RF_WEAPONMODEL) {
-        GL_Frustum(glr.fd.fov_x, glr.fd.fov_y, 1.0f);
+        GL_Frustum(glr.fd.fov_x, glr.fd.fov_y, 1.0f, 1.0f);
         qglFrontFace(GL_CW);
     }
 }

--- a/src/refresh/gl/state.c
+++ b/src/refresh/gl/state.c
@@ -174,13 +174,13 @@ void GL_Setup2D(void)
     gl_static.backend.load_view_matrix(NULL);
 }
 
-void GL_Frustum(GLfloat fov_x, GLfloat fov_y, GLfloat reflect_x)
+void GL_Frustum(GLfloat fov_x, GLfloat fov_y, GLfloat reflect_x, GLfloat near_scale)
 {
     GLfloat xmin, xmax, ymin, ymax, zfar, znear;
     GLfloat width, height, depth;
     GLfloat matrix[16];
 
-    znear = gl_znear->value;
+    znear = gl_znear->value * near_scale;
 
     if (glr.fd.rdflags & RDF_NOWORLDMODEL)
         zfar = 2048;
@@ -260,7 +260,7 @@ void GL_Setup3D(bool waterwarp)
     if (gl_static.backend.setup_3d)
         gl_static.backend.setup_3d();
 
-    GL_Frustum(glr.fd.fov_x, glr.fd.fov_y, 1.0f);
+    GL_Frustum(glr.fd.fov_x, glr.fd.fov_y, 1.0f, 1.0f);
 
     GL_RotateForViewer();
 


### PR DESCRIPTION
Our default `cl_gunscale` value of 0.25 results in the weapon clipping through the near plane. Adjust the near plane distance to work around this.