### PR TITLE
Only evaluate cvar_pt_beam_lights when using the RTX renderer. For #487

### DIFF
--- a/src/client/tent.c
+++ b/src/client/tent.c
@@ -1092,7 +1092,7 @@ static void CL_RailTrail(void)
         }
     }
 
-    if (!cl_railtrail_type->integer || cvar_pt_beam_lights->value <= 0)
+    if (!cl_railtrail_type->integer || (cls.ref_type == REF_TYPE_VKPT && cvar_pt_beam_lights->value <= 0))
     {
         CL_RailLights(rail_color);
     }


### PR DESCRIPTION
Based on the cvar name, the additional condition was intended for RTX mode only, anyway.