### PR TITLE
Restore rail trail light effects

### DIFF
--- a/src/client/client.h
+++ b/src/client/client.h
@@ -871,6 +871,7 @@ typedef struct cparticle_s {
 
 typedef struct cdlight_s {
     int     key;        // so entities can reuse same entry
+    int     born;       // cl.time when this light was created
     vec3_t  color;
     vec3_t  origin;
     float   radius;

--- a/src/client/effects.c
+++ b/src/client/effects.c
@@ -111,6 +111,7 @@ cdlight_t *CL_AllocDlight(int key)
             if (dl->key == key) {
                 memset(dl, 0, sizeof(*dl));
                 dl->key = key;
+                dl->born = cl.time;
                 return dl;
             }
         }
@@ -122,6 +123,7 @@ cdlight_t *CL_AllocDlight(int key)
         if (dl->die < cl.time) {
             memset(dl, 0, sizeof(*dl));
             dl->key = key;
+            dl->born = cl.time;
             return dl;
         }
     }
@@ -129,6 +131,7 @@ cdlight_t *CL_AllocDlight(int key)
     dl = &cl_dlights[0];
     memset(dl, 0, sizeof(*dl));
     dl->key = key;
+    dl->born = cl.time;
     return dl;
 }
 
@@ -146,7 +149,11 @@ void CL_AddDLights(void)
     for (i = 0; i < MAX_DLIGHTS; i++, dl++) {
         if (dl->die < cl.time)
             continue;
-        V_AddLight(dl->origin, dl->radius,
+        float seconds_alive = (cl.time - dl->born) / 1000.f;
+        float radius = dl->radius - dl->decay * seconds_alive;
+        vec3_t origin;
+        VectorMA(dl->origin, seconds_alive, dl->velosity, origin);
+        V_AddLight(origin, radius,
                    dl->color[0], dl->color[1], dl->color[2]);
     }
 }


### PR DESCRIPTION
Commit 11bd9e53db08cb7921e36214940cdc0037ef5325 (picked from upstream) removed support for the 'decay' and 'velosity' (sic) dlight fields, but it turns out we still use them for the rail trail lights (oops).

Restore support for this fields, bringing back the pleasing fade-out of the rail trail lights.